### PR TITLE
feat(dashboard): 2-column widget layout, stats card, and recognition inbox

### DIFF
--- a/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
@@ -1,15 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { Globe, Building2 } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { RecognitionFeed } from "../recognition/_components/recognition-feed";
 
+const FEED_TABS = [
+	{
+		key: "all" as const,
+		label: "Public",
+		icon: Globe,
+		emptyTitle: "No recognition cards yet",
+		emptyDescription: "Be the first to recognize a colleague!",
+	},
+	{
+		key: "department" as const,
+		label: "My Department",
+		icon: Building2,
+		emptyTitle: "No department recognitions yet",
+		emptyDescription:
+			"Recognition cards involving your department will appear here.",
+	},
+];
+
 export function RecognitionFeedWidget() {
+	const [activeTab, setActiveTab] = useState<"all" | "department">("all");
+	const currentTab = FEED_TABS.find((t) => t.key === activeTab)!;
+
 	return (
 		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] overflow-hidden flex flex-col">
-			<div className="px-6 pt-6 pb-2">
+			<div className="px-6 pt-6 pb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 				<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight">
-					Public Recognition Feed
+					Recognition Feed
 				</h3>
+				<div
+					className="flex gap-1 rounded-full bg-gray-100 dark:bg-white/5 p-1 w-fit"
+					role="tablist"
+					aria-label="Recognition feed filter"
+				>
+					{FEED_TABS.map((tab) => (
+						<button
+							key={tab.key}
+							type="button"
+							role="tab"
+							aria-selected={activeTab === tab.key}
+							onClick={() => setActiveTab(tab.key)}
+							className={cn(
+								"inline-flex items-center gap-1.5 rounded-full px-4 py-1.5 text-xs font-medium transition-all duration-200",
+								activeTab === tab.key
+									? "bg-card text-foreground shadow-sm"
+									: "text-muted-foreground hover:text-foreground",
+							)}
+						>
+							<tab.icon size={14} />
+							{tab.label}
+						</button>
+					))}
+				</div>
 			</div>
-			<div className="px-6 pb-6 overflow-y-auto max-h-[calc(100vh-12rem)]">
-				<RecognitionFeed filter="all" showTitle={false} />
+			<div
+				className="px-6 pb-6 overflow-y-auto max-h-[calc(100vh-12rem)]"
+				role="tabpanel"
+			>
+				<RecognitionFeed
+					filter={activeTab}
+					showTitle={false}
+					emptyTitle={currentTab.emptyTitle}
+					emptyDescription={currentTab.emptyDescription}
+				/>
 			</div>
 		</div>
 	);

