### PR TITLE
feat(dashboard): swap Recognition Feed and Stats widget positions

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -35,8 +35,12 @@ export default async function DashboardPage() {
 
 			{/* Widgets: Public Feed + Stats */}
 			<div className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-8">
-				<RecognitionFeedWidget />
-				<StatsWidget />
+				<div className="order-2 lg:order-1">
+					<RecognitionFeedWidget />
+				</div>
+				<div className="order-1 lg:order-2">
+					<StatsWidget />
+				</div>
 			</div>
 		</div>
 	);

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -33,10 +33,10 @@ export default async function DashboardPage() {
 				</Link>
 			</div>
 
-			{/* Widgets: Stats + Public Feed */}
-			<div className="grid grid-cols-1 lg:grid-cols-[2fr_3fr] gap-8">
-				<StatsWidget />
+			{/* Widgets: Public Feed + Stats */}
+			<div className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-8">
 				<RecognitionFeedWidget />
+				<StatsWidget />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Moves **Recognition Feed** to the left column (`3fr`) and **Recognition Stats** to the right (`2fr`)
- Grid template updated from `[2fr_3fr]` to `[3fr_2fr]` to preserve each widget's original proportions

## Test plan
- [ ] Visit `/dashboard` and confirm Recognition Feed appears on the left
- [ ] Confirm Recognition Stats appears on the right
- [ ] Check responsive layout — both widgets stack correctly on mobile (`grid-cols-1`)