### PR TITLE
fix(theme): prevent background color preference from overriding dark mode

### DIFF
--- a/app/(dashboard)/dashboard/profile/page.tsx
+++ b/app/(dashboard)/dashboard/profile/page.tsx
@@ -15,6 +15,7 @@ export default async function ProfilePage() {
 			displayName: true,
 			phone: true,
 			position: true,
+			branch: true,
 		},
 	});
 

--- a/app/(dashboard)/dashboard/profile/preferences/page.tsx
+++ b/app/(dashboard)/dashboard/profile/preferences/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Check, CreditCard, List, Minimize2, Square, Maximize2 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { toast } from "sonner";
@@ -28,8 +29,13 @@ const SIZE_ICONS: Record<CardSize, React.ComponentType<{ size?: number; classNam
 };
 
 export default function PreferencesPage() {
+	const [mounted, setMounted] = useState(false);
 	const { resolvedTheme } = useTheme();
-	const isDark = resolvedTheme === "dark";
+	const isDark = mounted && resolvedTheme === "dark";
+
+	useEffect(() => {
+		setMounted(true);
+	}, []);
 	const bgColorId = usePreferencesStore((s) => s.bgColorId);
 	const setBgColor = usePreferencesStore((s) => s.setBgColor);
 	const cardView = usePreferencesStore((s) => s.cardView);

--- a/app/(dashboard)/dashboard/profile/preferences/page.tsx
+++ b/app/(dashboard)/dashboard/profile/preferences/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Check, CreditCard, List, Minimize2, Square, Maximize2 } from "lucide-react";
+import { useTheme } from "next-themes";
 import { toast } from "sonner";
 import {
 	usePreferencesStore,
@@ -27,6 +28,8 @@ const SIZE_ICONS: Record<CardSize, React.ComponentType<{ size?: number; classNam
 };
 
 export default function PreferencesPage() {
+	const { resolvedTheme } = useTheme();
+	const isDark = resolvedTheme === "dark";
 	const bgColorId = usePreferencesStore((s) => s.bgColorId);
 	const setBgColor = usePreferencesStore((s) => s.setBgColor);
 	const cardView = usePreferencesStore((s) => s.cardView);
@@ -67,6 +70,11 @@ export default function PreferencesPage() {
 						<p className="mt-1 text-sm text-muted-foreground">
 							Choose the page background color for your dashboard.
 						</p>
+						{isDark && (
+							<p className="mt-1.5 text-xs text-muted-foreground/70">
+								Background color is only available in light mode.
+							</p>
+						)}
 					</div>
 
 					<div className="grid grid-cols-3 gap-3 sm:grid-cols-6">
@@ -76,10 +84,12 @@ export default function PreferencesPage() {
 								<button
 									key={option.id}
 									type="button"
+									disabled={isDark}
 									onClick={() => handleBgSelect(option.id)}
 									className={cn(
 										"group relative flex flex-col items-center gap-2 rounded-2xl border-2 p-3 transition-all duration-200",
-										isSelected
+										isDark && "opacity-40 cursor-not-allowed",
+										isSelected && !isDark
 											? "border-primary ring-2 ring-primary/20"
 											: "border-gray-200 dark:border-white/10 hover:border-gray-300 dark:hover:border-white/20",
 									)}

--- a/components/shared/bg-provider.tsx
+++ b/components/shared/bg-provider.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import { useEffect } from "react";
+import { useTheme } from "next-themes";
 import { usePreferencesStore, BG_OPTIONS } from "@/stores/use-preferences-store";
 
 export function BgProvider() {
 	const bgColorId = usePreferencesStore((s) => s.bgColorId);
+	const { resolvedTheme } = useTheme();
 
 	useEffect(() => {
+		if (resolvedTheme === "dark") {
+			document.documentElement.style.removeProperty("--background");
+			return;
+		}
+
 		const option = BG_OPTIONS.find((o) => o.id === bgColorId);
 		if (option) {
 			document.documentElement.style.setProperty("--background", option.value);
@@ -14,7 +21,7 @@ export function BgProvider() {
 		return () => {
 			document.documentElement.style.removeProperty("--background");
 		};
-	}, [bgColorId]);
+	}, [bgColorId, resolvedTheme]);
 
 	return null;
 }

--- a/lib/validations/user.ts
+++ b/lib/validations/user.ts
@@ -8,6 +8,7 @@ export const createUserSchema = z.object({
 	displayName: z.string().optional(),
 	phone: z.string().optional(),
 	position: z.string().optional(),
+	branch: z.enum(["ISO", "PERTH"]).nullable().optional(),
 	role: z.enum(["STAFF", "ADMIN", "SUPERADMIN"]),
 	departmentId: z.string().nullable().optional(),
 	isActive: z.boolean().default(true),


### PR DESCRIPTION
## Summary
- Fix conflict between dark mode toggle and background color preference — BgProvider was overriding `--background` CSS variable with a light color (e.g. cream) even in dark mode, causing a broken UI (light background + dark-themed text/sidebar/cards)
- Disable background color swatches in preferences page when dark mode is active, with explanatory note
- Add missing `branch` field to profile page select query and user validation schema

## Changes
- **`components/shared/bg-provider.tsx`**: Check `resolvedTheme` from `next-themes` — skip `--background` override and remove inline style when dark mode is active
- **`app/(dashboard)/dashboard/profile/preferences/page.tsx`**: Disable background color buttons with 40% opacity and "Background color is only available in light mode" note when in dark mode
- **`app/(dashboard)/dashboard/profile/page.tsx`**: Add `branch: true` to Prisma select query (fixes TS error)
- **`lib/validations/user.ts`**: Add `branch` field to `createUserSchema` (fixes TS error on edit page)

## Test plan
- [ ] Light mode: select a background color → background changes immediately
- [ ] Toggle to dark mode → background switches to dark theme, preference ignored
- [ ] Toggle back to light mode → background restores to previously selected preference
- [ ] Dark mode preferences page → background swatches disabled with note
- [ ] TypeScript: `bunx tsc --noEmit` passes with 0 errors