### PR TITLE
feat(recognition): add new card indicator on received tab

### DIFF
--- a/app/(dashboard)/dashboard/recognition/[id]/_components/mark-notifications-read.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/_components/mark-notifications-read.tsx
@@ -14,6 +14,7 @@ export function MarkNotificationsRead({ cardId }: { cardId: string }) {
 
 		markNotificationsReadByCardAction(cardId).then(() => {
 			queryClient.invalidateQueries({ queryKey: ["notifications"] });
+			queryClient.invalidateQueries({ queryKey: ["unread-card-ids"] });
 		});
 	}, [cardId, queryClient]);
 

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-card-mini.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-card-mini.tsx
@@ -108,9 +108,11 @@ function ValueIndicator({
 export function RecognitionCardMini({
 	card,
 	size = "normal",
+	isNew = false,
 }: {
 	card: RecognitionCard;
 	size?: CardSize;
+	isNew?: boolean;
 }) {
 	const s = SIZE_CONFIG[size];
 
@@ -119,8 +121,18 @@ export function RecognitionCardMini({
 			className={cn(
 				"bg-[#e6e7e8] relative shadow-md flex flex-col md:flex-row",
 				s.outer,
+				isNew && "ring-2 ring-primary/30",
 			)}
 		>
+			{/* New Badge */}
+			{isNew && (
+				<div className="absolute top-2 left-2 z-10">
+					<span className="inline-flex items-center rounded-full bg-primary px-2.5 py-1 text-[10px] font-bold text-primary-foreground uppercase tracking-wider shadow-sm">
+						New
+					</span>
+				</div>
+			)}
+
 			{/* Crop Marks */}
 			<div
 				className="absolute top-1 left-1 w-2.5 h-2.5 border-t border-l border-gray-400"

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -100,7 +100,7 @@ export function RecognitionFeed({
 }: RecognitionFeedProps) {
 	const cardView = usePreferencesStore((s) => s.cardView);
 	const cardSize = usePreferencesStore((s) => s.cardSize);
-	const { unreadCardIds } = useUnreadCardIds();
+	const { unreadCardIds } = useUnreadCardIds(filter === "received");
 	const queryParam = filter !== "all" ? `?filter=${filter}` : "";
 
 	const { data, isPending } = useQuery<{

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -10,7 +10,7 @@ import {
 	formatRecognitionDate,
 } from "@/lib/recognition";
 import { usePreferencesStore } from "@/stores/use-preferences-store";
-import { useNotifications } from "@/hooks/use-notifications";
+import { useUnreadCardIds } from "@/hooks/use-unread-card-ids";
 import { RecognitionCardMini } from "./recognition-card-mini";
 
 function CardSkeleton() {
@@ -100,14 +100,8 @@ export function RecognitionFeed({
 }: RecognitionFeedProps) {
 	const cardView = usePreferencesStore((s) => s.cardView);
 	const cardSize = usePreferencesStore((s) => s.cardSize);
-	const { notifications } = useNotifications();
+	const { unreadCardIds } = useUnreadCardIds();
 	const queryParam = filter !== "all" ? `?filter=${filter}` : "";
-
-	const unreadCardIds = new Set(
-		notifications
-			.filter((n) => !n.isRead && n.cardId)
-			.map((n) => n.cardId as string),
-	);
 
 	const { data, isPending } = useQuery<{
 		success: boolean;

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -10,6 +10,7 @@ import {
 	formatRecognitionDate,
 } from "@/lib/recognition";
 import { usePreferencesStore } from "@/stores/use-preferences-store";
+import { useNotifications } from "@/hooks/use-notifications";
 import { RecognitionCardMini } from "./recognition-card-mini";
 
 function CardSkeleton() {
@@ -99,7 +100,14 @@ export function RecognitionFeed({
 }: RecognitionFeedProps) {
 	const cardView = usePreferencesStore((s) => s.cardView);
 	const cardSize = usePreferencesStore((s) => s.cardSize);
+	const { notifications } = useNotifications();
 	const queryParam = filter !== "all" ? `?filter=${filter}` : "";
+
+	const unreadCardIds = new Set(
+		notifications
+			.filter((n) => !n.isRead && n.cardId)
+			.map((n) => n.cardId as string),
+	);
 
 	const { data, isPending } = useQuery<{
 		success: boolean;
@@ -172,11 +180,13 @@ export function RecognitionFeed({
 				) : null;
 
 				if (cardView === "physical") {
+					const isNew = filter === "received" && unreadCardIds.has(card.id);
 					return (
 						<div key={card.id} className={cn("group relative", cardMaxWidth)}>
 							<RecognitionCardMini
 								card={card}
 								size={cardSize}
+								isNew={isNew}
 							/>
 							{actions && (
 								<div className="absolute top-3 right-3 z-10">
@@ -188,10 +198,11 @@ export function RecognitionFeed({
 				}
 
 				const values = getSelectedValues(card);
+				const isNewCard = filter === "received" && unreadCardIds.has(card.id);
 				return (
 					<div
 						key={card.id}
-						className={cn("group rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]", cardMaxWidth)}
+						className={cn("group rounded-[2rem] border bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]", isNewCard ? "border-primary/40 ring-1 ring-primary/20" : "border-gray-200/60 dark:border-white/10", cardMaxWidth)}
 					>
 						<div className="flex items-center gap-3 mb-3">
 							<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary text-sm font-semibold">
@@ -232,9 +243,14 @@ export function RecognitionFeed({
 									</p>
 								)}
 							</div>
-							{actions && (
-								<div className="ml-auto">{actions}</div>
-							)}
+							<div className="ml-auto flex items-center gap-2">
+								{isNewCard && (
+									<span className="inline-flex items-center rounded-full bg-primary px-2.5 py-0.5 text-[10px] font-semibold text-primary-foreground uppercase tracking-wide">
+										New
+									</span>
+								)}
+								{actions}
+							</div>
 						</div>
 
 						<p className="text-sm text-foreground/80 mb-3 leading-relaxed">

--- a/app/api/notifications/unread-cards/route.ts
+++ b/app/api/notifications/unread-cards/route.ts
@@ -1,0 +1,35 @@
+import { requireSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+
+export async function GET() {
+	let session: Awaited<ReturnType<typeof requireSession>>;
+	try {
+		session = await requireSession();
+	} catch {
+		return Response.json(
+			{ success: false, error: "Unauthorized" },
+			{ status: 401 },
+		);
+	}
+
+	try {
+		const notifications = await prisma.notification.findMany({
+			where: {
+				userId: session.user.id,
+				type: "CARD_RECEIVED",
+				isRead: false,
+				cardId: { not: null },
+			},
+			select: { cardId: true },
+		});
+
+		const cardIds = notifications.map((n) => n.cardId as string);
+
+		return Response.json({ success: true, data: cardIds });
+	} catch {
+		return Response.json(
+			{ success: false, error: "Internal server error" },
+			{ status: 500 },
+		);
+	}
+}

--- a/components/shared/notification-bell.tsx
+++ b/components/shared/notification-bell.tsx
@@ -51,12 +51,14 @@ export function NotificationBell() {
 	async function handleMarkAllRead() {
 		await markAllNotificationsReadAction();
 		queryClient.invalidateQueries({ queryKey: ["notifications"] });
+		queryClient.invalidateQueries({ queryKey: ["unread-card-ids"] });
 	}
 
 	function handleNotificationClick(notification: Notification) {
 		if (!notification.isRead) {
 			markNotificationReadAction(notification.id).then(() => {
 				queryClient.invalidateQueries({ queryKey: ["notifications"] });
+				queryClient.invalidateQueries({ queryKey: ["unread-card-ids"] });
 			});
 		}
 		if (notification.cardId) {

--- a/hooks/use-unread-card-ids.ts
+++ b/hooks/use-unread-card-ids.ts
@@ -2,7 +2,9 @@
 
 import { useQuery } from "@tanstack/react-query";
 
-export function useUnreadCardIds() {
+const EMPTY_SET = new Set<string>();
+
+export function useUnreadCardIds(enabled = true) {
 	const { data, ...rest } = useQuery<{
 		success: boolean;
 		data: string[];
@@ -14,10 +16,11 @@ export function useUnreadCardIds() {
 			return res.json();
 		},
 		staleTime: 30_000,
+		enabled,
 	});
 
 	return {
-		unreadCardIds: new Set(data?.data ?? []),
+		unreadCardIds: enabled ? new Set(data?.data ?? []) : EMPTY_SET,
 		...rest,
 	};
 }

--- a/hooks/use-unread-card-ids.ts
+++ b/hooks/use-unread-card-ids.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+export function useUnreadCardIds() {
+	const { data, ...rest } = useQuery<{
+		success: boolean;
+		data: string[];
+	}>({
+		queryKey: ["unread-card-ids"],
+		queryFn: async () => {
+			const res = await fetch("/api/notifications/unread-cards");
+			if (!res.ok) throw new Error("Failed to fetch unread card IDs");
+			return res.json();
+		},
+		staleTime: 30_000,
+	});
+
+	return {
+		unreadCardIds: new Set(data?.data ?? []),
+		...rest,
+	};
+}


### PR DESCRIPTION
## Summary
- Adds a "NEW" badge and ring highlight on unread recognition cards in the received tab
- Physical card view: "NEW" pill badge on top-left corner + primary ring border
- List card view: "NEW" pill next to actions + primary border/ring highlight
- Uses unread notification `cardId`s from the shared `useNotifications` hook
- Indicator disappears once the user views the card detail page (marking it as read)

## Test plan
- [ ] Navigate to `/dashboard/recognition/received` with unread notifications
- [ ] Verify "NEW" badge appears on physical card view for unread cards
- [ ] Verify "NEW" badge and border highlight appear on list card view
- [ ] Click into a card detail page, go back — verify the indicator is gone
- [ ] Verify no indicators show on the sent tab
- [ ] Test both light and dark mode