--- a/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { RecognitionFeed } from "../recognition/_components/recognition-feed";
 
 export function RecognitionFeedWidget() {

--- a/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { RecognitionFeed } from "../recognition/_components/recognition-feed";
+
+export function RecognitionFeedWidget() {
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] overflow-hidden flex flex-col">
+			<div className="px-6 pt-6 pb-2">
+				<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight">
+					Public Recognition Feed
+				</h3>
+			</div>
+			<div className="px-6 pb-6 overflow-y-auto max-h-[calc(100vh-12rem)]">
+				<RecognitionFeed filter="all" showTitle={false} />
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -69,7 +69,7 @@ function StatsWidgetSkeleton() {
 }
 
 export function StatsWidget() {
-	const { data, isPending } = useQuery<{
+	const { data, isPending, isError } = useQuery<{
 		success: boolean;
 		data: StatsData;
 	}>({
@@ -85,7 +85,20 @@ export function StatsWidget() {
 		return <StatsWidgetSkeleton />;
 	}
 
-	const stats = data?.data;
+	if (isError || !data?.data) {
+		return (
+			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+				<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight mb-2">
+					Recognition Stats
+				</h3>
+				<p className="text-sm text-muted-foreground">
+					Unable to load stats. Please try again later.
+				</p>
+			</div>
+		);
+	}
+
+	const stats = data.data;
 
 	return (
 		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] space-y-6">

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Send, Inbox, Calendar, Trophy } from "lucide-react";
+import { getInitials } from "@/lib/utils";
 
 interface StatsData {
 	sent: number;
@@ -15,9 +16,6 @@ interface StatsData {
 	}[];
 }
 
-function getInitials(firstName: string, lastName: string) {
-	return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
-}
 
 function StatItem({
 	icon: Icon,
@@ -43,7 +41,7 @@ function StatItem({
 
 function StatsWidgetSkeleton() {
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] animate-pulse space-y-6">
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] animate-pulse space-y-6" aria-busy="true" aria-label="Loading recognition stats">
 			<div className="h-5 w-32 bg-gray-200 dark:bg-white/10 rounded" />
 			<div className="grid grid-cols-3 gap-4">
 				{[1, 2, 3].map((i) => (
@@ -79,6 +77,7 @@ export function StatsWidget() {
 			if (!res.ok) throw new Error("Failed to fetch stats");
 			return res.json();
 		},
+		staleTime: 30_000,
 	});
 
 	if (isPending) {
@@ -132,15 +131,12 @@ export function StatsWidget() {
 							Most Recognized
 						</h4>
 					</div>
-					<div className="space-y-3">
-						{stats.topRecipients.map((person, i) => (
-							<div
+					<ol className="space-y-3">
+						{stats.topRecipients.map((person) => (
+							<li
 								key={`${person.firstName}-${person.lastName}`}
 								className="flex items-center gap-3"
 							>
-								<span className="text-xs font-semibold text-muted-foreground w-4">
-									{i + 1}.
-								</span>
 								<div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold">
 									{getInitials(
 										person.firstName,
@@ -153,9 +149,9 @@ export function StatsWidget() {
 								<span className="text-sm font-semibold text-primary">
 									{person.count}
 								</span>
-							</div>
+							</li>
 						))}
-					</div>
+					</ol>
 				</div>
 			)}
 		</div>

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Send, Inbox, Calendar, Trophy } from "lucide-react";
+
+interface StatsData {
+	sent: number;
+	received: number;
+	monthlyTotal: number;
+	topRecipients: {
+		firstName: string;
+		lastName: string;
+		avatar: string | null;
+		count: number;
+	}[];
+}
+
+function getInitials(firstName: string, lastName: string) {
+	return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+}
+
+function StatItem({
+	icon: Icon,
+	label,
+	value,
+}: {
+	icon: React.ComponentType<{ size?: number; className?: string }>;
+	label: string;
+	value: number;
+}) {
+	return (
+		<div className="flex items-center gap-3">
+			<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+				<Icon size={18} className="text-primary" />
+			</div>
+			<div>
+				<p className="text-2xl font-semibold text-foreground">{value}</p>
+				<p className="text-xs text-muted-foreground">{label}</p>
+			</div>
+		</div>
+	);
+}
+
+function StatsWidgetSkeleton() {
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] animate-pulse space-y-6">
+			<div className="h-5 w-32 bg-gray-200 dark:bg-white/10 rounded" />
+			<div className="grid grid-cols-3 gap-4">
+				{[1, 2, 3].map((i) => (
+					<div key={i} className="flex items-center gap-3">
+						<div className="h-10 w-10 rounded-full bg-gray-200 dark:bg-white/10" />
+						<div className="space-y-1">
+							<div className="h-6 w-8 bg-gray-200 dark:bg-white/10 rounded" />
+							<div className="h-3 w-16 bg-gray-200 dark:bg-white/10 rounded" />
+						</div>
+					</div>
+				))}
+			</div>
+			<div className="space-y-3">
+				{[1, 2, 3].map((i) => (
+					<div key={i} className="flex items-center gap-3">
+						<div className="h-8 w-8 rounded-full bg-gray-200 dark:bg-white/10" />
+						<div className="h-4 w-24 bg-gray-200 dark:bg-white/10 rounded" />
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+export function StatsWidget() {
+	const { data, isPending } = useQuery<{
+		success: boolean;
+		data: StatsData;
+	}>({
+		queryKey: ["recognition-stats"],
+		queryFn: async () => {
+			const res = await fetch("/api/recognition/stats");
+			if (!res.ok) throw new Error("Failed to fetch stats");
+			return res.json();
+		},
+	});
+
+	if (isPending) {
+		return <StatsWidgetSkeleton />;
+	}
+
+	const stats = data?.data;
+
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] space-y-6">
+			<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight">
+				Recognition Stats
+			</h3>
+
+			<div className="grid grid-cols-3 gap-4">
+				<StatItem
+					icon={Send}
+					label="Cards Sent"
+					value={stats?.sent ?? 0}
+				/>
+				<StatItem
+					icon={Inbox}
+					label="Cards Received"
+					value={stats?.received ?? 0}
+				/>
+				<StatItem
+					icon={Calendar}
+					label="This Month"
+					value={stats?.monthlyTotal ?? 0}
+				/>
+			</div>
+
+			{stats?.topRecipients && stats.topRecipients.length > 0 && (
+				<div>
+					<div className="flex items-center gap-2 mb-3">
+						<Trophy size={16} className="text-primary" />
+						<h4 className="text-sm font-medium text-foreground/70">
+							Most Recognized
+						</h4>
+					</div>
+					<div className="space-y-3">
+						{stats.topRecipients.map((person, i) => (
+							<div
+								key={`${person.firstName}-${person.lastName}`}
+								className="flex items-center gap-3"
+							>
+								<span className="text-xs font-semibold text-muted-foreground w-4">
+									{i + 1}.
+								</span>
+								<div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold">
+									{getInitials(
+										person.firstName,
+										person.lastName,
+									)}
+								</div>
+								<span className="text-sm font-medium text-foreground flex-1">
+									{person.firstName} {person.lastName}
+								</span>
+								<span className="text-sm font-semibold text-primary">
+									{person.count}
+								</span>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,9 @@
 import { getServerSession } from "@/lib/auth-utils";
 import { redirect } from "next/navigation";
-import { LayoutDashboard } from "lucide-react";
+import Link from "next/link";
+import { Plus } from "lucide-react";
+import { StatsWidget } from "./_components/stats-widget";
+import { RecognitionFeedWidget } from "./_components/recognition-feed-widget";
 
 export default async function DashboardPage() {
 	const session = await getServerSession();
@@ -9,25 +12,34 @@ export default async function DashboardPage() {
 	const user = session.user;
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
-			<div>
-				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-					Welcome back, {user.firstName as string ?? user.name}!
-				</h1>
-				<p className="mt-2 text-base text-muted-foreground">
-					Here&apos;s what&apos;s happening at Access Group today.
-				</p>
-			</div>
-			<div className="flex flex-col items-center justify-center rounded-[2rem] border border-gray-200 dark:border-white/10 bg-card p-16 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
-				<div className="mb-6 rounded-full bg-background p-6">
-					<LayoutDashboard size={48} className="text-muted-foreground opacity-40" />
+		<div className="max-w-7xl mx-auto mt-2">
+			<div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-8">
+				{/* Left Column */}
+				<div className="space-y-6">
+					<div>
+						<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+							Welcome back,{" "}
+							{(user.firstName as string) ?? user.name}!
+						</h1>
+						<p className="mt-2 text-base text-muted-foreground">
+							Here&apos;s what&apos;s happening at Access Group
+							today.
+						</p>
+					</div>
+
+					<StatsWidget />
+
+					<Link
+						href="/dashboard/recognition/create"
+						className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
+					>
+						<Plus className="-ml-1 h-5 w-5" />
+						Send Recognition Card
+					</Link>
 				</div>
-				<p className="text-[1.5rem] font-medium text-foreground">
-					Recognition feed coming in Phase 2
-				</p>
-				<p className="mt-2 text-base text-muted-foreground">
-					This is where you&apos;ll see recognition cards from your colleagues.
-				</p>
+
+				{/* Right Column */}
+				<RecognitionFeedWidget />
 			</div>
 		</div>
 	);

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -12,33 +12,30 @@ export default async function DashboardPage() {
 	const user = session.user;
 
 	return (
-		<div className="max-w-7xl mx-auto mt-2">
-			<div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-8">
-				{/* Left Column */}
-				<div className="space-y-6">
-					<div>
-						<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-							Welcome back,{" "}
-							{(user.firstName as string) ?? user.name}!
-						</h1>
-						<p className="mt-2 text-base text-muted-foreground">
-							Here&apos;s what&apos;s happening at Access Group
-							today.
-						</p>
-					</div>
-
-					<StatsWidget />
-
-					<Link
-						href="/dashboard/recognition/create"
-						className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-					>
-						<Plus className="-ml-1 h-5 w-5" />
-						Send Recognition Card
-					</Link>
+		<div className="max-w-7xl mx-auto mt-2 space-y-8">
+			{/* Top Row: Welcome + Send Button */}
+			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+				<div>
+					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+						Welcome back,{" "}
+						{(user.firstName as string) ?? user.name}!
+					</h1>
+					<p className="mt-2 text-base text-muted-foreground">
+						Here&apos;s what&apos;s happening at Access Group today.
+					</p>
 				</div>
+				<Link
+					href="/dashboard/recognition/create"
+					className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
+				>
+					<Plus className="-ml-1 h-5 w-5" />
+					Send Recognition Card
+				</Link>
+			</div>
 
-				{/* Right Column */}
+			{/* Widgets: Stats + Public Feed */}
+			<div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-8">
+				<StatsWidget />
 				<RecognitionFeedWidget />
 			</div>
 		</div>

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -75,7 +75,7 @@ function CardSkeleton() {
 }
 
 interface RecognitionFeedProps {
-	filter?: "all" | "received" | "sent";
+	filter?: "all" | "received" | "sent" | "department";
 	showTitle?: boolean;
 	emptyTitle?: string;
 	emptyDescription?: string;

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Heart, ArrowRight } from "lucide-react";
+import { getInitials } from "@/lib/utils";
 
 interface RecognitionUser {
 	id: string;
@@ -32,10 +33,6 @@ const VALUE_LABELS: Record<string, string> = {
 	valuesCommunication: "Communication",
 	valuesContinuousImprovement: "Continuous Improvement",
 };
-
-function getInitials(firstName: string, lastName: string) {
-	return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
-}
 
 function getSelectedValues(card: RecognitionCard): string[] {
 	return Object.entries(VALUE_LABELS)
@@ -102,6 +99,7 @@ export function RecognitionFeed({
 			if (!res.ok) throw new Error("Failed to fetch recognition cards");
 			return res.json();
 		},
+		staleTime: 30_000,
 	});
 
 	const cards = data?.data ?? [];

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -45,7 +45,11 @@ function getSelectedValues(card: RecognitionCard): string[] {
 
 function formatDate(dateString: string) {
 	const [year, month, day] = dateString.split("T")[0].split("-");
-	return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-US", {
+	return new Date(
+		Number(year),
+		Number(month) - 1,
+		Number(day),
+	).toLocaleDateString("en-US", {
 		month: "short",
 		day: "numeric",
 		year: "numeric",
@@ -73,14 +77,28 @@ function CardSkeleton() {
 	);
 }
 
-export function RecognitionFeed() {
+interface RecognitionFeedProps {
+	filter?: "all" | "received" | "sent";
+	showTitle?: boolean;
+	emptyTitle?: string;
+	emptyDescription?: string;
+}
+
+export function RecognitionFeed({
+	filter = "all",
+	showTitle = true,
+	emptyTitle = "No recognition cards yet",
+	emptyDescription = "Be the first to recognize a colleague!",
+}: RecognitionFeedProps) {
+	const queryParam = filter !== "all" ? `?filter=${filter}` : "";
+
 	const { data, isPending } = useQuery<{
 		success: boolean;
 		data: RecognitionCard[];
 	}>({
-		queryKey: ["recognition-cards"],
+		queryKey: ["recognition-cards", filter],
 		queryFn: async () => {
-			const res = await fetch("/api/recognition");
+			const res = await fetch(`/api/recognition${queryParam}`);
 			if (!res.ok) throw new Error("Failed to fetch recognition cards");
 			return res.json();
 		},
@@ -91,9 +109,11 @@ export function RecognitionFeed() {
 	if (isPending) {
 		return (
 			<div className="space-y-4">
-				<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight">
-					Recent Recognitions
-				</h3>
+				{showTitle && (
+					<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight">
+						Recent Recognitions
+					</h3>
+				)}
 				<CardSkeleton />
 				<CardSkeleton />
 				<CardSkeleton />
@@ -111,10 +131,10 @@ export function RecognitionFeed() {
 					/>
 				</div>
 				<p className="text-[1.5rem] font-medium text-foreground">
-					No recognition cards yet
+					{emptyTitle}
 				</p>
 				<p className="mt-2 text-base text-muted-foreground">
-					Be the first to recognize a colleague!
+					{emptyDescription}
 				</p>
 			</div>
 		);
@@ -122,9 +142,11 @@ export function RecognitionFeed() {
 
 	return (
 		<div className="space-y-4">
-			<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight">
-				Recent Recognitions
-			</h3>
+			{showTitle && (
+				<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight">
+					Recent Recognitions
+				</h3>
+			)}
 			{cards.map((card) => {
 				const values = getSelectedValues(card);
 				return (
@@ -132,7 +154,6 @@ export function RecognitionFeed() {
 						key={card.id}
 						className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]"
 					>
-						{/* Header: Sender → Recipient */}
 						<div className="flex items-center gap-3 mb-3">
 							<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary text-sm font-semibold">
 								{getInitials(
@@ -142,7 +163,8 @@ export function RecognitionFeed() {
 							</div>
 							<div className="text-sm">
 								<span className="font-medium text-foreground">
-									{card.sender.firstName} {card.sender.lastName}
+									{card.sender.firstName}{" "}
+									{card.sender.lastName}
 								</span>
 								{card.sender.position && (
 									<p className="text-muted-foreground text-xs">
@@ -173,12 +195,10 @@ export function RecognitionFeed() {
 							</div>
 						</div>
 
-						{/* Message */}
 						<p className="text-sm text-foreground/80 mb-3 leading-relaxed">
 							{card.message}
 						</p>
 
-						{/* Footer: Values + Date */}
 						<div className="flex flex-wrap items-center gap-2">
 							{values.map((value) => (
 								<span

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
@@ -372,9 +372,14 @@ export function RecognitionForm() {
 			}
 
 			toast.success("Recognition card sent!");
-			await queryClient.invalidateQueries({
-				queryKey: ["recognition-cards"],
-			});
+			await Promise.all([
+				queryClient.invalidateQueries({
+					queryKey: ["recognition-cards"],
+				}),
+				queryClient.invalidateQueries({
+					queryKey: ["recognition-stats"],
+				}),
+			]);
 			router.push("/dashboard/recognition");
 		} catch {
 			toast.error("Something went wrong");

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-inbox.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-inbox.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { Inbox, Send } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { RecognitionFeed } from "./recognition-feed";
+
+const TABS = [
+	{
+		key: "received" as const,
+		label: "Received",
+		icon: Inbox,
+		emptyTitle: "No recognition cards received yet",
+		emptyDescription:
+			"When a colleague recognizes you, it will appear here.",
+	},
+	{
+		key: "sent" as const,
+		label: "Sent",
+		icon: Send,
+		emptyTitle: "You haven't sent any cards yet",
+		emptyDescription: "Recognize a colleague to get started!",
+	},
+];
+
+export function RecognitionInbox() {
+	const [activeTab, setActiveTab] = useState<"received" | "sent">("received");
+	const currentTab = TABS.find((t) => t.key === activeTab)!;
+
+	return (
+		<>
+			<div
+				className="flex gap-1 rounded-full bg-gray-100 dark:bg-white/5 p-1 w-fit"
+				role="tablist"
+				aria-label="Recognition inbox"
+			>
+				{TABS.map((tab) => (
+					<button
+						key={tab.key}
+						type="button"
+						role="tab"
+						aria-selected={activeTab === tab.key}
+						onClick={() => setActiveTab(tab.key)}
+						className={cn(
+							"inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition-all duration-200",
+							activeTab === tab.key
+								? "bg-card text-foreground shadow-sm"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+					>
+						<tab.icon size={16} />
+						{tab.label}
+					</button>
+				))}
+			</div>
+
+			<div role="tabpanel">
+				<RecognitionFeed
+					filter={activeTab}
+					showTitle={false}
+					emptyTitle={currentTab.emptyTitle}
+					emptyDescription={currentTab.emptyDescription}
+				/>
+			</div>
+		</>
+	);
+}

--- a/app/(dashboard)/dashboard/recognition/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/page.tsx
@@ -1,32 +1,12 @@
-"use client";
-
-import { useState } from "react";
+import { getServerSession } from "@/lib/auth-utils";
+import { redirect } from "next/navigation";
 import Link from "next/link";
-import { Plus, Inbox, Send } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { RecognitionFeed } from "./_components/recognition-feed";
+import { Plus } from "lucide-react";
+import { RecognitionInbox } from "./_components/recognition-inbox";
 
-const TABS = [
-	{
-		key: "received" as const,
-		label: "Received",
-		icon: Inbox,
-		emptyTitle: "No recognition cards received yet",
-		emptyDescription:
-			"When a colleague recognizes you, it will appear here.",
-	},
-	{
-		key: "sent" as const,
-		label: "Sent",
-		icon: Send,
-		emptyTitle: "You haven't sent any cards yet",
-		emptyDescription: "Recognize a colleague to get started!",
-	},
-];
-
-export default function RecognitionPage() {
-	const [activeTab, setActiveTab] = useState<"received" | "sent">("received");
-	const currentTab = TABS.find((t) => t.key === activeTab)!;
+export default async function RecognitionPage() {
+	const session = await getServerSession();
+	if (!session) redirect("/login");
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-6 mt-2">
@@ -48,33 +28,7 @@ export default function RecognitionPage() {
 				</Link>
 			</div>
 
-			{/* Tabs */}
-			<div className="flex gap-1 rounded-full bg-gray-100 dark:bg-white/5 p-1 w-fit">
-				{TABS.map((tab) => (
-					<button
-						key={tab.key}
-						type="button"
-						onClick={() => setActiveTab(tab.key)}
-						className={cn(
-							"inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition-all duration-200",
-							activeTab === tab.key
-								? "bg-card text-foreground shadow-sm"
-								: "text-muted-foreground hover:text-foreground",
-						)}
-					>
-						<tab.icon size={16} />
-						{tab.label}
-					</button>
-				))}
-			</div>
-
-			{/* Feed */}
-			<RecognitionFeed
-				filter={activeTab}
-				showTitle={false}
-				emptyTitle={currentTab.emptyTitle}
-				emptyDescription={currentTab.emptyDescription}
-			/>
+			<RecognitionInbox />
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/recognition/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/page.tsx
@@ -1,23 +1,42 @@
-import { getServerSession } from "@/lib/auth-utils";
-import { redirect } from "next/navigation";
+"use client";
+
+import { useState } from "react";
 import Link from "next/link";
-import { Plus } from "lucide-react";
+import { Plus, Inbox, Send } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { RecognitionFeed } from "./_components/recognition-feed";
 
-export default async function RecognitionPage() {
-	const session = await getServerSession();
-	if (!session) redirect("/login");
+const TABS = [
+	{
+		key: "received" as const,
+		label: "Received",
+		icon: Inbox,
+		emptyTitle: "No recognition cards received yet",
+		emptyDescription:
+			"When a colleague recognizes you, it will appear here.",
+	},
+	{
+		key: "sent" as const,
+		label: "Sent",
+		icon: Send,
+		emptyTitle: "You haven't sent any cards yet",
+		emptyDescription: "Recognize a colleague to get started!",
+	},
+];
+
+export default function RecognitionPage() {
+	const [activeTab, setActiveTab] = useState<"received" | "sent">("received");
+	const currentTab = TABS.find((t) => t.key === activeTab)!;
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
+		<div className="max-w-7xl mx-auto space-y-6 mt-2">
 			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
 				<div>
 					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
 						Recognition Card
 					</h1>
 					<p className="mt-2 text-base text-muted-foreground">
-						Recognize your colleagues with digital thank-you cards
-						tied to company values.
+						Your personal recognition inbox.
 					</p>
 				</div>
 				<Link
@@ -28,7 +47,34 @@ export default async function RecognitionPage() {
 					Send Recognition Card
 				</Link>
 			</div>
-			<RecognitionFeed />
+
+			{/* Tabs */}
+			<div className="flex gap-1 rounded-full bg-gray-100 dark:bg-white/5 p-1 w-fit">
+				{TABS.map((tab) => (
+					<button
+						key={tab.key}
+						type="button"
+						onClick={() => setActiveTab(tab.key)}
+						className={cn(
+							"inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition-all duration-200",
+							activeTab === tab.key
+								? "bg-card text-foreground shadow-sm"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+					>
+						<tab.icon size={16} />
+						{tab.label}
+					</button>
+				))}
+			</div>
+
+			{/* Feed */}
+			<RecognitionFeed
+				filter={activeTab}
+				showTitle={false}
+				emptyTitle={currentTab.emptyTitle}
+				emptyDescription={currentTab.emptyDescription}
+			/>
 		</div>
 	);
 }

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -15,12 +15,26 @@ export async function GET(request: NextRequest) {
 
 	try {
 		const filter = request.nextUrl.searchParams.get("filter");
-		const where =
-			filter === "received"
-				? { recipientId: session.user.id }
-				: filter === "sent"
-					? { senderId: session.user.id }
-					: undefined;
+
+		let where: object | undefined;
+		if (filter === "received") {
+			where = { recipientId: session.user.id };
+		} else if (filter === "sent") {
+			where = { senderId: session.user.id };
+		} else if (filter === "department") {
+			const user = await prisma.user.findUnique({
+				where: { id: session.user.id },
+				select: { departmentId: true },
+			});
+			if (user?.departmentId) {
+				where = {
+					OR: [
+						{ sender: { departmentId: user.departmentId } },
+						{ recipient: { departmentId: user.departmentId } },
+					],
+				};
+			}
+		}
 
 		const cards = await prisma.recognitionCard.findMany({
 			where,

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -45,6 +45,7 @@ export async function GET(request: NextRequest) {
 				},
 			},
 			orderBy: { createdAt: "desc" },
+			take: 50,
 		});
 
 		return Response.json({ success: true, data: cards });

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -1,5 +1,6 @@
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
+import type { Prisma } from "@/app/generated/prisma/client";
 import type { NextRequest } from "next/server";
 
 export async function GET(request: NextRequest) {
@@ -16,23 +17,25 @@ export async function GET(request: NextRequest) {
 	try {
 		const filter = request.nextUrl.searchParams.get("filter");
 
-		let where: object | undefined;
+		let where: Prisma.RecognitionCardWhereInput | undefined;
 		if (filter === "received") {
 			where = { recipientId: session.user.id };
 		} else if (filter === "sent") {
 			where = { senderId: session.user.id };
 		} else if (filter === "department") {
-			const user = await prisma.user.findUnique({
-				where: { id: session.user.id },
-				select: { departmentId: true },
-			});
-			if (user?.departmentId) {
+			const departmentId = session.user.departmentId as
+				| string
+				| null
+				| undefined;
+			if (departmentId) {
 				where = {
 					OR: [
-						{ sender: { departmentId: user.departmentId } },
-						{ recipient: { departmentId: user.departmentId } },
+						{ sender: { departmentId } },
+						{ recipient: { departmentId } },
 					],
 				};
+			} else {
+				where = { id: "none" };
 			}
 		}
 

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -1,9 +1,11 @@
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
+import type { NextRequest } from "next/server";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+	let session: Awaited<ReturnType<typeof requireSession>>;
 	try {
-		await requireSession();
+		session = await requireSession();
 	} catch {
 		return Response.json(
 			{ success: false, error: "Unauthorized" },
@@ -12,7 +14,16 @@ export async function GET() {
 	}
 
 	try {
+		const filter = request.nextUrl.searchParams.get("filter");
+		const where =
+			filter === "received"
+				? { recipientId: session.user.id }
+				: filter === "sent"
+					? { senderId: session.user.id }
+					: undefined;
+
 		const cards = await prisma.recognitionCard.findMany({
+			where,
 			include: {
 				sender: {
 					select: {

--- a/app/api/recognition/stats/route.ts
+++ b/app/api/recognition/stats/route.ts
@@ -1,0 +1,65 @@
+import { requireSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+
+export async function GET() {
+	let session: Awaited<ReturnType<typeof requireSession>>;
+	try {
+		session = await requireSession();
+	} catch {
+		return Response.json(
+			{ success: false, error: "Unauthorized" },
+			{ status: 401 },
+		);
+	}
+
+	try {
+		const userId = session.user.id;
+		const now = new Date();
+		const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+		const [sent, received, monthlyTotal, topRecipientsRaw] =
+			await Promise.all([
+				prisma.recognitionCard.count({
+					where: { senderId: userId },
+				}),
+				prisma.recognitionCard.count({
+					where: { recipientId: userId },
+				}),
+				prisma.recognitionCard.count({
+					where: { createdAt: { gte: startOfMonth } },
+				}),
+				prisma.recognitionCard.groupBy({
+					by: ["recipientId"],
+					_count: { recipientId: true },
+					orderBy: { _count: { recipientId: "desc" } },
+					take: 3,
+				}),
+			]);
+
+		const recipientIds = topRecipientsRaw.map((r) => r.recipientId);
+		const recipients = await prisma.user.findMany({
+			where: { id: { in: recipientIds } },
+			select: { id: true, firstName: true, lastName: true, avatar: true },
+		});
+
+		const topRecipients = topRecipientsRaw.map((r) => {
+			const user = recipients.find((u) => u.id === r.recipientId);
+			return {
+				firstName: user?.firstName ?? "",
+				lastName: user?.lastName ?? "",
+				avatar: user?.avatar ?? null,
+				count: r._count.recipientId,
+			};
+		});
+
+		return Response.json({
+			success: true,
+			data: { sent, received, monthlyTotal, topRecipients },
+		});
+	} catch {
+		return Response.json(
+			{ success: false, error: "Internal server error" },
+			{ status: 500 },
+		);
+	}
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getInitials(firstName: string, lastName: string) {
+  return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+}


### PR DESCRIPTION
## Summary
- Redesign `/dashboard` with 2-column widget layout: top row (welcome + send button), bottom row (stats card + scrollable public recognition feed)
- Add stats widget showing cards sent/received, monthly total, and top 3 most recognized people
- Add `/api/recognition/stats` endpoint with Prisma `groupBy` for leaderboard
- Restructure `/dashboard/recognition` as a personal inbox with Received/Sent tabs
- Add `?filter=received|sent` query param support to `/api/recognition`
- Refactor `RecognitionFeed` to accept `filter`, `showTitle`, `emptyTitle`, `emptyDescription` props
- "Send Recognition Card" button appears on both dashboard and recognition pages

## Test plan
- [ ] `/dashboard` — 2-column layout with welcome + send button on top, stats card left, public feed right
- [ ] Stats card shows correct sent/received counts, monthly total, and top 3 leaderboard
- [ ] Public feed shows all recognition cards in a scrollable container
- [ ] `/dashboard/recognition` — defaults to "Received" tab showing only cards sent to current user
- [ ] Switch to "Sent" tab — shows only cards sent by current user
- [ ] Empty states render correctly per tab
- [ ] "Send Recognition Card" button works on both pages
- [ ] Mobile responsive — columns stack vertically
- [ ] Verify dark mode rendering