### PR TITLE
feat(recognition): add filter bar and CSV export to admin All table

### DIFF
--- a/app/(dashboard)/dashboard/profile/_components/profile-form.tsx
+++ b/app/(dashboard)/dashboard/profile/_components/profile-form.tsx
@@ -28,18 +28,20 @@ export function ProfileForm({ user }: ProfileFormProps) {
 	const router = useRouter();
 	const [isLoading, setIsLoading] = useState(false);
 
+	const defaultValues = {
+		firstName: user.firstName,
+		lastName: user.lastName,
+		displayName: user.displayName ?? "",
+		phone: user.phone ?? "",
+		position: user.position ?? "",
+		branch: user.branch ?? null,
+	};
+
 	const { register, handleSubmit, watch, setValue } = useForm({
-		defaultValues: {
-			firstName: user.firstName,
-			lastName: user.lastName,
-			displayName: user.displayName ?? "",
-			phone: user.phone ?? "",
-			position: user.position ?? "",
-			branch: user.branch ?? null,
-		},
+		defaultValues,
 	});
 
-	async function onSubmit(data: Record<string, string | null>) {
+	async function onSubmit(data: typeof defaultValues) {
 		setIsLoading(true);
 		try {
 			const result = await updateProfileAction(data);

--- a/app/(dashboard)/dashboard/profile/_components/profile-form.tsx
+++ b/app/(dashboard)/dashboard/profile/_components/profile-form.tsx
@@ -10,6 +10,9 @@ import { updateProfileAction } from "@/lib/actions/profile-actions";
 const inputClass =
 	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
 
+const selectClass =
+	"block w-full appearance-none rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
+
 interface ProfileFormProps {
 	user: {
 		firstName: string;
@@ -17,6 +20,7 @@ interface ProfileFormProps {
 		displayName: string | null;
 		phone: string | null;
 		position: string | null;
+		branch: string | null;
 	};
 }
 
@@ -24,17 +28,18 @@ export function ProfileForm({ user }: ProfileFormProps) {
 	const router = useRouter();
 	const [isLoading, setIsLoading] = useState(false);
 
-	const { register, handleSubmit } = useForm({
+	const { register, handleSubmit, watch, setValue } = useForm({
 		defaultValues: {
 			firstName: user.firstName,
 			lastName: user.lastName,
 			displayName: user.displayName ?? "",
 			phone: user.phone ?? "",
 			position: user.position ?? "",
+			branch: user.branch ?? null,
 		},
 	});
 
-	async function onSubmit(data: Record<string, string>) {
+	async function onSubmit(data: Record<string, string | null>) {
 		setIsLoading(true);
 		try {
 			const result = await updateProfileAction(data);
@@ -98,6 +103,21 @@ export function ProfileForm({ user }: ProfileFormProps) {
 							</label>
 							<input id="position" className={inputClass} {...register("position")} />
 						</div>
+					</div>
+
+					<div>
+						<label className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5">
+							Branch
+						</label>
+						<select
+							value={watch("branch") ?? "none"}
+							onChange={(e) => setValue("branch", e.target.value === "none" ? null : e.target.value)}
+							className={selectClass}
+						>
+							<option value="none">No Branch</option>
+							<option value="ISO">ISO</option>
+							<option value="PERTH">Perth</option>
+						</select>
 					</div>
 				</div>
 

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-filter-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-filter-bar.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { COMPANY_VALUES } from "@/lib/recognition";
+import { cn } from "@/lib/utils";
+
+interface RecognitionFilterBarProps {
+	search: string;
+	onSearchChange: (value: string) => void;
+	selectedValues: string[];
+	onSelectedValuesChange: (values: string[]) => void;
+	dateFrom: string;
+	onDateFromChange: (value: string) => void;
+	dateTo: string;
+	onDateToChange: (value: string) => void;
+	onClear: () => void;
+}
+
+export function RecognitionFilterBar({
+	search,
+	onSearchChange,
+	selectedValues,
+	onSelectedValuesChange,
+	dateFrom,
+	onDateFromChange,
+	dateTo,
+	onDateToChange,
+	onClear,
+}: RecognitionFilterBarProps) {
+	const hasActiveFilters =
+		search.length > 0 ||
+		selectedValues.length > 0 ||
+		dateFrom.length > 0 ||
+		dateTo.length > 0;
+
+	function toggleValue(key: string) {
+		if (selectedValues.includes(key)) {
+			onSelectedValuesChange(selectedValues.filter((v) => v !== key));
+		} else {
+			onSelectedValuesChange([...selectedValues, key]);
+		}
+	}
+
+	return (
+		<div className="rounded-xl border border-gray-200/60 dark:border-white/10 bg-card p-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+			<div className="flex flex-col gap-4 lg:flex-row lg:items-center">
+				{/* Search */}
+				<div className="relative min-w-0 lg:w-64">
+					<Search
+						size={16}
+						className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+					/>
+					<input
+						type="text"
+						placeholder="Search by name..."
+						value={search}
+						onChange={(e) => onSearchChange(e.target.value)}
+						className="h-9 w-full rounded-full border border-input bg-transparent pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
+					/>
+				</div>
+
+				{/* Value toggles */}
+				<div className="flex flex-wrap items-center gap-1.5">
+					{COMPANY_VALUES.map((value) => {
+						const shortKey = value.key.replace("values", "");
+						const urlKey =
+							shortKey.charAt(0).toLowerCase() + shortKey.slice(1);
+						const isActive = selectedValues.includes(urlKey);
+
+						return (
+							<button
+								key={value.key}
+								type="button"
+								onClick={() => toggleValue(urlKey)}
+								className={cn(
+									"inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
+									isActive
+										? "border-primary/20 bg-primary/5 text-primary dark:bg-primary/10"
+										: "border-gray-200 dark:border-white/10 bg-transparent text-muted-foreground hover:border-gray-300 dark:hover:border-white/20",
+								)}
+							>
+								{value.label}
+							</button>
+						);
+					})}
+				</div>
+
+				{/* Date range */}
+				<div className="flex items-center gap-2 lg:ml-auto">
+					<label className="text-xs text-muted-foreground shrink-0">
+						From
+					</label>
+					<input
+						type="date"
+						value={dateFrom}
+						onChange={(e) => onDateFromChange(e.target.value)}
+						className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
+					/>
+					<label className="text-xs text-muted-foreground shrink-0">
+						To
+					</label>
+					<input
+						type="date"
+						value={dateTo}
+						onChange={(e) => onDateToChange(e.target.value)}
+						className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
+					/>
+				</div>
+
+				{/* Clear */}
+				{hasActiveFilters && (
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={onClear}
+						className="shrink-0 gap-1 text-muted-foreground"
+					>
+						<X size={14} />
+						Clear
+					</Button>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-filter-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-filter-bar.tsx
@@ -5,15 +5,39 @@ import { Button } from "@/components/ui/button";
 import { COMPANY_VALUES } from "@/lib/recognition";
 import { cn } from "@/lib/utils";
 
+const MONTHS = [
+	{ value: "1", label: "January" },
+	{ value: "2", label: "February" },
+	{ value: "3", label: "March" },
+	{ value: "4", label: "April" },
+	{ value: "5", label: "May" },
+	{ value: "6", label: "June" },
+	{ value: "7", label: "July" },
+	{ value: "8", label: "August" },
+	{ value: "9", label: "September" },
+	{ value: "10", label: "October" },
+	{ value: "11", label: "November" },
+	{ value: "12", label: "December" },
+];
+
+function getYearOptions() {
+	const currentYear = new Date().getFullYear();
+	const years: string[] = [];
+	for (let y = currentYear; y >= currentYear - 5; y--) {
+		years.push(String(y));
+	}
+	return years;
+}
+
 interface RecognitionFilterBarProps {
 	search: string;
 	onSearchChange: (value: string) => void;
 	selectedValues: string[];
 	onSelectedValuesChange: (values: string[]) => void;
-	dateFrom: string;
-	onDateFromChange: (value: string) => void;
-	dateTo: string;
-	onDateToChange: (value: string) => void;
+	selectedMonth: string;
+	onMonthChange: (value: string) => void;
+	selectedYear: string;
+	onYearChange: (value: string) => void;
 	onClear: () => void;
 }
 
@@ -22,17 +46,17 @@ export function RecognitionFilterBar({
 	onSearchChange,
 	selectedValues,
 	onSelectedValuesChange,
-	dateFrom,
-	onDateFromChange,
-	dateTo,
-	onDateToChange,
+	selectedMonth,
+	onMonthChange,
+	selectedYear,
+	onYearChange,
 	onClear,
 }: RecognitionFilterBarProps) {
 	const hasActiveFilters =
 		search.length > 0 ||
 		selectedValues.length > 0 ||
-		dateFrom.length > 0 ||
-		dateTo.length > 0;
+		selectedMonth.length > 0 ||
+		selectedYear.length > 0;
 
 	function toggleValue(key: string) {
 		if (selectedValues.includes(key)) {
@@ -86,26 +110,38 @@ export function RecognitionFilterBar({
 					})}
 				</div>
 
-				{/* Date range */}
+				{/* Month / Year */}
 				<div className="flex items-center gap-2 lg:ml-auto">
-					<label className="text-xs text-muted-foreground shrink-0">
-						From
-					</label>
-					<input
-						type="date"
-						value={dateFrom}
-						onChange={(e) => onDateFromChange(e.target.value)}
-						className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
-					/>
-					<label className="text-xs text-muted-foreground shrink-0">
-						To
-					</label>
-					<input
-						type="date"
-						value={dateTo}
-						onChange={(e) => onDateToChange(e.target.value)}
-						className="h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
-					/>
+					<select
+						value={selectedMonth}
+						onChange={(e) => onMonthChange(e.target.value)}
+						className={cn(
+							"h-9 rounded-lg border border-input bg-transparent px-2.5 pr-8 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30",
+							!selectedMonth && "text-muted-foreground",
+						)}
+					>
+						<option value="">Month</option>
+						{MONTHS.map((m) => (
+							<option key={m.value} value={m.value}>
+								{m.label}
+							</option>
+						))}
+					</select>
+					<select
+						value={selectedYear}
+						onChange={(e) => onYearChange(e.target.value)}
+						className={cn(
+							"h-9 rounded-lg border border-input bg-transparent px-2.5 pr-8 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30",
+							!selectedYear && "text-muted-foreground",
+						)}
+					>
+						<option value="">Year</option>
+						{getYearOptions().map((y) => (
+							<option key={y} value={y}>
+								{y}
+							</option>
+						))}
+					</select>
 				</div>
 
 				{/* Clear */}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-filter-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-filter-bar.tsx
@@ -2,7 +2,7 @@
 
 import { Download, Loader2, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { COMPANY_VALUES } from "@/lib/recognition";
+import { COMPANY_VALUES, VALUE_KEY_MAP } from "@/lib/recognition";
 import { cn } from "@/lib/utils";
 
 const MONTHS = [
@@ -38,6 +38,7 @@ interface RecognitionFilterBarProps {
 	onMonthChange: (value: string) => void;
 	selectedYear: string;
 	onYearChange: (value: string) => void;
+	hasActiveFilters: boolean;
 	onClear: () => void;
 	onExport: () => void;
 	isExporting: boolean;
@@ -52,15 +53,11 @@ export function RecognitionFilterBar({
 	onMonthChange,
 	selectedYear,
 	onYearChange,
+	hasActiveFilters,
 	onClear,
 	onExport,
 	isExporting,
 }: RecognitionFilterBarProps) {
-	const hasActiveFilters =
-		search.length > 0 ||
-		selectedValues.length > 0 ||
-		selectedMonth.length > 0 ||
-		selectedYear.length > 0;
 
 	function toggleValue(key: string) {
 		if (selectedValues.includes(key)) {
@@ -91,9 +88,9 @@ export function RecognitionFilterBar({
 				{/* Value toggles */}
 				<div className="flex flex-wrap items-center gap-1.5">
 					{COMPANY_VALUES.map((value) => {
-						const shortKey = value.key.replace("values", "");
-						const urlKey =
-							shortKey.charAt(0).toLowerCase() + shortKey.slice(1);
+						const urlKey = Object.entries(VALUE_KEY_MAP).find(
+							([, v]) => v === value.key,
+						)?.[0] ?? value.key;
 						const isActive = selectedValues.includes(urlKey);
 
 						return (

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-filter-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-filter-bar.tsx
@@ -145,17 +145,18 @@ export function RecognitionFilterBar({
 				</div>
 
 				{/* Clear */}
-				{hasActiveFilters && (
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={onClear}
-						className="shrink-0 gap-1 text-muted-foreground"
-					>
-						<X size={14} />
-						Clear
-					</Button>
-				)}
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={onClear}
+					className={cn(
+						"shrink-0 gap-1 text-muted-foreground",
+						!hasActiveFilters && "invisible",
+					)}
+				>
+					<X size={14} />
+					Clear
+				</Button>
 			</div>
 		</div>
 	);

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-filter-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-filter-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Search, X } from "lucide-react";
+import { Download, Loader2, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { COMPANY_VALUES } from "@/lib/recognition";
 import { cn } from "@/lib/utils";
@@ -39,6 +39,8 @@ interface RecognitionFilterBarProps {
 	selectedYear: string;
 	onYearChange: (value: string) => void;
 	onClear: () => void;
+	onExport: () => void;
+	isExporting: boolean;
 }
 
 export function RecognitionFilterBar({
@@ -51,6 +53,8 @@ export function RecognitionFilterBar({
 	selectedYear,
 	onYearChange,
 	onClear,
+	onExport,
+	isExporting,
 }: RecognitionFilterBarProps) {
 	const hasActiveFilters =
 		search.length > 0 ||
@@ -144,19 +148,35 @@ export function RecognitionFilterBar({
 					</select>
 				</div>
 
-				{/* Clear */}
-				<Button
-					variant="ghost"
-					size="sm"
-					onClick={onClear}
-					className={cn(
-						"shrink-0 gap-1 text-muted-foreground",
-						!hasActiveFilters && "invisible",
-					)}
-				>
-					<X size={14} />
-					Clear
-				</Button>
+				{/* Actions */}
+				<div className="flex items-center gap-1 shrink-0">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={onClear}
+						className={cn(
+							"gap-1 text-muted-foreground",
+							!hasActiveFilters && "invisible",
+						)}
+					>
+						<X size={14} />
+						Clear
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={onExport}
+						disabled={isExporting}
+						className="gap-1"
+					>
+						{isExporting ? (
+							<Loader2 size={14} className="animate-spin" />
+						) : (
+							<Download size={14} />
+						)}
+						{isExporting ? "Exporting..." : "Export"}
+					</Button>
+				</div>
 			</div>
 		</div>
 	);

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
@@ -9,8 +9,10 @@ import { useSession } from "@/lib/auth-client";
 import { getUserRole, hasMinRole } from "@/lib/permissions";
 import {
 	type RecognitionCard,
+	type ExportRecognitionCard,
 	getSelectedValues,
 	formatRecognitionDate,
+	generateRecognitionCsv,
 } from "@/lib/recognition";
 import { deleteRecognitionCardAction } from "@/lib/actions/recognition-actions";
 import {
@@ -85,6 +87,7 @@ export function RecognitionTable() {
 	const [selectedValues, setSelectedValues] = useState<string[]>([]);
 	const [selectedMonth, setSelectedMonth] = useState("");
 	const [selectedYear, setSelectedYear] = useState("");
+	const [isExporting, setIsExporting] = useState(false);
 	const [shareCardId, setShareCardId] = useState<string | null>(null);
 	const [deleteCardId, setDeleteCardId] = useState<string | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);
@@ -138,6 +141,38 @@ export function RecognitionTable() {
 		}
 
 		return { dateFrom: "", dateTo: "" };
+	}
+
+	async function exportCards() {
+		setIsExporting(true);
+		try {
+			const params = new URLSearchParams({ export: "true" });
+			if (debouncedSearch) params.set("search", debouncedSearch);
+			if (selectedValues.length > 0) params.set("values", selectedValues.join(","));
+			const { dateFrom, dateTo } = getDateRange();
+			if (dateFrom) params.set("dateFrom", dateFrom);
+			if (dateTo) params.set("dateTo", dateTo);
+
+			const res = await fetch(`/api/recognition?${params}`);
+			if (!res.ok) throw new Error("Failed to fetch recognition cards");
+
+			const json = await res.json() as { success: boolean; data: ExportRecognitionCard[] };
+			if (!json.success) throw new Error("Export failed");
+
+			const csv = generateRecognitionCsv(json.data);
+			const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = `recognition-export-${new Date().toISOString().split("T")[0]}.csv`;
+			link.click();
+			URL.revokeObjectURL(url);
+			toast.success(`Exported ${json.data.length} recognition cards`);
+		} catch {
+			toast.error("Failed to export recognition cards");
+		} finally {
+			setIsExporting(false);
+		}
 	}
 
 	const { data, isPending, isError } = useQuery<PaginatedResponse>({
@@ -228,6 +263,8 @@ export function RecognitionTable() {
 				selectedYear={selectedYear}
 				onYearChange={setSelectedYear}
 				onClear={clearFilters}
+				onExport={exportCards}
+				isExporting={isExporting}
 			/>
 
 			{cards.length === 0 && hasActiveFilters ? (

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
@@ -252,6 +252,7 @@ export function RecognitionTable() {
 				onMonthChange={setSelectedMonth}
 				selectedYear={selectedYear}
 				onYearChange={setSelectedYear}
+				hasActiveFilters={hasActiveFilters}
 				onClear={clearFilters}
 				onExport={exportCards}
 				isExporting={isExporting}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
@@ -116,11 +116,8 @@ export function RecognitionTable() {
 	}
 
 	function getDateRange() {
-		const year = selectedYear
-			? Number(selectedYear)
-			: new Date().getFullYear();
-
 		if (selectedMonth && selectedYear) {
+			const year = Number(selectedYear);
 			const month = Number(selectedMonth);
 			const from = `${year}-${String(month).padStart(2, "0")}-01`;
 			const lastDay = new Date(year, month, 0).getDate();
@@ -129,15 +126,8 @@ export function RecognitionTable() {
 		}
 
 		if (selectedYear) {
+			const year = Number(selectedYear);
 			return { dateFrom: `${year}-01-01`, dateTo: `${year}-12-31` };
-		}
-
-		if (selectedMonth) {
-			const month = Number(selectedMonth);
-			const from = `${year}-${String(month).padStart(2, "0")}-01`;
-			const lastDay = new Date(year, month, 0).getDate();
-			const to = `${year}-${String(month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
-			return { dateFrom: from, dateTo: to };
 		}
 
 		return { dateFrom: "", dateTo: "" };
@@ -147,7 +137,7 @@ export function RecognitionTable() {
 		setIsExporting(true);
 		try {
 			const params = new URLSearchParams({ export: "true" });
-			if (debouncedSearch) params.set("search", debouncedSearch);
+			if (search) params.set("search", search);
 			if (selectedValues.length > 0) params.set("values", selectedValues.join(","));
 			const { dateFrom, dateTo } = getDateRange();
 			if (dateFrom) params.set("dateFrom", dateFrom);

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
@@ -83,8 +83,8 @@ export function RecognitionTable() {
 	const [search, setSearch] = useState("");
 	const [debouncedSearch, setDebouncedSearch] = useState("");
 	const [selectedValues, setSelectedValues] = useState<string[]>([]);
-	const [dateFrom, setDateFrom] = useState("");
-	const [dateTo, setDateTo] = useState("");
+	const [selectedMonth, setSelectedMonth] = useState("");
+	const [selectedYear, setSelectedYear] = useState("");
 	const [shareCardId, setShareCardId] = useState<string | null>(null);
 	const [deleteCardId, setDeleteCardId] = useState<string | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);
@@ -96,24 +96,52 @@ export function RecognitionTable() {
 
 	useEffect(() => {
 		setPage(1);
-	}, [debouncedSearch, selectedValues, dateFrom, dateTo]);
+	}, [debouncedSearch, selectedValues, selectedMonth, selectedYear]);
 
 	const hasActiveFilters =
 		search.length > 0 ||
 		selectedValues.length > 0 ||
-		dateFrom.length > 0 ||
-		dateTo.length > 0;
+		selectedMonth.length > 0 ||
+		selectedYear.length > 0;
 
 	function clearFilters() {
 		setSearch("");
 		setDebouncedSearch("");
 		setSelectedValues([]);
-		setDateFrom("");
-		setDateTo("");
+		setSelectedMonth("");
+		setSelectedYear("");
+	}
+
+	function getDateRange() {
+		const year = selectedYear
+			? Number(selectedYear)
+			: new Date().getFullYear();
+
+		if (selectedMonth && selectedYear) {
+			const month = Number(selectedMonth);
+			const from = `${year}-${String(month).padStart(2, "0")}-01`;
+			const lastDay = new Date(year, month, 0).getDate();
+			const to = `${year}-${String(month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+			return { dateFrom: from, dateTo: to };
+		}
+
+		if (selectedYear) {
+			return { dateFrom: `${year}-01-01`, dateTo: `${year}-12-31` };
+		}
+
+		if (selectedMonth) {
+			const month = Number(selectedMonth);
+			const from = `${year}-${String(month).padStart(2, "0")}-01`;
+			const lastDay = new Date(year, month, 0).getDate();
+			const to = `${year}-${String(month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+			return { dateFrom: from, dateTo: to };
+		}
+
+		return { dateFrom: "", dateTo: "" };
 	}
 
 	const { data, isPending, isError } = useQuery<PaginatedResponse>({
-		queryKey: ["recognition-cards", "all", page, debouncedSearch, selectedValues, dateFrom, dateTo],
+		queryKey: ["recognition-cards", "all", page, debouncedSearch, selectedValues, selectedMonth, selectedYear],
 		queryFn: async () => {
 			const params = new URLSearchParams({
 				paginated: "true",
@@ -122,6 +150,7 @@ export function RecognitionTable() {
 			});
 			if (debouncedSearch) params.set("search", debouncedSearch);
 			if (selectedValues.length > 0) params.set("values", selectedValues.join(","));
+			const { dateFrom, dateTo } = getDateRange();
 			if (dateFrom) params.set("dateFrom", dateFrom);
 			if (dateTo) params.set("dateTo", dateTo);
 
@@ -194,10 +223,10 @@ export function RecognitionTable() {
 				onSearchChange={setSearch}
 				selectedValues={selectedValues}
 				onSelectedValuesChange={setSelectedValues}
-				dateFrom={dateFrom}
-				onDateFromChange={setDateFrom}
-				dateTo={dateTo}
-				onDateToChange={setDateTo}
+				selectedMonth={selectedMonth}
+				onMonthChange={setSelectedMonth}
+				selectedYear={selectedYear}
+				onYearChange={setSelectedYear}
 				onClear={clearFilters}
 			/>
 

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { Eye, Share2, Heart, Trash2, Pencil, ChevronLeft, ChevronRight } from "lucide-react";
+import { Eye, Share2, Heart, Trash2, Pencil, ChevronLeft, ChevronRight, Search } from "lucide-react";
 import { toast } from "sonner";
 import { useSession } from "@/lib/auth-client";
 import { getUserRole, hasMinRole } from "@/lib/permissions";
@@ -31,6 +31,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { RecognitionFilterBar } from "./recognition-filter-bar";
 import { ShareDialog } from "./share-dialog";
 
 function getInitials(firstName: string, lastName: string) {
@@ -79,16 +80,52 @@ export function RecognitionTable() {
 	const userRole = getUserRole(session);
 	const canDelete = hasMinRole(userRole, "ADMIN");
 	const [page, setPage] = useState(1);
+	const [search, setSearch] = useState("");
+	const [debouncedSearch, setDebouncedSearch] = useState("");
+	const [selectedValues, setSelectedValues] = useState<string[]>([]);
+	const [dateFrom, setDateFrom] = useState("");
+	const [dateTo, setDateTo] = useState("");
 	const [shareCardId, setShareCardId] = useState<string | null>(null);
 	const [deleteCardId, setDeleteCardId] = useState<string | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);
 
+	useEffect(() => {
+		const timer = setTimeout(() => setDebouncedSearch(search), 300);
+		return () => clearTimeout(timer);
+	}, [search]);
+
+	useEffect(() => {
+		setPage(1);
+	}, [debouncedSearch, selectedValues, dateFrom, dateTo]);
+
+	const hasActiveFilters =
+		search.length > 0 ||
+		selectedValues.length > 0 ||
+		dateFrom.length > 0 ||
+		dateTo.length > 0;
+
+	function clearFilters() {
+		setSearch("");
+		setDebouncedSearch("");
+		setSelectedValues([]);
+		setDateFrom("");
+		setDateTo("");
+	}
+
 	const { data, isPending, isError } = useQuery<PaginatedResponse>({
-		queryKey: ["recognition-cards", "all", page],
+		queryKey: ["recognition-cards", "all", page, debouncedSearch, selectedValues, dateFrom, dateTo],
 		queryFn: async () => {
-			const res = await fetch(
-				`/api/recognition?paginated=true&page=${page}&pageSize=${PAGE_SIZE}`,
-			);
+			const params = new URLSearchParams({
+				paginated: "true",
+				page: String(page),
+				pageSize: String(PAGE_SIZE),
+			});
+			if (debouncedSearch) params.set("search", debouncedSearch);
+			if (selectedValues.length > 0) params.set("values", selectedValues.join(","));
+			if (dateFrom) params.set("dateFrom", dateFrom);
+			if (dateTo) params.set("dateTo", dateTo);
+
+			const res = await fetch(`/api/recognition?${params}`);
 			if (!res.ok) throw new Error("Failed to fetch recognition cards");
 			return res.json();
 		},
@@ -134,7 +171,7 @@ export function RecognitionTable() {
 		);
 	}
 
-	if (cards.length === 0 && page === 1) {
+	if (cards.length === 0 && page === 1 && !hasActiveFilters) {
 		return (
 			<div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 dark:border-white/10 bg-card p-16">
 				<div className="mb-6 rounded-full bg-background p-6">
@@ -152,154 +189,189 @@ export function RecognitionTable() {
 
 	return (
 		<>
-			<div className="rounded-xl border border-gray-200/60 dark:border-white/10 bg-card overflow-hidden shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
-				<Table>
-					<TableHeader>
-						<TableRow className="bg-muted/30 hover:bg-muted/30">
-							<TableHead>From</TableHead>
-							<TableHead>To</TableHead>
-							<TableHead>Message</TableHead>
-							<TableHead>Values</TableHead>
-							<TableHead>Date</TableHead>
-							<TableHead className="text-right">Actions</TableHead>
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{cards.map((card) => {
-							const values = getSelectedValues(card);
-							return (
-								<TableRow key={card.id}>
-									<TableCell>
-										<div className="flex items-center gap-2">
-											<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold">
-												{getInitials(card.sender.firstName, card.sender.lastName)}
-											</div>
-											<div className="min-w-0">
-												<p className="text-sm font-medium text-foreground truncate">
-													{card.sender.firstName} {card.sender.lastName}
-												</p>
-												{card.sender.position && (
-													<p className="text-xs text-muted-foreground truncate">
-														{card.sender.position}
-													</p>
-												)}
-											</div>
-										</div>
-									</TableCell>
-									<TableCell>
-										<div className="flex items-center gap-2">
-											<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold">
-												{getInitials(card.recipient.firstName, card.recipient.lastName)}
-											</div>
-											<div className="min-w-0">
-												<p className="text-sm font-medium text-foreground truncate">
-													{card.recipient.firstName} {card.recipient.lastName}
-												</p>
-												{card.recipient.position && (
-													<p className="text-xs text-muted-foreground truncate">
-														{card.recipient.position}
-													</p>
-												)}
-											</div>
-										</div>
-									</TableCell>
-									<TableCell className="max-w-xs">
-										<p className="text-sm text-foreground/80 truncate">
-											{card.message}
-										</p>
-									</TableCell>
-									<TableCell>
-										<div className="flex flex-wrap gap-1">
-											{values.map((value) => (
-												<span
-													key={value}
-													className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs font-medium text-primary dark:bg-primary/10"
-												>
-													{value}
-												</span>
-											))}
-										</div>
-									</TableCell>
-									<TableCell>
-										<span className="text-sm text-muted-foreground">
-											{formatRecognitionDate(card.date)}
-										</span>
-									</TableCell>
-									<TableCell className="text-right">
-										<div className="flex justify-end gap-1">
-											<button
-												type="button"
-												onClick={() => router.push(`/dashboard/recognition/${card.id}`)}
-												className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
-												aria-label="View card"
-											>
-												<Eye size={16} />
-											</button>
-											<button
-												type="button"
-												onClick={() => setShareCardId(card.id)}
-												className="rounded-full p-2 text-muted-foreground hover:bg-primary/10 hover:text-primary transition-colors"
-												aria-label="Share card"
-											>
-												<Share2 size={16} />
-											</button>
-											<button
-												type="button"
-												disabled={session?.user?.id !== card.sender.id}
-												onClick={() => router.push(`/dashboard/recognition/${card.id}/edit`)}
-												className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors disabled:opacity-30 disabled:pointer-events-none"
-												aria-label="Edit card"
-											>
-												<Pencil size={16} />
-											</button>
-											{canDelete && (
-												<button
-													type="button"
-													onClick={() => setDeleteCardId(card.id)}
-													className="rounded-full p-2 text-muted-foreground hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-500/10 transition-colors"
-													aria-label="Delete card"
-												>
-													<Trash2 size={16} />
-												</button>
-											)}
-										</div>
-									</TableCell>
-								</TableRow>
-							);
-						})}
-					</TableBody>
-				</Table>
-			</div>
+			<RecognitionFilterBar
+				search={search}
+				onSearchChange={setSearch}
+				selectedValues={selectedValues}
+				onSelectedValuesChange={setSelectedValues}
+				dateFrom={dateFrom}
+				onDateFromChange={setDateFrom}
+				dateTo={dateTo}
+				onDateToChange={setDateTo}
+				onClear={clearFilters}
+			/>
 
-			{pagination && pagination.totalPages > 1 && (
-				<div className="flex items-center justify-between pt-2">
-					<p className="text-sm text-muted-foreground">
-						Showing {(pagination.page - 1) * pagination.pageSize + 1}–{Math.min(pagination.page * pagination.pageSize, pagination.total)} of {pagination.total} cards
-					</p>
-					<div className="flex items-center gap-2">
-						<button
-							type="button"
-							disabled={page === 1}
-							onClick={() => setPage((p) => p - 1)}
-							className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-gray-100 dark:hover:bg-white/5 transition-colors disabled:opacity-30 disabled:pointer-events-none"
-						>
-							<ChevronLeft size={16} />
-							Previous
-						</button>
-						<span className="text-sm font-medium text-foreground">
-							{pagination.page} / {pagination.totalPages}
-						</span>
-						<button
-							type="button"
-							disabled={page >= pagination.totalPages}
-							onClick={() => setPage((p) => p + 1)}
-							className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-gray-100 dark:hover:bg-white/5 transition-colors disabled:opacity-30 disabled:pointer-events-none"
-						>
-							Next
-							<ChevronRight size={16} />
-						</button>
+			{cards.length === 0 && hasActiveFilters ? (
+				<div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 dark:border-white/10 bg-card p-16">
+					<div className="mb-6 rounded-full bg-background p-6">
+						<Search size={48} className="text-muted-foreground opacity-40" />
 					</div>
+					<p className="text-[1.5rem] font-medium text-foreground">
+						No matching cards
+					</p>
+					<p className="mt-2 text-base text-muted-foreground">
+						No recognition cards match your current filters.
+					</p>
+					<button
+						type="button"
+						onClick={clearFilters}
+						className="mt-4 text-sm font-medium text-primary hover:text-primary/80 transition-colors"
+					>
+						Clear all filters
+					</button>
 				</div>
+			) : (
+				<>
+					<div className="rounded-xl border border-gray-200/60 dark:border-white/10 bg-card overflow-hidden shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+						<Table>
+							<TableHeader>
+								<TableRow className="bg-muted/30 hover:bg-muted/30">
+									<TableHead>From</TableHead>
+									<TableHead>To</TableHead>
+									<TableHead>Message</TableHead>
+									<TableHead>Values</TableHead>
+									<TableHead>Date</TableHead>
+									<TableHead className="text-right">Actions</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{cards.map((card) => {
+									const values = getSelectedValues(card);
+									return (
+										<TableRow key={card.id}>
+											<TableCell>
+												<div className="flex items-center gap-2">
+													<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold">
+														{getInitials(card.sender.firstName, card.sender.lastName)}
+													</div>
+													<div className="min-w-0">
+														<p className="text-sm font-medium text-foreground truncate">
+															{card.sender.firstName} {card.sender.lastName}
+														</p>
+														{card.sender.position && (
+															<p className="text-xs text-muted-foreground truncate">
+																{card.sender.position}
+															</p>
+														)}
+													</div>
+												</div>
+											</TableCell>
+											<TableCell>
+												<div className="flex items-center gap-2">
+													<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold">
+														{getInitials(card.recipient.firstName, card.recipient.lastName)}
+													</div>
+													<div className="min-w-0">
+														<p className="text-sm font-medium text-foreground truncate">
+															{card.recipient.firstName} {card.recipient.lastName}
+														</p>
+														{card.recipient.position && (
+															<p className="text-xs text-muted-foreground truncate">
+																{card.recipient.position}
+															</p>
+														)}
+													</div>
+												</div>
+											</TableCell>
+											<TableCell className="max-w-xs">
+												<p className="text-sm text-foreground/80 truncate">
+													{card.message}
+												</p>
+											</TableCell>
+											<TableCell>
+												<div className="flex flex-wrap gap-1">
+													{values.map((value) => (
+														<span
+															key={value}
+															className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs font-medium text-primary dark:bg-primary/10"
+														>
+															{value}
+														</span>
+													))}
+												</div>
+											</TableCell>
+											<TableCell>
+												<span className="text-sm text-muted-foreground">
+													{formatRecognitionDate(card.date)}
+												</span>
+											</TableCell>
+											<TableCell className="text-right">
+												<div className="flex justify-end gap-1">
+													<button
+														type="button"
+														onClick={() => router.push(`/dashboard/recognition/${card.id}`)}
+														className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
+														aria-label="View card"
+													>
+														<Eye size={16} />
+													</button>
+													<button
+														type="button"
+														onClick={() => setShareCardId(card.id)}
+														className="rounded-full p-2 text-muted-foreground hover:bg-primary/10 hover:text-primary transition-colors"
+														aria-label="Share card"
+													>
+														<Share2 size={16} />
+													</button>
+													<button
+														type="button"
+														disabled={session?.user?.id !== card.sender.id}
+														onClick={() => router.push(`/dashboard/recognition/${card.id}/edit`)}
+														className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors disabled:opacity-30 disabled:pointer-events-none"
+														aria-label="Edit card"
+													>
+														<Pencil size={16} />
+													</button>
+													{canDelete && (
+														<button
+															type="button"
+															onClick={() => setDeleteCardId(card.id)}
+															className="rounded-full p-2 text-muted-foreground hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-500/10 transition-colors"
+															aria-label="Delete card"
+														>
+															<Trash2 size={16} />
+														</button>
+													)}
+												</div>
+											</TableCell>
+										</TableRow>
+									);
+								})}
+							</TableBody>
+						</Table>
+					</div>
+
+					{pagination && pagination.totalPages > 1 && (
+						<div className="flex items-center justify-between pt-2">
+							<p className="text-sm text-muted-foreground">
+								Showing {(pagination.page - 1) * pagination.pageSize + 1}–{Math.min(pagination.page * pagination.pageSize, pagination.total)} of {pagination.total} cards
+							</p>
+							<div className="flex items-center gap-2">
+								<button
+									type="button"
+									disabled={page === 1}
+									onClick={() => setPage((p) => p - 1)}
+									className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-gray-100 dark:hover:bg-white/5 transition-colors disabled:opacity-30 disabled:pointer-events-none"
+								>
+									<ChevronLeft size={16} />
+									Previous
+								</button>
+								<span className="text-sm font-medium text-foreground">
+									{pagination.page} / {pagination.totalPages}
+								</span>
+								<button
+									type="button"
+									disabled={page >= pagination.totalPages}
+									onClick={() => setPage((p) => p + 1)}
+									className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-gray-100 dark:hover:bg-white/5 transition-colors disabled:opacity-30 disabled:pointer-events-none"
+								>
+									Next
+									<ChevronRight size={16} />
+								</button>
+							</div>
+						</div>
+					)}
+				</>
 			)}
 
 			<AlertDialog open={!!deleteCardId} onOpenChange={(open) => !open && setDeleteCardId(null)}>

--- a/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
@@ -31,6 +31,7 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 				displayName: user.displayName ?? undefined,
 				phone: user.phone ?? undefined,
 				position: user.position ?? undefined,
+				branch: user.branch ?? null,
 				role: user.role,
 				departmentId: user.departmentId,
 				isActive: user.isActive,

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -18,6 +18,7 @@ interface User {
 	role: string;
 	isActive: boolean;
 	position: string | null;
+	branch: string | null;
 	department: { id: string; name: string; code: string } | null;
 }
 
@@ -125,6 +126,9 @@ export function UserListClient() {
 									Position / Dept
 								</th>
 								<th className="px-8 py-4 text-left text-[0.75rem] font-semibold uppercase tracking-widest text-muted-foreground">
+									Branch
+								</th>
+								<th className="px-8 py-4 text-left text-[0.75rem] font-semibold uppercase tracking-widest text-muted-foreground">
 									Status
 								</th>
 								<th className="relative px-8 py-4">
@@ -162,6 +166,11 @@ export function UserListClient() {
 											<div className="mt-0.5 text-sm text-muted-foreground">
 												{user.department?.name ?? "—"}
 											</div>
+										</td>
+										<td className="whitespace-nowrap px-8 py-5">
+											<span className="text-sm text-foreground">
+												{user.branch ?? "—"}
+											</span>
 										</td>
 										<td className="whitespace-nowrap px-8 py-5">
 											<div className="flex flex-col gap-1.5">
@@ -211,7 +220,7 @@ export function UserListClient() {
 								))
 							) : (
 								<tr>
-									<td colSpan={4} className="px-8 py-16 text-center">
+									<td colSpan={5} className="px-8 py-16 text-center">
 										<div className="flex flex-col items-center justify-center text-muted-foreground">
 											<Users size={40} className="mb-3 opacity-20" />
 											<p className="text-base font-medium text-foreground">

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -1,6 +1,7 @@
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { getUserRole, hasMinRole } from "@/lib/permissions";
+import { VALUE_KEY_MAP } from "@/lib/recognition";
 import type { Prisma } from "@/app/generated/prisma/client";
 import type { NextRequest } from "next/server";
 
@@ -71,15 +72,52 @@ export async function GET(request: NextRequest) {
 			const page = Math.max(1, Number(request.nextUrl.searchParams.get("page")) || 1);
 			const pageSize = Math.min(100, Math.max(1, Number(request.nextUrl.searchParams.get("pageSize")) || 20));
 
+			const search = request.nextUrl.searchParams.get("search")?.trim();
+			const valuesParam = request.nextUrl.searchParams.get("values");
+			const dateFrom = request.nextUrl.searchParams.get("dateFrom");
+			const dateTo = request.nextUrl.searchParams.get("dateTo");
+
+			const conditions: Prisma.RecognitionCardWhereInput[] = [];
+
+			if (search) {
+				conditions.push({
+					OR: [
+						{ sender: { firstName: { contains: search, mode: "insensitive" } } },
+						{ sender: { lastName: { contains: search, mode: "insensitive" } } },
+						{ recipient: { firstName: { contains: search, mode: "insensitive" } } },
+						{ recipient: { lastName: { contains: search, mode: "insensitive" } } },
+					],
+				});
+			}
+
+			if (valuesParam) {
+				const valueKeys = valuesParam.split(",").filter((k) => k in VALUE_KEY_MAP);
+				for (const key of valueKeys) {
+					conditions.push({ [VALUE_KEY_MAP[key]]: true });
+				}
+			}
+
+			if (dateFrom) {
+				conditions.push({ date: { gte: new Date(dateFrom) } });
+			}
+
+			if (dateTo) {
+				conditions.push({ date: { lte: new Date(`${dateTo}T23:59:59.999Z`) } });
+			}
+
+			const filteredWhere: Prisma.RecognitionCardWhereInput = conditions.length > 0
+				? { AND: conditions }
+				: {};
+
 			const [cards, total] = await Promise.all([
 				prisma.recognitionCard.findMany({
-					where,
+					where: filteredWhere,
 					include,
 					orderBy: { createdAt: "desc" },
 					skip: (page - 1) * pageSize,
 					take: pageSize,
 				}),
-				prisma.recognitionCard.count({ where }),
+				prisma.recognitionCard.count({ where: filteredWhere }),
 			]);
 
 			return Response.json({

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -132,10 +132,12 @@ export async function GET(request: NextRequest) {
 					},
 				};
 
+				const EXPORT_LIMIT = 10_000;
 				const cards = await prisma.recognitionCard.findMany({
 					where: filteredWhere,
 					include: exportInclude,
 					orderBy: { createdAt: "desc" },
+					take: EXPORT_LIMIT,
 				});
 
 				return Response.json({ success: true, data: cards });

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -68,10 +68,9 @@ export async function GET(request: NextRequest) {
 			},
 		};
 
-		if (paginated && !filter && isAdmin) {
-			const page = Math.max(1, Number(request.nextUrl.searchParams.get("page")) || 1);
-			const pageSize = Math.min(100, Math.max(1, Number(request.nextUrl.searchParams.get("pageSize")) || 20));
+		const isExport = request.nextUrl.searchParams.get("export") === "true";
 
+		if ((paginated || isExport) && !filter && isAdmin) {
 			const search = request.nextUrl.searchParams.get("search")?.trim();
 			const valuesParam = request.nextUrl.searchParams.get("values");
 			const dateFrom = request.nextUrl.searchParams.get("dateFrom");
@@ -108,6 +107,42 @@ export async function GET(request: NextRequest) {
 			const filteredWhere: Prisma.RecognitionCardWhereInput = conditions.length > 0
 				? { AND: conditions }
 				: {};
+
+			if (isExport) {
+				const exportInclude = {
+					sender: {
+						select: {
+							id: true,
+							firstName: true,
+							lastName: true,
+							position: true,
+							branch: true,
+							department: { select: { name: true } },
+						},
+					},
+					recipient: {
+						select: {
+							id: true,
+							firstName: true,
+							lastName: true,
+							position: true,
+							branch: true,
+							department: { select: { name: true } },
+						},
+					},
+				};
+
+				const cards = await prisma.recognitionCard.findMany({
+					where: filteredWhere,
+					include: exportInclude,
+					orderBy: { createdAt: "desc" },
+				});
+
+				return Response.json({ success: true, data: cards });
+			}
+
+			const page = Math.max(1, Number(request.nextUrl.searchParams.get("page")) || 1);
+			const pageSize = Math.min(100, Math.max(1, Number(request.nextUrl.searchParams.get("pageSize")) || 20));
 
 			const [cards, total] = await Promise.all([
 				prisma.recognitionCard.findMany({

--- a/lib/recognition.ts
+++ b/lib/recognition.ts
@@ -66,3 +66,92 @@ export function getSelectedValues(card: RecognitionCard): string[] {
 		.filter(([key]) => card[key as keyof RecognitionCard] === true)
 		.map(([, label]) => label);
 }
+
+export interface ExportRecognitionUser {
+	id: string;
+	firstName: string;
+	lastName: string;
+	position: string | null;
+	branch: string | null;
+	department: { name: string } | null;
+}
+
+export interface ExportRecognitionCard {
+	id: string;
+	message: string;
+	date: string;
+	sender: ExportRecognitionUser;
+	recipient: ExportRecognitionUser;
+	valuesPeople: boolean;
+	valuesSafety: boolean;
+	valuesRespect: boolean;
+	valuesCommunication: boolean;
+	valuesContinuousImprovement: boolean;
+}
+
+function formatDateForExport(dateString: string): string {
+	const [year, month, day] = dateString.split("T")[0].split("-");
+	const d = new Date(Number(year), Number(month) - 1, Number(day));
+	const dayNum = d.getDate();
+	const mon = d.toLocaleDateString("en-US", { month: "short" });
+	const yr = String(d.getFullYear()).slice(2);
+	return `${dayNum}-${mon}-${yr}`;
+}
+
+function getQuarter(dateString: string): string {
+	const month = Number(dateString.split("T")[0].split("-")[1]);
+	if (month <= 3) return "Q1";
+	if (month <= 6) return "Q2";
+	if (month <= 9) return "Q3";
+	return "Q4";
+}
+
+function escapeCsvField(value: string): string {
+	if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+		return `"${value.replace(/"/g, '""')}"`;
+	}
+	return value;
+}
+
+const CSV_HEADERS = [
+	"Department",
+	"Team Member",
+	"Role",
+	"Date Received",
+	"Receivers Branch",
+	"Givers Branch",
+	"Given By",
+	"Brief of what team member did",
+	"Safety",
+	"People",
+	"Respect",
+	"Communication",
+	"Continuous Improvement",
+	"Quarter Received",
+];
+
+export function generateRecognitionCsv(cards: ExportRecognitionCard[]): string {
+	const rows = cards.map((card) => [
+		card.recipient.department?.name ?? "",
+		`${card.recipient.firstName} ${card.recipient.lastName}`,
+		card.recipient.position ?? "",
+		formatDateForExport(card.date),
+		card.recipient.branch ?? "",
+		card.sender.branch ?? "",
+		`${card.sender.firstName} ${card.sender.lastName}`,
+		card.message,
+		card.valuesSafety ? "x" : "",
+		card.valuesPeople ? "x" : "",
+		card.valuesRespect ? "x" : "",
+		card.valuesCommunication ? "x" : "",
+		card.valuesContinuousImprovement ? "x" : "",
+		getQuarter(card.date),
+	]);
+
+	const lines = [
+		CSV_HEADERS.join(","),
+		...rows.map((row) => row.map(escapeCsvField).join(",")),
+	];
+
+	return lines.join("\n");
+}

--- a/lib/recognition.ts
+++ b/lib/recognition.ts
@@ -40,6 +40,14 @@ export const VALUE_LABELS: Record<string, string> = {
 	valuesContinuousImprovement: "Continuous Improvement",
 };
 
+export const VALUE_KEY_MAP: Record<string, string> = {
+	people: "valuesPeople",
+	safety: "valuesSafety",
+	respect: "valuesRespect",
+	communication: "valuesCommunication",
+	continuousImprovement: "valuesContinuousImprovement",
+};
+
 export function formatRecognitionDate(dateString: string) {
 	const [year, month, day] = dateString.split("T")[0].split("-");
 	return new Date(

--- a/lib/recognition.ts
+++ b/lib/recognition.ts
@@ -107,10 +107,13 @@ function getQuarter(dateString: string): string {
 }
 
 function escapeCsvField(value: string): string {
-	if (value.includes(",") || value.includes('"') || value.includes("\n")) {
-		return `"${value.replace(/"/g, '""')}"`;
+	const needsQuoting =
+		value.includes(",") || value.includes('"') || value.includes("\n");
+	const escaped = needsQuoting ? `"${value.replace(/"/g, '""')}"` : value;
+	if (/^[=+\-@\t\r]/.test(escaped)) {
+		return `\t${escaped}`;
 	}
-	return value;
+	return escaped;
 }
 
 const CSV_HEADERS = [

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,11 @@ enum Role {
   STAFF
 }
 
+enum Branch {
+  ISO
+  PERTH
+}
+
 model User {
   id            String   @id @default(cuid())
   name          String?
@@ -26,6 +31,7 @@ model User {
   position      String?
   avatar        String?
   role          Role     @default(STAFF)
+  branch        Branch?  @map("branch")
   isActive      Boolean  @default(true) @map("is_active")
   departmentId  String?  @map("department_id")
   createdAt     DateTime @default(now()) @map("created_at")


### PR DESCRIPTION
## Summary
- Add filter bar to admin recognition All table with search by name, company values toggle (AND logic), and month/year dropdowns
- Add CSV export that respects current filters and auto-downloads with structure matching `export-sample.csv`
- Add `Branch` enum (`ISO`, `PERTH`) and optional `branch` field to User model

## Changes
- **Filter bar**: search input, value toggle pills, month/year selects, clear button, export button
- **API**: server-side filtering (search, values, date range) + `export=true` param for unpaginated filtered results with department/branch
- **CSV export**: columns match sample — Department, Team Member, Role, Date Received, Receivers/Givers Branch, Given By, Message, Values (x/blank), Quarter Received
- **Schema**: `Branch` enum + `branch` field on User

## Test plan
- [ ] Filter by name, values, month/year — verify results update correctly
- [ ] Combine multiple filters — verify AND logic
- [ ] Click Export with no filters — downloads all cards as CSV
- [ ] Click Export with filters applied — CSV only contains matching cards
- [ ] Verify CSV structure matches `export-sample.csv` headers and format
- [ ] Verify layout doesn't shift when Clear button appears/disappears