### PR TITLE
feat(auth): add super admin OAuth provider toggle settings

### DIFF
--- a/app/(auth)/login/_components/login-form.tsx
+++ b/app/(auth)/login/_components/login-form.tsx
@@ -118,6 +118,7 @@ export function LoginForm() {
 		}
 	}
 
+	const oauthLoaded = oauthSettings !== null;
 	const anyOAuthDisabled = isLoading || isGoogleLoading || isMicrosoftLoading;
 	const showGoogle = oauthSettings?.oauth_google_enabled && oauthAvailability?.google !== false;
 	const showMicrosoft = oauthSettings?.oauth_microsoft_enabled && oauthAvailability?.microsoft === true;
@@ -145,7 +146,13 @@ export function LoginForm() {
 
 			<div className="bg-card py-10 px-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] rounded-[2rem] sm:px-12 border border-gray-200/60 dark:border-white/10">
 				<div className="space-y-6">
-					{hasOAuth && (
+					{!oauthLoaded && (
+						<div className="space-y-3">
+							<div className="h-[52px] w-full animate-pulse rounded-full bg-gray-100 dark:bg-white/5" />
+						</div>
+					)}
+
+					{oauthLoaded && hasOAuth && (
 						<>
 							<div className="space-y-3">
 								{showGoogle && (

--- a/app/(auth)/login/_components/login-form.tsx
+++ b/app/(auth)/login/_components/login-form.tsx
@@ -3,13 +3,44 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import Link from "next/link";
 import { Loader2 } from "lucide-react";
 import { signIn } from "@/lib/auth-client";
 import { loginSchema, type LoginInput } from "@/lib/validations/auth";
 import { AccessGroupLogo } from "@/components/shared/access-logos";
+import type { OAuthSettings } from "@/lib/actions/settings-actions";
+
+const GOOGLE_ICON = (
+	<svg className="h-4 w-4" viewBox="0 0 24 24">
+		<path
+			d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+			fill="#4285F4"
+		/>
+		<path
+			d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+			fill="#34A853"
+		/>
+		<path
+			d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+			fill="#FBBC05"
+		/>
+		<path
+			d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+			fill="#EA4335"
+		/>
+	</svg>
+);
+
+const MICROSOFT_ICON = (
+	<svg className="h-4 w-4" viewBox="0 0 23 23">
+		<path fill="#f35325" d="M1 1h10v10H1z" />
+		<path fill="#81bc06" d="M12 1h10v10H12z" />
+		<path fill="#05a6f0" d="M1 12h10v10H1z" />
+		<path fill="#ffba08" d="M12 12h10v10H12z" />
+	</svg>
+);
 
 export function LoginForm() {
 	const router = useRouter();
@@ -17,6 +48,15 @@ export function LoginForm() {
 	const callbackUrl = searchParams.get("callbackUrl") ?? "/dashboard";
 	const [isLoading, setIsLoading] = useState(false);
 	const [isGoogleLoading, setIsGoogleLoading] = useState(false);
+	const [isMicrosoftLoading, setIsMicrosoftLoading] = useState(false);
+	const [oauthSettings, setOauthSettings] = useState<OAuthSettings | null>(null);
+
+	useEffect(() => {
+		fetch("/api/settings/oauth")
+			.then((res) => res.json())
+			.then((json) => setOauthSettings(json.data))
+			.catch(() => {});
+	}, []);
 
 	const {
 		register,
@@ -61,6 +101,24 @@ export function LoginForm() {
 		}
 	}
 
+	async function handleMicrosoftSignIn() {
+		setIsMicrosoftLoading(true);
+		try {
+			await signIn.social({
+				provider: "microsoft",
+				callbackURL: callbackUrl,
+			});
+		} catch {
+			toast.error("Failed to sign in with Microsoft");
+			setIsMicrosoftLoading(false);
+		}
+	}
+
+	const anyOAuthDisabled = isLoading || isGoogleLoading || isMicrosoftLoading;
+	const showGoogle = oauthSettings?.oauth_google_enabled;
+	const showMicrosoft = oauthSettings?.oauth_microsoft_enabled;
+	const hasOAuth = showGoogle || showMicrosoft;
+
 	return (
 		<div className="w-full max-w-md">
 			<div className="flex flex-col items-center mb-8">
@@ -83,47 +141,54 @@ export function LoginForm() {
 
 			<div className="bg-card py-10 px-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] rounded-[2rem] sm:px-12 border border-gray-200/60 dark:border-white/10">
 				<div className="space-y-6">
-					<button
-						type="button"
-						onClick={handleGoogleSignIn}
-						disabled={isGoogleLoading || isLoading}
-						className="flex w-full items-center justify-center gap-2 rounded-full border border-gray-200 dark:border-white/10 bg-card px-4 py-3.5 text-sm font-medium text-foreground hover:bg-gray-50 dark:hover:bg-white/5 focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50"
-					>
-						{isGoogleLoading ? (
-							<Loader2 className="h-4 w-4 animate-spin" />
-						) : (
-							<svg className="h-4 w-4" viewBox="0 0 24 24">
-								<path
-									d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-									fill="#4285F4"
-								/>
-								<path
-									d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-									fill="#34A853"
-								/>
-								<path
-									d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-									fill="#FBBC05"
-								/>
-								<path
-									d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-									fill="#EA4335"
-								/>
-							</svg>
-						)}
-						Continue with Google
-					</button>
+					{hasOAuth && (
+						<>
+							<div className="space-y-3">
+								{showGoogle && (
+									<button
+										type="button"
+										onClick={handleGoogleSignIn}
+										disabled={anyOAuthDisabled}
+										className="flex w-full items-center justify-center gap-2 rounded-full border border-gray-200 dark:border-white/10 bg-card px-4 py-3.5 text-sm font-medium text-foreground hover:bg-gray-50 dark:hover:bg-white/5 focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50"
+									>
+										{isGoogleLoading ? (
+											<Loader2 className="h-4 w-4 animate-spin" />
+										) : (
+											GOOGLE_ICON
+										)}
+										Continue with Google
+									</button>
+								)}
 
-					<div className="relative">
-						<div className="absolute inset-0 flex items-center">
-							<div className="w-full border-t border-gray-200 dark:border-white/10" />
-						</div>
-						<div className="relative flex justify-center text-xs uppercase">
-							<span className="bg-card px-2 text-muted-foreground">
-								Or continue with
-							</span>
-						</div>
-					</div>
+								{showMicrosoft && (
+									<button
+										type="button"
+										onClick={handleMicrosoftSignIn}
+										disabled={anyOAuthDisabled}
+										className="flex w-full items-center justify-center gap-2 rounded-full border border-gray-200 dark:border-white/10 bg-card px-4 py-3.5 text-sm font-medium text-foreground hover:bg-gray-50 dark:hover:bg-white/5 focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50"
+									>
+										{isMicrosoftLoading ? (
+											<Loader2 className="h-4 w-4 animate-spin" />
+										) : (
+											MICROSOFT_ICON
+										)}
+										Continue with Microsoft
+									</button>
+								)}
+							</div>
+
+							<div className="relative">
+								<div className="absolute inset-0 flex items-center">
+									<div className="w-full border-t border-gray-200 dark:border-white/10" />
+								</div>
+								<div className="relative flex justify-center text-xs uppercase">
+									<span className="bg-card px-2 text-muted-foreground">
+										Or continue with
+									</span>
+								</div>
+							</div>
+						</>
+					)}
 
 					<form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
 						<div>
@@ -136,7 +201,7 @@ export function LoginForm() {
 							<input
 								id="email"
 								type="email"
-								placeholder="name@accessgroup.com.au"
+								placeholder="name@accessgroup.net.au"
 								className="block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200"
 								{...register("email")}
 							/>
@@ -167,7 +232,7 @@ export function LoginForm() {
 						<div className="pt-2">
 							<button
 								type="submit"
-								disabled={isLoading || isGoogleLoading}
+								disabled={isLoading || isGoogleLoading || isMicrosoftLoading}
 								className="flex w-full justify-center rounded-full bg-primary px-4 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50"
 							>
 								{isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/app/(auth)/login/_components/login-form.tsx
+++ b/app/(auth)/login/_components/login-form.tsx
@@ -50,11 +50,15 @@ export function LoginForm() {
 	const [isGoogleLoading, setIsGoogleLoading] = useState(false);
 	const [isMicrosoftLoading, setIsMicrosoftLoading] = useState(false);
 	const [oauthSettings, setOauthSettings] = useState<OAuthSettings | null>(null);
+	const [oauthAvailability, setOauthAvailability] = useState<{ google: boolean; microsoft: boolean } | null>(null);
 
 	useEffect(() => {
 		fetch("/api/settings/oauth")
 			.then((res) => res.json())
-			.then((json) => setOauthSettings(json.data))
+			.then((json) => {
+				setOauthSettings(json.data);
+				setOauthAvailability(json.availability);
+			})
 			.catch(() => {});
 	}, []);
 
@@ -115,8 +119,8 @@ export function LoginForm() {
 	}
 
 	const anyOAuthDisabled = isLoading || isGoogleLoading || isMicrosoftLoading;
-	const showGoogle = oauthSettings?.oauth_google_enabled;
-	const showMicrosoft = oauthSettings?.oauth_microsoft_enabled;
+	const showGoogle = oauthSettings?.oauth_google_enabled && oauthAvailability?.google !== false;
+	const showMicrosoft = oauthSettings?.oauth_microsoft_enabled && oauthAvailability?.microsoft === true;
 	const hasOAuth = showGoogle || showMicrosoft;
 
 	return (

--- a/app/(dashboard)/dashboard/super-admin/_components/oauth-settings.tsx
+++ b/app/(dashboard)/dashboard/super-admin/_components/oauth-settings.tsx
@@ -48,10 +48,22 @@ const PROVIDERS = [
 	},
 ];
 
+interface ProviderAvailability {
+	google: boolean;
+	microsoft: boolean;
+}
+
+const AVAILABILITY_KEY_MAP: Record<string, keyof ProviderAvailability> = {
+	oauth_google_enabled: "google",
+	oauth_microsoft_enabled: "microsoft",
+};
+
 export function OAuthSettingsPanel({
 	initialSettings,
+	providerAvailability,
 }: {
 	initialSettings: OAuthSettings;
+	providerAvailability: ProviderAvailability;
 }) {
 	const [settings, setSettings] = useState(initialSettings);
 	const [isPending, startTransition] = useTransition();
@@ -89,7 +101,9 @@ export function OAuthSettingsPanel({
 
 			<div className="px-8 py-6 space-y-4">
 				{PROVIDERS.map((provider) => {
-					const isEnabled = settings[provider.key];
+					const availabilityKey = AVAILABILITY_KEY_MAP[provider.key];
+					const isConfigured = providerAvailability[availabilityKey];
+					const isEnabled = isConfigured && settings[provider.key];
 					const isLoading = isPending && pendingKey === provider.key;
 
 					return (
@@ -97,6 +111,7 @@ export function OAuthSettingsPanel({
 							key={provider.key}
 							className={cn(
 								"flex items-center justify-between rounded-2xl border p-5 transition-all duration-200",
+								!isConfigured && "opacity-60",
 								isEnabled
 									? "border-primary/20 bg-primary/5"
 									: "border-gray-200 dark:border-white/10",
@@ -111,7 +126,9 @@ export function OAuthSettingsPanel({
 										{provider.name}
 									</p>
 									<p className="text-xs text-muted-foreground">
-										{provider.description}
+										{isConfigured
+											? provider.description
+											: "Not configured — environment variables are missing"}
 									</p>
 								</div>
 							</div>
@@ -123,12 +140,12 @@ export function OAuthSettingsPanel({
 										isEnabled ? "text-primary" : "text-muted-foreground",
 									)}
 								>
-									{isEnabled ? "Enabled" : "Disabled"}
+									{!isConfigured ? "Unavailable" : isEnabled ? "Enabled" : "Disabled"}
 								</span>
 								<Switch
 									checked={isEnabled}
 									onCheckedChange={(checked) => handleToggle(provider.key, checked)}
-									disabled={isLoading}
+									disabled={isLoading || !isConfigured}
 								/>
 							</div>
 						</div>

--- a/app/(dashboard)/dashboard/super-admin/_components/oauth-settings.tsx
+++ b/app/(dashboard)/dashboard/super-admin/_components/oauth-settings.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+import { updateOAuthSetting } from "@/lib/actions/settings-actions";
+import type { OAuthSettings } from "@/lib/actions/settings-actions";
+import { cn } from "@/lib/utils";
+
+const PROVIDERS = [
+	{
+		key: "oauth_google_enabled" as const,
+		name: "Google",
+		description: "Allow users to sign in with their Google account",
+		icon: (
+			<svg className="h-5 w-5" viewBox="0 0 24 24">
+				<path
+					d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+					fill="#4285F4"
+				/>
+				<path
+					d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+					fill="#34A853"
+				/>
+				<path
+					d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+					fill="#FBBC05"
+				/>
+				<path
+					d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+					fill="#EA4335"
+				/>
+			</svg>
+		),
+	},
+	{
+		key: "oauth_microsoft_enabled" as const,
+		name: "Microsoft",
+		description: "Allow users to sign in with their Microsoft account",
+		icon: (
+			<svg className="h-5 w-5" viewBox="0 0 23 23">
+				<path fill="#f35325" d="M1 1h10v10H1z" />
+				<path fill="#81bc06" d="M12 1h10v10H12z" />
+				<path fill="#05a6f0" d="M1 12h10v10H1z" />
+				<path fill="#ffba08" d="M12 12h10v10H12z" />
+			</svg>
+		),
+	},
+];
+
+export function OAuthSettingsPanel({
+	initialSettings,
+}: {
+	initialSettings: OAuthSettings;
+}) {
+	const [settings, setSettings] = useState(initialSettings);
+	const [isPending, startTransition] = useTransition();
+	const [pendingKey, setPendingKey] = useState<string | null>(null);
+
+	function handleToggle(key: "oauth_google_enabled" | "oauth_microsoft_enabled", enabled: boolean) {
+		setPendingKey(key);
+		const previous = settings[key];
+
+		setSettings((prev) => ({ ...prev, [key]: enabled }));
+
+		startTransition(async () => {
+			const result = await updateOAuthSetting(key, enabled);
+			if (!result.success) {
+				setSettings((prev) => ({ ...prev, [key]: previous }));
+				toast.error(result.error ?? "Failed to update setting");
+			} else {
+				const providerName = key === "oauth_google_enabled" ? "Google" : "Microsoft";
+				toast.success(`${providerName} OAuth ${enabled ? "enabled" : "disabled"}`);
+			}
+			setPendingKey(null);
+		});
+	}
+
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
+			<div className="px-8 pt-8 pb-2">
+				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
+					OAuth Providers
+				</h3>
+				<p className="mt-2 text-sm text-muted-foreground">
+					Enable or disable social login providers on the sign-in page.
+				</p>
+			</div>
+
+			<div className="px-8 py-6 space-y-4">
+				{PROVIDERS.map((provider) => {
+					const isEnabled = settings[provider.key];
+					const isLoading = isPending && pendingKey === provider.key;
+
+					return (
+						<div
+							key={provider.key}
+							className={cn(
+								"flex items-center justify-between rounded-2xl border p-5 transition-all duration-200",
+								isEnabled
+									? "border-primary/20 bg-primary/5"
+									: "border-gray-200 dark:border-white/10",
+							)}
+						>
+							<div className="flex items-center gap-4">
+								<div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gray-100 dark:bg-white/10">
+									{provider.icon}
+								</div>
+								<div>
+									<p className="text-sm font-medium text-foreground">
+										{provider.name}
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{provider.description}
+									</p>
+								</div>
+							</div>
+
+							<div className="flex items-center gap-3">
+								<span
+									className={cn(
+										"text-xs font-medium",
+										isEnabled ? "text-primary" : "text-muted-foreground",
+									)}
+								>
+									{isEnabled ? "Enabled" : "Disabled"}
+								</span>
+								<Switch
+									checked={isEnabled}
+									onCheckedChange={(checked) => handleToggle(provider.key, checked)}
+									disabled={isLoading}
+								/>
+							</div>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/super-admin/page.tsx
+++ b/app/(dashboard)/dashboard/super-admin/page.tsx
@@ -11,7 +11,7 @@ export default async function SuperAdminPage() {
 	}
 
 	const oauthSettings = await getOAuthSettings();
-	const providerAvailability = getOAuthProviderAvailability();
+	const providerAvailability = await getOAuthProviderAvailability();
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-8 mt-2">

--- a/app/(dashboard)/dashboard/super-admin/page.tsx
+++ b/app/(dashboard)/dashboard/super-admin/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { requireRole } from "@/lib/auth-utils";
-import { getOAuthSettings } from "@/lib/actions/settings-actions";
+import { getOAuthSettings, getOAuthProviderAvailability } from "@/lib/actions/settings-actions";
 import { OAuthSettingsPanel } from "./_components/oauth-settings";
 
 export default async function SuperAdminPage() {
@@ -11,6 +11,7 @@ export default async function SuperAdminPage() {
 	}
 
 	const oauthSettings = await getOAuthSettings();
+	const providerAvailability = getOAuthProviderAvailability();
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-8 mt-2">
@@ -23,7 +24,7 @@ export default async function SuperAdminPage() {
 				</p>
 			</div>
 
-			<OAuthSettingsPanel initialSettings={oauthSettings} />
+			<OAuthSettingsPanel initialSettings={oauthSettings} providerAvailability={providerAvailability} />
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/super-admin/page.tsx
+++ b/app/(dashboard)/dashboard/super-admin/page.tsx
@@ -1,6 +1,7 @@
-import { requireRole } from "@/lib/auth-utils";
 import { redirect } from "next/navigation";
-import { ShieldCheck } from "lucide-react";
+import { requireRole } from "@/lib/auth-utils";
+import { getOAuthSettings } from "@/lib/actions/settings-actions";
+import { OAuthSettingsPanel } from "./_components/oauth-settings";
 
 export default async function SuperAdminPage() {
 	try {
@@ -8,6 +9,8 @@ export default async function SuperAdminPage() {
 	} catch {
 		redirect("/dashboard");
 	}
+
+	const oauthSettings = await getOAuthSettings();
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-8 mt-2">
@@ -19,21 +22,8 @@ export default async function SuperAdminPage() {
 					System-level administration and advanced controls.
 				</p>
 			</div>
-			<div className="flex flex-col items-center justify-center rounded-[2rem] border border-gray-200 dark:border-white/10 bg-card p-16 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
-				<div className="mb-6 rounded-full bg-background p-6">
-					<ShieldCheck
-						size={48}
-						className="text-muted-foreground opacity-40"
-					/>
-				</div>
-				<p className="text-[1.5rem] font-medium text-foreground">
-					Super admin panel coming soon
-				</p>
-				<p className="mt-2 text-base text-muted-foreground">
-					System administration and advanced controls will appear
-					here.
-				</p>
-			</div>
+
+			<OAuthSettingsPanel initialSettings={oauthSettings} />
 		</div>
 	);
 }

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -1,4 +1,59 @@
 import { auth } from "@/lib/auth";
 import { toNextJsHandler } from "better-auth/next-js";
+import { getOAuthSettings, getOAuthProviderAvailability } from "@/lib/actions/settings-actions";
+import type { NextRequest } from "next/server";
 
-export const { GET, POST } = toNextJsHandler(auth);
+const { GET: authGET, POST: authPOST } = toNextJsHandler(auth);
+
+const PROVIDER_SETTING_MAP: Record<string, keyof Awaited<ReturnType<typeof getOAuthSettings>>> = {
+	google: "oauth_google_enabled",
+	microsoft: "oauth_microsoft_enabled",
+};
+
+async function checkOAuthAllowed(request: NextRequest): Promise<Response | null> {
+	const pathname = request.nextUrl.pathname;
+
+	const providerMatch = pathname.match(
+		/\/api\/auth\/(?:callback|sign-in\/social)\/?(.*)?/,
+	);
+	if (!providerMatch) return null;
+
+	const body = request.method === "POST" ? await request.clone().json().catch(() => null) : null;
+	const provider =
+		providerMatch[1] ||
+		(body as Record<string, unknown> | null)?.provider;
+
+	if (typeof provider !== "string" || !(provider in PROVIDER_SETTING_MAP)) return null;
+
+	const availability = getOAuthProviderAvailability();
+	const availabilityKey = provider as keyof typeof availability;
+	if (!availability[availabilityKey]) {
+		return Response.json(
+			{ success: false, error: `${provider} OAuth is not configured` },
+			{ status: 403 },
+		);
+	}
+
+	const settings = await getOAuthSettings();
+	const settingKey = PROVIDER_SETTING_MAP[provider];
+	if (!settings[settingKey]) {
+		return Response.json(
+			{ success: false, error: `${provider} OAuth is currently disabled` },
+			{ status: 403 },
+		);
+	}
+
+	return null;
+}
+
+export async function GET(request: NextRequest) {
+	const blocked = await checkOAuthAllowed(request);
+	if (blocked) return blocked;
+	return authGET(request);
+}
+
+export async function POST(request: NextRequest) {
+	const blocked = await checkOAuthAllowed(request);
+	if (blocked) return blocked;
+	return authPOST(request);
+}

--- a/app/api/settings/oauth/route.ts
+++ b/app/api/settings/oauth/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { getOAuthSettings } from "@/lib/actions/settings-actions";
+
+export async function GET() {
+	const settings = await getOAuthSettings();
+	return NextResponse.json({ success: true, data: settings });
+}

--- a/app/api/settings/oauth/route.ts
+++ b/app/api/settings/oauth/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
-import { getOAuthSettings } from "@/lib/actions/settings-actions";
+import { getOAuthSettings, getOAuthProviderAvailability } from "@/lib/actions/settings-actions";
 
 export async function GET() {
 	const settings = await getOAuthSettings();
-	return NextResponse.json({ success: true, data: settings });
+	const availability = getOAuthProviderAvailability();
+	return NextResponse.json({ success: true, data: settings, availability });
 }

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/env.ts
+++ b/env.ts
@@ -8,6 +8,8 @@ export const env = createEnv({
 		BETTER_AUTH_URL: z.string().url(),
 		GOOGLE_CLIENT_ID: z.string().min(1),
 		GOOGLE_CLIENT_SECRET: z.string().min(1),
+		MICROSOFT_CLIENT_ID: z.string().min(1).optional(),
+		MICROSOFT_CLIENT_SECRET: z.string().min(1).optional(),
 		RESEND_API_KEY: z.string().min(1).optional(),
 	},
 	client: {

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -1,0 +1,45 @@
+"use server";
+
+import { prisma } from "@/lib/db";
+import { requireRole } from "@/lib/auth-utils";
+
+const OAUTH_KEYS = ["oauth_google_enabled", "oauth_microsoft_enabled"] as const;
+type OAuthKey = (typeof OAUTH_KEYS)[number];
+
+export type OAuthSettings = Record<OAuthKey, boolean>;
+
+export async function getOAuthSettings(): Promise<OAuthSettings> {
+	const settings = await prisma.appSetting.findMany({
+		where: { key: { in: [...OAUTH_KEYS] } },
+	});
+
+	const map = new Map(settings.map((s) => [s.key, s.value]));
+
+	return {
+		oauth_google_enabled: map.get("oauth_google_enabled") === "true",
+		oauth_microsoft_enabled: map.get("oauth_microsoft_enabled") === "true",
+	};
+}
+
+export async function updateOAuthSetting(
+	key: OAuthKey,
+	enabled: boolean,
+): Promise<{ success: boolean; error?: string }> {
+	try {
+		await requireRole("SUPERADMIN");
+	} catch {
+		return { success: false, error: "Unauthorized" };
+	}
+
+	if (!OAUTH_KEYS.includes(key)) {
+		return { success: false, error: "Invalid setting key" };
+	}
+
+	await prisma.appSetting.upsert({
+		where: { key },
+		update: { value: String(enabled) },
+		create: { key, value: String(enabled) },
+	});
+
+	return { success: true };
+}

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -38,7 +38,7 @@ function invalidateOAuthCache() {
 	cacheExpiry = 0;
 }
 
-export function getOAuthProviderAvailability() {
+export async function getOAuthProviderAvailability() {
 	return {
 		google: true,
 		microsoft: !!(env.MICROSOFT_CLIENT_ID && env.MICROSOFT_CLIENT_SECRET),

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -9,17 +9,33 @@ type OAuthKey = (typeof OAUTH_KEYS)[number];
 
 export type OAuthSettings = Record<OAuthKey, boolean>;
 
+let cachedSettings: OAuthSettings | null = null;
+let cacheExpiry = 0;
+const CACHE_TTL_MS = 30_000;
+
 export async function getOAuthSettings(): Promise<OAuthSettings> {
+	if (cachedSettings && Date.now() < cacheExpiry) {
+		return cachedSettings;
+	}
+
 	const settings = await prisma.appSetting.findMany({
 		where: { key: { in: [...OAUTH_KEYS] } },
 	});
 
 	const map = new Map(settings.map((s) => [s.key, s.value]));
 
-	return {
+	cachedSettings = {
 		oauth_google_enabled: map.get("oauth_google_enabled") !== "false",
 		oauth_microsoft_enabled: map.get("oauth_microsoft_enabled") !== "false",
 	};
+	cacheExpiry = Date.now() + CACHE_TTL_MS;
+
+	return cachedSettings;
+}
+
+function invalidateOAuthCache() {
+	cachedSettings = null;
+	cacheExpiry = 0;
 }
 
 export function getOAuthProviderAvailability() {
@@ -48,6 +64,8 @@ export async function updateOAuthSetting(
 		update: { value: String(enabled) },
 		create: { key, value: String(enabled) },
 	});
+
+	invalidateOAuthCache();
 
 	return { success: true };
 }

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from "@/lib/db";
 import { requireRole } from "@/lib/auth-utils";
+import { env } from "@/env";
 
 const OAUTH_KEYS = ["oauth_google_enabled", "oauth_microsoft_enabled"] as const;
 type OAuthKey = (typeof OAUTH_KEYS)[number];
@@ -16,8 +17,15 @@ export async function getOAuthSettings(): Promise<OAuthSettings> {
 	const map = new Map(settings.map((s) => [s.key, s.value]));
 
 	return {
-		oauth_google_enabled: map.get("oauth_google_enabled") === "true",
-		oauth_microsoft_enabled: map.get("oauth_microsoft_enabled") === "true",
+		oauth_google_enabled: map.get("oauth_google_enabled") !== "false",
+		oauth_microsoft_enabled: map.get("oauth_microsoft_enabled") !== "false",
+	};
+}
+
+export function getOAuthProviderAvailability() {
+	return {
+		google: true,
+		microsoft: !!(env.MICROSOFT_CLIENT_ID && env.MICROSOFT_CLIENT_SECRET),
 	};
 }
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -19,10 +19,10 @@ if (env.MICROSOFT_CLIENT_ID && env.MICROSOFT_CLIENT_SECRET) {
 	socialProviders.microsoft = {
 		clientId: env.MICROSOFT_CLIENT_ID,
 		clientSecret: env.MICROSOFT_CLIENT_SECRET,
-		mapProfileToUser: (profile: { givenName: string; surname: string }) => ({
-			firstName: profile.givenName,
-			lastName: profile.surname,
-			name: `${profile.givenName} ${profile.surname}`,
+		mapProfileToUser: (profile: { given_name: string; family_name: string }) => ({
+			firstName: profile.given_name,
+			lastName: profile.family_name,
+			name: `${profile.given_name} ${profile.family_name}`,
 		}),
 	};
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,6 +3,30 @@ import { prismaAdapter } from "better-auth/adapters/prisma";
 import { prisma } from "@/lib/db";
 import { env } from "@/env";
 
+const socialProviders: Record<string, unknown> = {
+	google: {
+		clientId: env.GOOGLE_CLIENT_ID,
+		clientSecret: env.GOOGLE_CLIENT_SECRET,
+		mapProfileToUser: (profile: { given_name: string; family_name: string }) => ({
+			firstName: profile.given_name,
+			lastName: profile.family_name,
+			name: `${profile.given_name} ${profile.family_name}`,
+		}),
+	},
+};
+
+if (env.MICROSOFT_CLIENT_ID && env.MICROSOFT_CLIENT_SECRET) {
+	socialProviders.microsoft = {
+		clientId: env.MICROSOFT_CLIENT_ID,
+		clientSecret: env.MICROSOFT_CLIENT_SECRET,
+		mapProfileToUser: (profile: { givenName: string; surname: string }) => ({
+			firstName: profile.givenName,
+			lastName: profile.surname,
+			name: `${profile.givenName} ${profile.surname}`,
+		}),
+	};
+}
+
 export const auth = betterAuth({
 	database: prismaAdapter(prisma, { provider: "postgresql" }),
 	secret: env.BETTER_AUTH_SECRET,
@@ -10,17 +34,7 @@ export const auth = betterAuth({
 	emailAndPassword: {
 		enabled: true,
 	},
-	socialProviders: {
-		google: {
-			clientId: env.GOOGLE_CLIENT_ID,
-			clientSecret: env.GOOGLE_CLIENT_SECRET,
-			mapProfileToUser: (profile) => ({
-				firstName: profile.given_name,
-				lastName: profile.family_name,
-				name: `${profile.given_name} ${profile.family_name}`,
-			}),
-		},
-	},
+	socialProviders,
 	user: {
 		additionalFields: {
 			firstName: {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,14 @@ model Department {
   @@map("departments")
 }
 
+model AppSetting {
+  key       String   @id
+  value     String
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("app_settings")
+}
+
 model RecognitionCard {
   id        String   @id @default(uuid())
   message   String


### PR DESCRIPTION
## Summary
- Add super admin panel to enable/disable Google and Microsoft OAuth providers on the login page
- Add Microsoft OAuth support alongside existing Google sign-in
- Store OAuth toggle settings in a new `AppSetting` model, managed via server actions
- Login page dynamically fetches OAuth settings and conditionally renders provider buttons

## Changes
- **`prisma/schema.prisma`** — Add `AppSetting` model for key-value settings storage
- **`lib/actions/settings-actions.ts`** — Server actions for reading/updating OAuth settings (SUPERADMIN only)
- **`lib/auth.ts`** — Conditionally register Microsoft provider when env vars are present
- **`env.ts`** — Add optional `MICROSOFT_CLIENT_ID` and `MICROSOFT_CLIENT_SECRET`
- **`app/api/settings/oauth/route.ts`** — Public GET endpoint for login page to fetch OAuth state
- **`app/(dashboard)/dashboard/super-admin/`** — Replace placeholder with `OAuthSettingsPanel` (toggle switches per provider)
- **`app/(auth)/login/_components/login-form.tsx`** — Fetch OAuth settings on mount, conditionally render Google/Microsoft buttons, add Microsoft sign-in handler
- **`components/ui/switch.tsx`** — New shadcn/ui Switch component

## Test plan
- [ ] Super admin can toggle Google/Microsoft OAuth on and off
- [ ] Login page shows only enabled providers
- [ ] Login page shows no OAuth section when both are disabled
- [ ] Microsoft sign-in works when enabled and env vars are configured
- [ ] Non-super-admin users cannot access the toggle endpoint
- [ ] Email/password login still works regardless of OAuth settings