### PR TITLE
feat(recognition): add Recognition Card feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,138 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Access Recognition
+
+Internal employee recognition app for Access Group. Team members publicly recognize colleagues via digital thank-you cards tied to company values.
+
+## Tech Stack
+
+| Category | Technology |
+|----------|-----------|
+| Framework | Next.js 16 (App Router, Turbopack) |
+| Language | TypeScript 5 |
+| Runtime | Node.js 20+, Bun (package manager) |
+| Auth | better-auth (email/password + Google OAuth) |
+| Database | PostgreSQL + Prisma 7 |
+| Styling | Tailwind CSS v4 + shadcn/ui + Lucide React |
+| Forms | React Hook Form + Zod |
+| Client State | Zustand |
+| Server State | TanStack React Query |
+| Toasts | Sonner |
+| Linting | Biome |
+| Dark Mode | next-themes |
+| Env Validation | @t3-oss/env-nextjs |
 
 ## Getting Started
 
-First, run the development server:
+### Prerequisites
+
+- Node.js 20.9+
+- [Bun](https://bun.sh) (package manager)
+- PostgreSQL (local or Docker)
+
+### Setup
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+# Clone and install
+git clone https://github.com/chrisgen19/access-group-staff.git
+cd access-group-staff
+bun install
+
+# Environment variables
+cp .env.example .env
+# Edit .env with your database URL and auth secrets
+
+# Database
+bunx prisma db push
+bun prisma/seed.ts
+
+# Run dev server
+bun run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+### Environment Variables
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+| Variable | Description |
+|----------|------------|
+| `DATABASE_URL` | PostgreSQL connection string |
+| `BETTER_AUTH_SECRET` | Auth secret (min 32 chars) |
+| `BETTER_AUTH_URL` | App base URL (e.g. `http://localhost:3000`) |
+| `NEXT_PUBLIC_APP_URL` | Public app URL |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+### Seed Users
 
-## Learn More
+| Email | Password | Role |
+|-------|----------|------|
+| admin@accessgroup.com.au | Password123! | SUPERADMIN |
+| eng.admin@accessgroup.com.au | Password123! | ADMIN |
+| john.doe@accessgroup.com.au | Password123! | STAFF |
+| sarah.jones@accessgroup.com.au | Password123! | STAFF |
 
-To learn more about Next.js, take a look at the following resources:
+## Project Structure
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```
+app/
+├── (auth)/                        # Auth pages (login, register)
+├── (dashboard)/                   # Dashboard layout + pages
+│   └── dashboard/
+│       ├── page.tsx               # Dashboard home
+│       ├── users/                 # User management (CRUD)
+│       ├── departments/           # Department management (CRUD)
+│       └── profile/               # Profile + Preferences
+│           └── preferences/       # Background color customization
+├── api/
+│   ├── auth/[...all]/             # better-auth catch-all handler
+│   └── users/                     # Users API (React Query)
+└── globals.css                    # Tailwind v4 theme (CSS variables)
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+components/
+├── ui/                            # shadcn/ui primitives (do not edit)
+└── shared/                        # Shared components (sidebar, header, etc.)
 
-## Deploy on Vercel
+lib/
+├── auth.ts                        # better-auth server config
+├── auth-client.ts                 # better-auth client
+├── auth-utils.ts                  # Session helpers (requireSession, requireRole)
+├── permissions.ts                 # Role-based permission checks
+├── actions/                       # Server Actions (user, department, profile)
+├── validations/                   # Zod schemas
+└── db/index.ts                    # Prisma client singleton
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+stores/                            # Zustand stores
+prisma/
+├── schema.prisma                  # Database schema
+└── seed.ts                        # Seed data
+proxy.ts                           # Route protection (replaces middleware.ts)
+env.ts                             # Typed env via @t3-oss/env-nextjs
+```
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Database Schema
+
+**Models:** User, Session, Account, Verification, Department
+
+**Roles:** `SUPERADMIN` > `ADMIN` > `STAFF`
+
+- SUPERADMIN/ADMIN can manage users and departments
+- STAFF can view dashboard and edit own profile
+- Deactivated users (`isActive: false`) are blocked at proxy and session level
+
+## Scripts
+
+```bash
+bun run dev          # Start dev server (Turbopack)
+bun run build        # Production build
+bun run start        # Start production server
+bun run lint         # Biome check
+bun run lint:fix     # Biome auto-fix
+bun run format       # Biome format
+bun run db:push      # Push schema to database
+bun run db:seed      # Seed database
+bun run db:studio    # Open Prisma Studio
+```
+
+## Deployment
+
+- **Vercel:** Zero config, all Next.js 16 features supported
+- **Self-hosted (Coolify):** Uses `output: "standalone"` in next.config.ts
+
+All secrets must be configured in the deployment platform's environment variable settings.

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Heart, ArrowRight } from "lucide-react";
+
+interface RecognitionUser {
+	id: string;
+	firstName: string;
+	lastName: string;
+	avatar: string | null;
+	position: string | null;
+}
+
+interface RecognitionCard {
+	id: string;
+	message: string;
+	date: string;
+	createdAt: string;
+	sender: RecognitionUser;
+	recipient: RecognitionUser;
+	valuesPeople: boolean;
+	valuesSafety: boolean;
+	valuesRespect: boolean;
+	valuesCommunication: boolean;
+	valuesContinuousImprovement: boolean;
+}
+
+const VALUE_LABELS: Record<string, string> = {
+	valuesPeople: "People",
+	valuesSafety: "Safety",
+	valuesRespect: "Respect",
+	valuesCommunication: "Communication",
+	valuesContinuousImprovement: "Continuous Improvement",
+};
+
+function getInitials(firstName: string, lastName: string) {
+	return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+}
+
+function getSelectedValues(card: RecognitionCard): string[] {
+	return Object.entries(VALUE_LABELS)
+		.filter(([key]) => card[key as keyof RecognitionCard] === true)
+		.map(([, label]) => label);
+}
+
+function formatDate(dateString: string) {
+	return new Date(dateString).toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
+function CardSkeleton() {
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] animate-pulse">
+			<div className="flex items-center gap-3 mb-4">
+				<div className="h-10 w-10 rounded-full bg-gray-200 dark:bg-white/10" />
+				<div className="h-4 w-6 bg-gray-200 dark:bg-white/10 rounded" />
+				<div className="h-10 w-10 rounded-full bg-gray-200 dark:bg-white/10" />
+				<div className="h-4 w-24 bg-gray-200 dark:bg-white/10 rounded" />
+			</div>
+			<div className="space-y-2 mb-4">
+				<div className="h-4 w-full bg-gray-200 dark:bg-white/10 rounded" />
+				<div className="h-4 w-2/3 bg-gray-200 dark:bg-white/10 rounded" />
+			</div>
+			<div className="flex gap-2">
+				<div className="h-6 w-16 bg-gray-200 dark:bg-white/10 rounded-full" />
+				<div className="h-6 w-20 bg-gray-200 dark:bg-white/10 rounded-full" />
+			</div>
+		</div>
+	);
+}
+
+export function RecognitionFeed() {
+	const { data, isPending } = useQuery<{
+		success: boolean;
+		data: RecognitionCard[];
+	}>({
+		queryKey: ["recognition-cards"],
+		queryFn: async () => {
+			const res = await fetch("/api/recognition");
+			if (!res.ok) throw new Error("Failed to fetch recognition cards");
+			return res.json();
+		},
+	});
+
+	const cards = data?.data ?? [];
+
+	if (isPending) {
+		return (
+			<div className="space-y-4">
+				<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight">
+					Recent Recognitions
+				</h3>
+				<CardSkeleton />
+				<CardSkeleton />
+				<CardSkeleton />
+			</div>
+		);
+	}
+
+	if (cards.length === 0) {
+		return (
+			<div className="flex flex-col items-center justify-center rounded-[2rem] border border-gray-200 dark:border-white/10 bg-card p-16 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+				<div className="mb-6 rounded-full bg-background p-6">
+					<Heart
+						size={48}
+						className="text-muted-foreground opacity-40"
+					/>
+				</div>
+				<p className="text-[1.5rem] font-medium text-foreground">
+					No recognition cards yet
+				</p>
+				<p className="mt-2 text-base text-muted-foreground">
+					Be the first to recognize a colleague!
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight">
+				Recent Recognitions
+			</h3>
+			{cards.map((card) => {
+				const values = getSelectedValues(card);
+				return (
+					<div
+						key={card.id}
+						className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]"
+					>
+						{/* Header: Sender → Recipient */}
+						<div className="flex items-center gap-3 mb-3">
+							<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary text-sm font-semibold">
+								{getInitials(
+									card.sender.firstName,
+									card.sender.lastName,
+								)}
+							</div>
+							<div className="text-sm">
+								<span className="font-medium text-foreground">
+									{card.sender.firstName} {card.sender.lastName}
+								</span>
+								{card.sender.position && (
+									<p className="text-muted-foreground text-xs">
+										{card.sender.position}
+									</p>
+								)}
+							</div>
+							<ArrowRight
+								size={16}
+								className="text-muted-foreground mx-1"
+							/>
+							<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary text-sm font-semibold">
+								{getInitials(
+									card.recipient.firstName,
+									card.recipient.lastName,
+								)}
+							</div>
+							<div className="text-sm">
+								<span className="font-medium text-foreground">
+									{card.recipient.firstName}{" "}
+									{card.recipient.lastName}
+								</span>
+								{card.recipient.position && (
+									<p className="text-muted-foreground text-xs">
+										{card.recipient.position}
+									</p>
+								)}
+							</div>
+						</div>
+
+						{/* Message */}
+						<p className="text-sm text-foreground/80 mb-3 leading-relaxed">
+							{card.message}
+						</p>
+
+						{/* Footer: Values + Date */}
+						<div className="flex flex-wrap items-center gap-2">
+							{values.map((value) => (
+								<span
+									key={value}
+									className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-xs font-medium text-primary dark:bg-primary/10"
+								>
+									{value}
+								</span>
+							))}
+							<span className="ml-auto text-xs text-muted-foreground">
+								{formatDate(card.date)}
+							</span>
+						</div>
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -44,7 +44,8 @@ function getSelectedValues(card: RecognitionCard): string[] {
 }
 
 function formatDate(dateString: string) {
-	return new Date(dateString).toLocaleDateString("en-US", {
+	const [year, month, day] = dateString.split("T")[0].split("-");
+	return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-US", {
 		month: "short",
 		day: "numeric",
 		year: "numeric",

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
@@ -58,7 +58,11 @@ export function RecognitionForm() {
 		defaultValues: {
 			recipientId: "",
 			message: "",
-			date: new Date().toISOString().split("T")[0],
+			date: new Date(
+				Date.now() - new Date().getTimezoneOffset() * 60_000,
+			)
+				.toISOString()
+				.split("T")[0],
 			valuesPeople: false,
 			valuesSafety: false,
 			valuesRespect: false,

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState, useRef, useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2, Search, ChevronDown, X } from "lucide-react";
+import { useSession } from "@/lib/auth-client";
+import { createRecognitionCardAction } from "@/lib/actions/recognition-actions";
+import {
+	createRecognitionCardSchema,
+	type CreateRecognitionCardInput,
+} from "@/lib/validations/recognition";
+
+const inputClass =
+	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
+
+interface ActiveUser {
+	id: string;
+	firstName: string;
+	lastName: string;
+	position: string | null;
+}
+
+const COMPANY_VALUES = [
+	{ key: "valuesPeople" as const, label: "People" },
+	{ key: "valuesSafety" as const, label: "Safety" },
+	{ key: "valuesRespect" as const, label: "Respect" },
+	{ key: "valuesCommunication" as const, label: "Communication" },
+	{
+		key: "valuesContinuousImprovement" as const,
+		label: "Continuous Improvement",
+	},
+];
+
+export function RecognitionForm() {
+	const queryClient = useQueryClient();
+	const { data: session } = useSession();
+	const [isLoading, setIsLoading] = useState(false);
+	const [searchQuery, setSearchQuery] = useState("");
+	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+	const [selectedUser, setSelectedUser] = useState<ActiveUser | null>(null);
+	const dropdownRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const {
+		register,
+		handleSubmit,
+		setValue,
+		watch,
+		reset,
+		formState: { errors },
+	} = useForm<CreateRecognitionCardInput>({
+		resolver: zodResolver(createRecognitionCardSchema),
+		defaultValues: {
+			recipientId: "",
+			message: "",
+			date: new Date().toISOString().split("T")[0],
+			valuesPeople: false,
+			valuesSafety: false,
+			valuesRespect: false,
+			valuesCommunication: false,
+			valuesContinuousImprovement: false,
+		},
+	});
+
+	const { data: usersData } = useQuery<{ success: boolean; data: ActiveUser[] }>({
+		queryKey: ["active-users"],
+		queryFn: async () => {
+			const res = await fetch("/api/recognition/users");
+			if (!res.ok) throw new Error("Failed to fetch users");
+			return res.json();
+		},
+	});
+
+	const availableUsers = (usersData?.data ?? []).filter(
+		(user) => user.id !== session?.user?.id,
+	);
+
+	const filteredUsers = availableUsers.filter((user) => {
+		const fullName = `${user.firstName} ${user.lastName}`.toLowerCase();
+		return fullName.includes(searchQuery.toLowerCase());
+	});
+
+	useEffect(() => {
+		function handleClickOutside(event: MouseEvent) {
+			if (
+				dropdownRef.current &&
+				!dropdownRef.current.contains(event.target as Node)
+			) {
+				setIsDropdownOpen(false);
+			}
+		}
+		document.addEventListener("mousedown", handleClickOutside);
+		return () => document.removeEventListener("mousedown", handleClickOutside);
+	}, []);
+
+	function handleSelectUser(user: ActiveUser) {
+		setSelectedUser(user);
+		setValue("recipientId", user.id, { shouldValidate: true });
+		setSearchQuery("");
+		setIsDropdownOpen(false);
+	}
+
+	function handleClearSelection() {
+		setSelectedUser(null);
+		setValue("recipientId", "", { shouldValidate: true });
+		setSearchQuery("");
+		inputRef.current?.focus();
+	}
+
+	async function onSubmit(data: CreateRecognitionCardInput) {
+		setIsLoading(true);
+		try {
+			const result = await createRecognitionCardAction(data);
+
+			if (!result.success) {
+				const errorMsg =
+					typeof result.error === "string"
+						? result.error
+						: "Validation failed. Check the form fields.";
+				toast.error(errorMsg);
+				return;
+			}
+
+			toast.success("Recognition card sent!");
+			reset();
+			setSelectedUser(null);
+			setSearchQuery("");
+			await queryClient.invalidateQueries({
+				queryKey: ["recognition-cards"],
+			});
+		} catch {
+			toast.error("Something went wrong");
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
+			<div className="px-8 pt-8 pb-2">
+				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
+					Send Recognition
+				</h3>
+				<p className="mt-1 text-sm text-muted-foreground">
+					Recognize a colleague for demonstrating company values.
+				</p>
+			</div>
+			<form onSubmit={handleSubmit(onSubmit)}>
+				<div className="px-8 py-6 space-y-5">
+					{/* Recipient Combobox */}
+					<div>
+						<label className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5">
+							Recipient
+						</label>
+						<div className="relative" ref={dropdownRef}>
+							{selectedUser ? (
+								<div className="flex items-center justify-between rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3">
+									<span className="text-sm text-foreground">
+										{selectedUser.firstName} {selectedUser.lastName}
+										{selectedUser.position && (
+											<span className="text-muted-foreground">
+												{" "}
+												— {selectedUser.position}
+											</span>
+										)}
+									</span>
+									<button
+										type="button"
+										onClick={handleClearSelection}
+										className="ml-2 text-muted-foreground hover:text-foreground transition-colors"
+									>
+										<X size={16} />
+									</button>
+								</div>
+							) : (
+								<div className="relative">
+									<Search
+										size={16}
+										className="absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground"
+									/>
+									<input
+										ref={inputRef}
+										type="text"
+										placeholder="Search for a colleague..."
+										value={searchQuery}
+										onChange={(e) => {
+											setSearchQuery(e.target.value);
+											setIsDropdownOpen(true);
+										}}
+										onFocus={() => setIsDropdownOpen(true)}
+										className={`${inputClass} pl-10 pr-10`}
+									/>
+									<ChevronDown
+										size={16}
+										className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+									/>
+								</div>
+							)}
+
+							{isDropdownOpen && !selectedUser && (
+								<div className="absolute top-full left-0 right-0 z-50 mt-1 max-h-60 overflow-y-auto rounded-xl border border-gray-200 dark:border-white/10 bg-card shadow-lg">
+									{filteredUsers.length === 0 ? (
+										<div className="px-4 py-3 text-sm text-muted-foreground">
+											No users found
+										</div>
+									) : (
+										filteredUsers.map((user) => (
+											<button
+												key={user.id}
+												type="button"
+												onMouseDown={(e) => e.preventDefault()}
+												onClick={() => handleSelectUser(user)}
+												className="flex w-full items-center gap-3 px-4 py-3 text-left text-sm hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
+											>
+												<div>
+													<span className="font-medium text-foreground">
+														{user.firstName} {user.lastName}
+													</span>
+													{user.position && (
+														<span className="ml-2 text-muted-foreground">
+															{user.position}
+														</span>
+													)}
+												</div>
+											</button>
+										))
+									)}
+								</div>
+							)}
+						</div>
+						{errors.recipientId && (
+							<p className="mt-1 text-sm text-destructive">
+								{errors.recipientId.message}
+							</p>
+						)}
+					</div>
+
+					{/* Message */}
+					<div>
+						<label
+							htmlFor="message"
+							className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+						>
+							Message
+						</label>
+						<textarea
+							id="message"
+							rows={3}
+							placeholder="What did they do that you appreciate?"
+							className={`${inputClass} resize-none`}
+							{...register("message")}
+						/>
+						{errors.message && (
+							<p className="mt-1 text-sm text-destructive">
+								{errors.message.message}
+							</p>
+						)}
+					</div>
+
+					{/* Date */}
+					<div>
+						<label
+							htmlFor="date"
+							className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+						>
+							Date
+						</label>
+						<input
+							id="date"
+							type="date"
+							className={inputClass}
+							{...register("date")}
+						/>
+						{errors.date && (
+							<p className="mt-1 text-sm text-destructive">
+								{errors.date.message}
+							</p>
+						)}
+					</div>
+
+					{/* Company Values */}
+					<div>
+						<label className="block text-sm font-medium text-foreground/70 ml-1 mb-2">
+							Company Values
+						</label>
+						<div className="flex flex-wrap gap-3">
+							{COMPANY_VALUES.map((value) => {
+								const checked = watch(value.key);
+								return (
+									<label
+										key={value.key}
+										className={`inline-flex cursor-pointer items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-all duration-200 ${
+											checked
+												? "border-primary bg-primary/10 text-primary dark:bg-primary/15"
+												: "border-gray-200 dark:border-white/10 text-muted-foreground hover:border-gray-300 dark:hover:border-white/20"
+										}`}
+									>
+										<input
+											type="checkbox"
+											checked={checked}
+											onChange={(e) =>
+												setValue(value.key, e.target.checked, {
+													shouldValidate: true,
+												})
+											}
+											className="sr-only"
+										/>
+										{value.label}
+									</label>
+								);
+							})}
+						</div>
+						{errors.valuesPeople && (
+							<p className="mt-2 text-sm text-destructive">
+								{errors.valuesPeople.message}
+							</p>
+						)}
+					</div>
+				</div>
+
+				<div className="px-8 py-6 bg-gray-50/50 dark:bg-white/[0.02] border-t border-gray-200/60 dark:border-white/10 flex flex-row-reverse gap-3">
+					<button
+						type="submit"
+						disabled={isLoading}
+						className="inline-flex justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50"
+					>
+						{isLoading && (
+							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+						)}
+						Send Recognition
+					</button>
+				</div>
+			</form>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
@@ -3,6 +3,7 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Loader2, Search, ChevronDown, X } from "lucide-react";
@@ -35,6 +36,7 @@ const COMPANY_VALUES = [
 ];
 
 export function RecognitionForm() {
+	const router = useRouter();
 	const queryClient = useQueryClient();
 	const { data: session } = useSession();
 	const [isLoading, setIsLoading] = useState(false);
@@ -125,12 +127,10 @@ export function RecognitionForm() {
 			}
 
 			toast.success("Recognition card sent!");
-			reset();
-			setSelectedUser(null);
-			setSearchQuery("");
 			await queryClient.invalidateQueries({
 				queryKey: ["recognition-cards"],
 			});
+			router.push("/dashboard/recognition");
 		} catch {
 			toast.error("Something went wrong");
 		} finally {
@@ -331,6 +331,13 @@ export function RecognitionForm() {
 							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
 						)}
 						Send Recognition
+					</button>
+					<button
+						type="button"
+						onClick={() => router.push("/dashboard/recognition")}
+						className="inline-flex justify-center rounded-full border border-gray-200 dark:border-white/10 bg-card px-6 py-2.5 text-sm font-medium text-foreground hover:bg-gray-50 dark:hover:bg-white/5 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-white/10 transition-all duration-200"
+					>
+						Cancel
 					</button>
 				</div>
 			</form>

--- a/app/(dashboard)/dashboard/recognition/create/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/create/page.tsx
@@ -1,0 +1,22 @@
+import { getServerSession } from "@/lib/auth-utils";
+import { redirect } from "next/navigation";
+import { RecognitionForm } from "../_components/recognition-form";
+
+export default async function CreateRecognitionPage() {
+	const session = await getServerSession();
+	if (!session) redirect("/login");
+
+	return (
+		<div className="max-w-7xl mx-auto space-y-8 mt-2">
+			<div>
+				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+					Send Recognition Card
+				</h1>
+				<p className="mt-2 text-base text-muted-foreground">
+					Recognize a colleague for demonstrating company values.
+				</p>
+			</div>
+			<RecognitionForm />
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/recognition/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/page.tsx
@@ -1,0 +1,37 @@
+import { getServerSession } from "@/lib/auth-utils";
+import { redirect } from "next/navigation";
+import { Heart } from "lucide-react";
+
+export default async function RecognitionPage() {
+	const session = await getServerSession();
+	if (!session) redirect("/login");
+
+	return (
+		<div className="max-w-7xl mx-auto space-y-8 mt-2">
+			<div>
+				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+					Recognition Card
+				</h1>
+				<p className="mt-2 text-base text-muted-foreground">
+					Recognize your colleagues with digital thank-you cards tied to
+					company values.
+				</p>
+			</div>
+			<div className="flex flex-col items-center justify-center rounded-[2rem] border border-gray-200 dark:border-white/10 bg-card p-16 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+				<div className="mb-6 rounded-full bg-background p-6">
+					<Heart
+						size={48}
+						className="text-muted-foreground opacity-40"
+					/>
+				</div>
+				<p className="text-[1.5rem] font-medium text-foreground">
+					Recognition cards coming soon
+				</p>
+				<p className="mt-2 text-base text-muted-foreground">
+					This is where you&apos;ll send and view recognition cards for
+					your colleagues.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/recognition/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/page.tsx
@@ -1,6 +1,7 @@
 import { getServerSession } from "@/lib/auth-utils";
 import { redirect } from "next/navigation";
-import { RecognitionForm } from "./_components/recognition-form";
+import Link from "next/link";
+import { Plus } from "lucide-react";
 import { RecognitionFeed } from "./_components/recognition-feed";
 
 export default async function RecognitionPage() {
@@ -18,8 +19,15 @@ export default async function RecognitionPage() {
 					to company values.
 				</p>
 			</div>
-			<RecognitionForm />
 			<RecognitionFeed />
+
+			<Link
+				href="/dashboard/recognition/create"
+				className="fixed bottom-8 right-8 z-50 inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-lg hover:bg-primary/90 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
+			>
+				<Plus size={20} strokeWidth={2.5} />
+				Send Recognition Card
+			</Link>
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/recognition/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/page.tsx
@@ -1,6 +1,7 @@
 import { getServerSession } from "@/lib/auth-utils";
 import { redirect } from "next/navigation";
-import { Heart } from "lucide-react";
+import { RecognitionForm } from "./_components/recognition-form";
+import { RecognitionFeed } from "./_components/recognition-feed";
 
 export default async function RecognitionPage() {
 	const session = await getServerSession();
@@ -13,25 +14,12 @@ export default async function RecognitionPage() {
 					Recognition Card
 				</h1>
 				<p className="mt-2 text-base text-muted-foreground">
-					Recognize your colleagues with digital thank-you cards tied to
-					company values.
+					Recognize your colleagues with digital thank-you cards tied
+					to company values.
 				</p>
 			</div>
-			<div className="flex flex-col items-center justify-center rounded-[2rem] border border-gray-200 dark:border-white/10 bg-card p-16 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
-				<div className="mb-6 rounded-full bg-background p-6">
-					<Heart
-						size={48}
-						className="text-muted-foreground opacity-40"
-					/>
-				</div>
-				<p className="text-[1.5rem] font-medium text-foreground">
-					Recognition cards coming soon
-				</p>
-				<p className="mt-2 text-base text-muted-foreground">
-					This is where you&apos;ll send and view recognition cards for
-					your colleagues.
-				</p>
-			</div>
+			<RecognitionForm />
+			<RecognitionFeed />
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/recognition/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/page.tsx
@@ -10,24 +10,25 @@ export default async function RecognitionPage() {
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-8 mt-2">
-			<div>
-				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-					Recognition Card
-				</h1>
-				<p className="mt-2 text-base text-muted-foreground">
-					Recognize your colleagues with digital thank-you cards tied
-					to company values.
-				</p>
+			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+				<div>
+					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+						Recognition Card
+					</h1>
+					<p className="mt-2 text-base text-muted-foreground">
+						Recognize your colleagues with digital thank-you cards
+						tied to company values.
+					</p>
+				</div>
+				<Link
+					href="/dashboard/recognition/create"
+					className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
+				>
+					<Plus className="-ml-1 h-5 w-5" />
+					Send Recognition Card
+				</Link>
 			</div>
 			<RecognitionFeed />
-
-			<Link
-				href="/dashboard/recognition/create"
-				className="fixed bottom-8 right-8 z-50 inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-lg hover:bg-primary/90 hover:shadow-xl focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-			>
-				<Plus size={20} strokeWidth={2.5} />
-				Send Recognition Card
-			</Link>
 		</div>
 	);
 }

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -1,0 +1,40 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { headers } from "next/headers";
+
+export async function GET() {
+	const session = await auth.api.getSession({ headers: await headers() });
+
+	if (!session) {
+		return Response.json(
+			{ success: false, error: "Unauthorized" },
+			{ status: 401 },
+		);
+	}
+
+	const cards = await prisma.recognitionCard.findMany({
+		include: {
+			sender: {
+				select: {
+					id: true,
+					firstName: true,
+					lastName: true,
+					avatar: true,
+					position: true,
+				},
+			},
+			recipient: {
+				select: {
+					id: true,
+					firstName: true,
+					lastName: true,
+					avatar: true,
+					position: true,
+				},
+			},
+		},
+		orderBy: { createdAt: "desc" },
+	});
+
+	return Response.json({ success: true, data: cards });
+}

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -1,40 +1,39 @@
-import { auth } from "@/lib/auth";
+import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
-import { headers } from "next/headers";
 
 export async function GET() {
-	const session = await auth.api.getSession({ headers: await headers() });
+	try {
+		await requireSession();
 
-	if (!session) {
+		const cards = await prisma.recognitionCard.findMany({
+			include: {
+				sender: {
+					select: {
+						id: true,
+						firstName: true,
+						lastName: true,
+						avatar: true,
+						position: true,
+					},
+				},
+				recipient: {
+					select: {
+						id: true,
+						firstName: true,
+						lastName: true,
+						avatar: true,
+						position: true,
+					},
+				},
+			},
+			orderBy: { createdAt: "desc" },
+		});
+
+		return Response.json({ success: true, data: cards });
+	} catch {
 		return Response.json(
 			{ success: false, error: "Unauthorized" },
 			{ status: 401 },
 		);
 	}
-
-	const cards = await prisma.recognitionCard.findMany({
-		include: {
-			sender: {
-				select: {
-					id: true,
-					firstName: true,
-					lastName: true,
-					avatar: true,
-					position: true,
-				},
-			},
-			recipient: {
-				select: {
-					id: true,
-					firstName: true,
-					lastName: true,
-					avatar: true,
-					position: true,
-				},
-			},
-		},
-		orderBy: { createdAt: "desc" },
-	});
-
-	return Response.json({ success: true, data: cards });
 }

--- a/app/api/recognition/users/route.ts
+++ b/app/api/recognition/users/route.ts
@@ -1,0 +1,27 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { headers } from "next/headers";
+
+export async function GET() {
+	const session = await auth.api.getSession({ headers: await headers() });
+
+	if (!session) {
+		return Response.json(
+			{ success: false, error: "Unauthorized" },
+			{ status: 401 },
+		);
+	}
+
+	const users = await prisma.user.findMany({
+		where: { isActive: true },
+		select: {
+			id: true,
+			firstName: true,
+			lastName: true,
+			position: true,
+		},
+		orderBy: { firstName: "asc" },
+	});
+
+	return Response.json({ success: true, data: users });
+}

--- a/app/api/recognition/users/route.ts
+++ b/app/api/recognition/users/route.ts
@@ -1,27 +1,26 @@
-import { auth } from "@/lib/auth";
+import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
-import { headers } from "next/headers";
 
 export async function GET() {
-	const session = await auth.api.getSession({ headers: await headers() });
+	try {
+		await requireSession();
 
-	if (!session) {
+		const users = await prisma.user.findMany({
+			where: { isActive: true },
+			select: {
+				id: true,
+				firstName: true,
+				lastName: true,
+				position: true,
+			},
+			orderBy: { firstName: "asc" },
+		});
+
+		return Response.json({ success: true, data: users });
+	} catch {
 		return Response.json(
 			{ success: false, error: "Unauthorized" },
 			{ status: 401 },
 		);
 	}
-
-	const users = await prisma.user.findMany({
-		where: { isActive: true },
-		select: {
-			id: true,
-			firstName: true,
-			lastName: true,
-			position: true,
-		},
-		orderBy: { firstName: "asc" },
-	});
-
-	return Response.json({ success: true, data: users });
 }

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -25,6 +25,12 @@ const NAV_ITEMS = [
 		adminOnly: false,
 	},
 	{
+		label: "Recognition Card",
+		href: "/dashboard/recognition",
+		icon: Heart,
+		adminOnly: false,
+	},
+	{
 		label: "Staff",
 		href: "/dashboard/users",
 		icon: Users,
@@ -35,12 +41,6 @@ const NAV_ITEMS = [
 		href: "/dashboard/departments",
 		icon: Building2,
 		adminOnly: true,
-	},
-	{
-		label: "Recognition Card",
-		href: "/dashboard/recognition",
-		icon: Heart,
-		adminOnly: false,
 	},
 	{
 		label: "My Profile",

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -7,6 +7,7 @@ import {
 	LayoutDashboard,
 	Users,
 	Building2,
+	Heart,
 	UserCircle,
 	LogOut,
 	Menu,
@@ -34,6 +35,12 @@ const NAV_ITEMS = [
 		href: "/dashboard/departments",
 		icon: Building2,
 		adminOnly: true,
+	},
+	{
+		label: "Recognition Card",
+		href: "/dashboard/recognition",
+		icon: Heart,
+		adminOnly: false,
 	},
 	{
 		label: "My Profile",

--- a/lib/actions/recognition-actions.ts
+++ b/lib/actions/recognition-actions.ts
@@ -1,0 +1,95 @@
+"use server";
+
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/auth-utils";
+import { createRecognitionCardSchema } from "@/lib/validations/recognition";
+import { revalidatePath } from "next/cache";
+
+export async function createRecognitionCardAction(formData: unknown) {
+	try {
+		const session = await requireSession();
+		const parsed = createRecognitionCardSchema.safeParse(formData);
+
+		if (!parsed.success) {
+			return {
+				success: false as const,
+				error: parsed.error.flatten().fieldErrors,
+			};
+		}
+
+		const { date, recipientId, ...rest } = parsed.data;
+
+		if (recipientId === session.user.id) {
+			return {
+				success: false as const,
+				error: "You cannot send a recognition card to yourself",
+			};
+		}
+
+		const recipient = await prisma.user.findUnique({
+			where: { id: recipientId, isActive: true },
+			select: { id: true },
+		});
+
+		if (!recipient) {
+			return {
+				success: false as const,
+				error: "Recipient not found or inactive",
+			};
+		}
+
+		const card = await prisma.recognitionCard.create({
+			data: {
+				...rest,
+				recipientId,
+				senderId: session.user.id,
+				date: new Date(`${date}T00:00:00`),
+			},
+		});
+
+		revalidatePath("/dashboard/recognition");
+		return { success: true as const, data: card };
+	} catch (error) {
+		const message =
+			error instanceof Error
+				? error.message
+				: "Failed to create recognition card";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function getRecognitionCardsAction() {
+	try {
+		await requireSession();
+		const cards = await prisma.recognitionCard.findMany({
+			include: {
+				sender: {
+					select: {
+						id: true,
+						firstName: true,
+						lastName: true,
+						avatar: true,
+						position: true,
+					},
+				},
+				recipient: {
+					select: {
+						id: true,
+						firstName: true,
+						lastName: true,
+						avatar: true,
+						position: true,
+					},
+				},
+			},
+			orderBy: { createdAt: "desc" },
+		});
+		return { success: true as const, data: cards };
+	} catch (error) {
+		const message =
+			error instanceof Error
+				? error.message
+				: "Failed to fetch recognition cards";
+		return { success: false as const, error: message };
+	}
+}

--- a/lib/validations/recognition.ts
+++ b/lib/validations/recognition.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const createRecognitionCardSchema = z
+	.object({
+		recipientId: z.string().min(1, "Recipient is required"),
+		message: z
+			.string()
+			.min(1, "Message is required")
+			.max(500, "Message must be 500 characters or less"),
+		date: z.string().min(1, "Date is required"),
+		valuesPeople: z.boolean(),
+		valuesSafety: z.boolean(),
+		valuesRespect: z.boolean(),
+		valuesCommunication: z.boolean(),
+		valuesContinuousImprovement: z.boolean(),
+	})
+	.refine(
+		(data) =>
+			data.valuesPeople ||
+			data.valuesSafety ||
+			data.valuesRespect ||
+			data.valuesCommunication ||
+			data.valuesContinuousImprovement,
+		{
+			message: "At least one company value must be selected",
+			path: ["valuesPeople"],
+		},
+	);
+
+export type CreateRecognitionCardInput = z.infer<
+	typeof createRecognitionCardSchema
+>;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,26 +14,28 @@ enum Role {
 }
 
 model User {
-  id            String    @id @default(cuid())
+  id            String   @id @default(cuid())
   name          String?
-  email         String    @unique
-  emailVerified Boolean   @default(false) @map("email_verified")
+  email         String   @unique
+  emailVerified Boolean  @default(false) @map("email_verified")
   image         String?
-  firstName     String    @map("first_name")
-  lastName      String    @map("last_name")
-  displayName   String?   @map("display_name")
+  firstName     String   @map("first_name")
+  lastName      String   @map("last_name")
+  displayName   String?  @map("display_name")
   phone         String?
   position      String?
   avatar        String?
-  role          Role      @default(STAFF)
-  isActive      Boolean   @default(true) @map("is_active")
-  departmentId  String?   @map("department_id")
-  createdAt     DateTime  @default(now()) @map("created_at")
-  updatedAt     DateTime  @updatedAt @map("updated_at")
+  role          Role     @default(STAFF)
+  isActive      Boolean  @default(true) @map("is_active")
+  departmentId  String?  @map("department_id")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
 
-  department Department? @relation(fields: [departmentId], references: [id])
-  sessions   Session[]
-  accounts   Account[]
+  department           Department?       @relation(fields: [departmentId], references: [id])
+  sessions             Session[]
+  accounts             Account[]
+  sentRecognitions     RecognitionCard[] @relation("sender")
+  receivedRecognitions RecognitionCard[] @relation("recipient")
 
   @@map("users")
 }
@@ -94,4 +96,25 @@ model Department {
   users User[]
 
   @@map("departments")
+}
+
+model RecognitionCard {
+  id        String   @id @default(uuid())
+  message   String
+  date      DateTime @db.Date
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  senderId    String @map("sender_id")
+  sender      User   @relation("sender", fields: [senderId], references: [id])
+  recipientId String @map("recipient_id")
+  recipient   User   @relation("recipient", fields: [recipientId], references: [id])
+
+  valuesPeople                Boolean @default(false) @map("values_people")
+  valuesSafety                Boolean @default(false) @map("values_safety")
+  valuesRespect               Boolean @default(false) @map("values_respect")
+  valuesCommunication         Boolean @default(false) @map("values_communication")
+  valuesContinuousImprovement Boolean @default(false) @map("values_continuous_improvement")
+
+  @@map("recognition_cards")
 }


### PR DESCRIPTION
## Summary
- Add `RecognitionCard` Prisma model with sender/recipient relations and 5 company value booleans
- Add Recognition Card navigation item in sidebar (below Overview)
- Add `/dashboard/recognition` page with card feed (React Query) and top-right "Send Recognition Card" button
- Add `/dashboard/recognition/create` page with send form — searchable recipient combobox, message, date, and company value toggle pills
- Add Zod validation schema, server actions, and API routes (`/api/recognition`, `/api/recognition/users`)

## Test plan
- [ ] Navigate to `/dashboard/recognition` — page loads with feed (or empty state)
- [ ] Click "Send Recognition Card" — navigates to `/dashboard/recognition/create`
- [ ] Submit form without selecting a value — validation error shown
- [ ] Submit form with all fields filled — card appears in feed, toast shown, redirected back
- [ ] Verify you cannot select yourself as recipient
- [ ] Verify sidebar nav order: Overview → Recognition Card → Staff → Departments → My Profile
- [ ] Test dark mode and mobile responsive layout