### PR TITLE
feat(recognition): add emoji reactions and comment section to recognition cards

### DIFF
--- a/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
@@ -23,7 +23,12 @@ const FEED_TABS = [
 	},
 ];
 
-export function RecognitionFeedWidget() {
+interface RecognitionFeedWidgetProps {
+	currentUserId: string;
+	isAdmin: boolean;
+}
+
+export function RecognitionFeedWidget({ currentUserId, isAdmin }: RecognitionFeedWidgetProps) {
 	const [activeTab, setActiveTab] = useState<"all" | "department">("all");
 	const currentTab = FEED_TABS.find((t) => t.key === activeTab)!;
 
@@ -65,6 +70,8 @@ export function RecognitionFeedWidget() {
 				<RecognitionFeed
 					filter={activeTab}
 					showTitle={false}
+					currentUserId={currentUserId}
+					isAdmin={isAdmin}
 					emptyTitle={currentTab.emptyTitle}
 					emptyDescription={currentTab.emptyDescription}
 				/>

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from "@/lib/auth-utils";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Plus } from "lucide-react";
+import { hasMinRole, getUserRole } from "@/lib/permissions";
 import { StatsWidget } from "./_components/stats-widget";
 import { RecognitionFeedWidget } from "./_components/recognition-feed-widget";
 
@@ -10,6 +11,7 @@ export default async function DashboardPage() {
 	if (!session) redirect("/login");
 
 	const user = session.user;
+	const isAdmin = hasMinRole(getUserRole(session), "ADMIN");
 
 	return (
 		<div className="max-w-7xl mx-auto mt-2 space-y-8">
@@ -36,7 +38,7 @@ export default async function DashboardPage() {
 			{/* Widgets: Public Feed + Stats */}
 			<div className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-8">
 				<div className="order-2 lg:order-1">
-					<RecognitionFeedWidget />
+					<RecognitionFeedWidget currentUserId={user.id} isAdmin={isAdmin} />
 				</div>
 				<div className="order-1 lg:order-2">
 					<StatsWidget />

--- a/app/(dashboard)/dashboard/recognition/(inbox)/received/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/(inbox)/received/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "@/lib/auth-utils";
+import { hasMinRole, getUserRole } from "@/lib/permissions";
 import { RecognitionFeedClient } from "../../_components/recognition-feed-client";
 
 export default async function RecognitionReceivedPage() {
@@ -8,6 +9,7 @@ export default async function RecognitionReceivedPage() {
 		<RecognitionFeedClient
 			filter="received"
 			currentUserId={session!.user.id}
+			isAdmin={hasMinRole(getUserRole(session), "ADMIN")}
 			emptyTitle="No recognition cards received yet"
 			emptyDescription="When a colleague recognizes you, it will appear here."
 		/>

--- a/app/(dashboard)/dashboard/recognition/(inbox)/sent/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/(inbox)/sent/page.tsx
@@ -1,4 +1,5 @@
 import { getServerSession } from "@/lib/auth-utils";
+import { hasMinRole, getUserRole } from "@/lib/permissions";
 import { RecognitionFeedClient } from "../../_components/recognition-feed-client";
 
 export default async function RecognitionSentPage() {
@@ -8,6 +9,7 @@ export default async function RecognitionSentPage() {
 		<RecognitionFeedClient
 			filter="sent"
 			currentUserId={session!.user.id}
+			isAdmin={hasMinRole(getUserRole(session), "ADMIN")}
 			emptyTitle="You haven't sent any cards yet"
 			emptyDescription="Recognize a colleague to get started!"
 		/>

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -30,9 +30,9 @@ export function CardInteractionBar({
 	const [fetchEnabled, setFetchEnabled] = useState(false);
 
 	const { data } = useQuery<{ success: boolean; data: CardInteractions }>({
-		queryKey: ["card-interactions", cardId],
-		queryFn: async () => {
-			const res = await fetch(`/api/recognition/${cardId}/interactions`);
+		queryKey: ["card-interactions", cardId, currentUserId],
+		queryFn: async ({ signal }) => {
+			const res = await fetch(`/api/recognition/${cardId}/interactions`, { signal });
 			if (!res.ok) throw new Error("Failed to fetch interactions");
 			return res.json();
 		},
@@ -50,18 +50,17 @@ export function CardInteractionBar({
 			// Data not loaded yet — action handles add/remove atomically on server;
 			// invalidate after so the query picks up the new state
 			toggleReactionAction(cardId, emoji).then((result) => {
-				if (result.success) {
-					queryClient.invalidateQueries({ queryKey: ["card-interactions", cardId] });
-				} else {
+				if (!result.success) {
 					toast.error(result.error);
 				}
+				queryClient.invalidateQueries({ queryKey: ["card-interactions", cardId, currentUserId] });
 			});
 			return;
 		}
 
 		// Optimistic update when we already have the current state
 		queryClient.setQueryData<{ success: boolean; data: CardInteractions }>(
-			["card-interactions", cardId],
+			["card-interactions", cardId, currentUserId],
 			(old) => {
 				if (!old?.data) return old;
 				const reactions = old.data.reactions.map((r) => {
@@ -79,9 +78,10 @@ export function CardInteractionBar({
 
 		toggleReactionAction(cardId, emoji).then((result) => {
 			if (!result.success) {
-				queryClient.invalidateQueries({ queryKey: ["card-interactions", cardId] });
 				toast.error(result.error);
 			}
+			// Always invalidate to pick up concurrent reactions from other users
+			queryClient.invalidateQueries({ queryKey: ["card-interactions", cardId, currentUserId] });
 		});
 	}
 
@@ -91,9 +91,9 @@ export function CardInteractionBar({
 	}
 
 	async function handleCommentsChange(comments: CardComment[]) {
-		await queryClient.cancelQueries({ queryKey: ["card-interactions", cardId] });
+		await queryClient.cancelQueries({ queryKey: ["card-interactions", cardId, currentUserId] });
 		queryClient.setQueryData<{ success: boolean; data: CardInteractions }>(
-			["card-interactions", cardId],
+			["card-interactions", cardId, currentUserId],
 			(old) => {
 				// Seed cache from scratch if the lazy query hasn't fired yet
 				if (!old?.data) {

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -18,6 +18,7 @@ interface CardInteractionBarProps {
 	currentUserId: string;
 	isAdmin: boolean;
 	initialCommentCount?: number;
+	initialReactions?: { emoji: string; count: number; hasReacted: boolean }[];
 }
 
 export function CardInteractionBar({
@@ -25,6 +26,7 @@ export function CardInteractionBar({
 	currentUserId,
 	isAdmin,
 	initialCommentCount = 0,
+	initialReactions,
 }: CardInteractionBarProps) {
 	const queryClient = useQueryClient();
 	const [showComments, setShowComments] = useState(false);
@@ -138,11 +140,17 @@ export function CardInteractionBar({
 	const comments = interactions?.comments ?? [];
 	const totalComments = interactions?.totalComments ?? initialCommentCount;
 
-	const activeReactions = reactions.filter((r) => r.count > 0);
-	// Show all 6 ghost buttons when data not loaded; only zero-count ones after load
-	const ghostReactions = interactions
-		? reactions.filter((r) => r.count === 0)
-		: REACTION_EMOJIS.map((emoji) => ({ emoji, count: 0, hasReacted: false }));
+	// Use initialReactions from the feed before the lazy fetch fires
+	const displayReactions = interactions
+		? reactions
+		: initialReactions ?? [];
+
+	const activeReactions = displayReactions.filter((r) => r.count > 0);
+	// Build ghost buttons for emojis not already shown as active
+	const activeEmojis = new Set(activeReactions.map((r) => r.emoji));
+	const ghostReactions = REACTION_EMOJIS.filter((e) => !activeEmojis.has(e)).map(
+		(emoji) => ({ emoji, count: 0, hasReacted: false }),
+	);
 
 	return (
 		<div

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -26,24 +26,40 @@ export function CardInteractionBar({
 }: CardInteractionBarProps) {
 	const queryClient = useQueryClient();
 	const [showComments, setShowComments] = useState(false);
+	// Lazy: only fetch when user first hovers (desktop) or interacts (mobile)
+	const [fetchEnabled, setFetchEnabled] = useState(false);
 
-	const { data, isLoading } = useQuery<{ success: boolean; data: CardInteractions }>({
+	const { data } = useQuery<{ success: boolean; data: CardInteractions }>({
 		queryKey: ["card-interactions", cardId],
 		queryFn: async () => {
 			const res = await fetch(`/api/recognition/${cardId}/interactions`);
 			if (!res.ok) throw new Error("Failed to fetch interactions");
 			return res.json();
 		},
+		enabled: fetchEnabled,
 		staleTime: 30_000,
 	});
 
 	const interactions = data?.data;
 
 	function handleReaction(emoji: string) {
-		const current = interactions;
-		if (!current) return;
+		// Ensure the query is (or will be) active
+		setFetchEnabled(true);
 
-		// Optimistic update
+		if (!interactions) {
+			// Data not loaded yet — action handles add/remove atomically on server;
+			// invalidate after so the query picks up the new state
+			toggleReactionAction(cardId, emoji).then((result) => {
+				if (result.success) {
+					queryClient.invalidateQueries({ queryKey: ["card-interactions", cardId] });
+				} else {
+					toast.error(result.error);
+				}
+			});
+			return;
+		}
+
+		// Optimistic update when we already have the current state
 		queryClient.setQueryData<{ success: boolean; data: CardInteractions }>(
 			["card-interactions", cardId],
 			(old) => {
@@ -63,11 +79,15 @@ export function CardInteractionBar({
 
 		toggleReactionAction(cardId, emoji).then((result) => {
 			if (!result.success) {
-				// Revert on failure
 				queryClient.invalidateQueries({ queryKey: ["card-interactions", cardId] });
 				toast.error(result.error);
 			}
 		});
+	}
+
+	function handleCommentToggle() {
+		setFetchEnabled(true);
+		setShowComments((v) => !v);
 	}
 
 	function handleCommentsChange(comments: CardComment[]) {
@@ -83,31 +103,24 @@ export function CardInteractionBar({
 		);
 	}
 
-	if (isLoading) {
-		return (
-			<div className="flex gap-1.5 pt-3 mt-3 border-t border-border/50">
-				{REACTION_EMOJIS.map((emoji) => (
-					<div
-						key={emoji}
-						className="h-7 w-10 rounded-full bg-muted/60 animate-pulse"
-					/>
-				))}
-			</div>
-		);
-	}
-
 	const reactions = interactions?.reactions ?? [];
 	const comments = interactions?.comments ?? [];
 	const totalComments = interactions?.totalComments ?? 0;
 
 	const activeReactions = reactions.filter((r) => r.count > 0);
-	const inactiveReactions = reactions.filter((r) => r.count === 0);
+	// Show all 6 ghost buttons when data not loaded; only zero-count ones after load
+	const ghostReactions = interactions
+		? reactions.filter((r) => r.count === 0)
+		: REACTION_EMOJIS.map((emoji) => ({ emoji, count: 0, hasReacted: false }));
 
 	return (
-		<div className="pt-3 mt-3 border-t border-border/50">
+		<div
+			className="pt-3 mt-3 border-t border-border/50"
+			onMouseEnter={() => setFetchEnabled(true)}
+		>
 			{/* Reaction row */}
 			<div className="flex flex-wrap items-center gap-1.5">
-				{/* Active reactions first */}
+				{/* Active reactions with counts */}
 				{activeReactions.map((r) => (
 					<button
 						key={r.emoji}
@@ -126,8 +139,8 @@ export function CardInteractionBar({
 					</button>
 				))}
 
-				{/* Inactive emojis as small ghost buttons */}
-				{inactiveReactions.map((r) => (
+				{/* Ghost buttons for zero-count emojis */}
+				{ghostReactions.map((r) => (
 					<button
 						key={r.emoji}
 						type="button"
@@ -142,7 +155,7 @@ export function CardInteractionBar({
 				{/* Comment toggle */}
 				<button
 					type="button"
-					onClick={() => setShowComments((v) => !v)}
+					onClick={handleCommentToggle}
 					className={cn(
 						"ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-colors",
 						showComments

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { MessageCircle, ChevronDown, ChevronUp } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import {
+	REACTION_EMOJIS,
+	type CardInteractions,
+	type CardComment,
+} from "@/lib/recognition";
+import { toggleReactionAction } from "@/lib/actions/interaction-actions";
+import { CommentThread } from "./comment-thread";
+
+interface CardInteractionBarProps {
+	cardId: string;
+	currentUserId: string;
+	isAdmin: boolean;
+}
+
+export function CardInteractionBar({
+	cardId,
+	currentUserId,
+	isAdmin,
+}: CardInteractionBarProps) {
+	const queryClient = useQueryClient();
+	const [showComments, setShowComments] = useState(false);
+
+	const { data, isLoading } = useQuery<{ success: boolean; data: CardInteractions }>({
+		queryKey: ["card-interactions", cardId],
+		queryFn: async () => {
+			const res = await fetch(`/api/recognition/${cardId}/interactions`);
+			if (!res.ok) throw new Error("Failed to fetch interactions");
+			return res.json();
+		},
+		staleTime: 30_000,
+	});
+
+	const interactions = data?.data;
+
+	function handleReaction(emoji: string) {
+		const current = interactions;
+		if (!current) return;
+
+		// Optimistic update
+		queryClient.setQueryData<{ success: boolean; data: CardInteractions }>(
+			["card-interactions", cardId],
+			(old) => {
+				if (!old?.data) return old;
+				const reactions = old.data.reactions.map((r) => {
+					if (r.emoji !== emoji) return r;
+					const adding = !r.hasReacted;
+					return {
+						...r,
+						count: adding ? r.count + 1 : r.count - 1,
+						hasReacted: adding,
+					};
+				});
+				return { ...old, data: { ...old.data, reactions } };
+			},
+		);
+
+		toggleReactionAction(cardId, emoji).then((result) => {
+			if (!result.success) {
+				// Revert on failure
+				queryClient.invalidateQueries({ queryKey: ["card-interactions", cardId] });
+				toast.error(result.error);
+			}
+		});
+	}
+
+	function handleCommentsChange(comments: CardComment[]) {
+		queryClient.setQueryData<{ success: boolean; data: CardInteractions }>(
+			["card-interactions", cardId],
+			(old) => {
+				if (!old?.data) return old;
+				return {
+					...old,
+					data: { ...old.data, comments, totalComments: comments.length },
+				};
+			},
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div className="flex gap-1.5 pt-3 mt-3 border-t border-border/50">
+				{REACTION_EMOJIS.map((emoji) => (
+					<div
+						key={emoji}
+						className="h-7 w-10 rounded-full bg-muted/60 animate-pulse"
+					/>
+				))}
+			</div>
+		);
+	}
+
+	const reactions = interactions?.reactions ?? [];
+	const comments = interactions?.comments ?? [];
+	const totalComments = interactions?.totalComments ?? 0;
+
+	const activeReactions = reactions.filter((r) => r.count > 0);
+	const inactiveReactions = reactions.filter((r) => r.count === 0);
+
+	return (
+		<div className="pt-3 mt-3 border-t border-border/50">
+			{/* Reaction row */}
+			<div className="flex flex-wrap items-center gap-1.5">
+				{/* Active reactions first */}
+				{activeReactions.map((r) => (
+					<button
+						key={r.emoji}
+						type="button"
+						onClick={() => handleReaction(r.emoji)}
+						className={cn(
+							"inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-sm transition-all",
+							r.hasReacted
+								? "bg-primary/15 ring-1 ring-primary/40 text-foreground font-medium"
+								: "bg-muted/60 dark:bg-white/5 text-foreground/80 hover:bg-muted dark:hover:bg-white/10",
+						)}
+						aria-label={`React with ${r.emoji} (${r.count})`}
+					>
+						<span>{r.emoji}</span>
+						<span className="text-xs tabular-nums">{r.count}</span>
+					</button>
+				))}
+
+				{/* Inactive emojis as small ghost buttons */}
+				{inactiveReactions.map((r) => (
+					<button
+						key={r.emoji}
+						type="button"
+						onClick={() => handleReaction(r.emoji)}
+						className="inline-flex items-center justify-center rounded-full w-7 h-7 text-sm bg-muted/40 dark:bg-white/5 hover:bg-muted dark:hover:bg-white/10 transition-colors opacity-60 hover:opacity-100"
+						aria-label={`React with ${r.emoji}`}
+					>
+						{r.emoji}
+					</button>
+				))}
+
+				{/* Comment toggle */}
+				<button
+					type="button"
+					onClick={() => setShowComments((v) => !v)}
+					className={cn(
+						"ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-colors",
+						showComments
+							? "bg-muted text-foreground"
+							: "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+					)}
+					aria-label="Toggle comments"
+				>
+					<MessageCircle size={13} />
+					<span>
+						{totalComments > 0
+							? `${totalComments} comment${totalComments !== 1 ? "s" : ""}`
+							: "Comment"}
+					</span>
+					{totalComments > 0 &&
+						(showComments ? <ChevronUp size={12} /> : <ChevronDown size={12} />)}
+				</button>
+			</div>
+
+			{/* Comment thread */}
+			{showComments && (
+				<CommentThread
+					cardId={cardId}
+					comments={comments}
+					currentUserId={currentUserId}
+					isAdmin={isAdmin}
+					onCommentsChange={handleCommentsChange}
+				/>
+			)}
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -90,7 +90,8 @@ export function CardInteractionBar({
 		setShowComments((v) => !v);
 	}
 
-	function handleCommentsChange(comments: CardComment[]) {
+	async function handleCommentsChange(comments: CardComment[]) {
+		await queryClient.cancelQueries({ queryKey: ["card-interactions", cardId] });
 		queryClient.setQueryData<{ success: boolean; data: CardInteractions }>(
 			["card-interactions", cardId],
 			(old) => {

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -17,12 +17,14 @@ interface CardInteractionBarProps {
 	cardId: string;
 	currentUserId: string;
 	isAdmin: boolean;
+	initialCommentCount?: number;
 }
 
 export function CardInteractionBar({
 	cardId,
 	currentUserId,
 	isAdmin,
+	initialCommentCount = 0,
 }: CardInteractionBarProps) {
 	const queryClient = useQueryClient();
 	const [showComments, setShowComments] = useState(false);
@@ -120,7 +122,7 @@ export function CardInteractionBar({
 
 	const reactions = interactions?.reactions ?? [];
 	const comments = interactions?.comments ?? [];
-	const totalComments = interactions?.totalComments ?? 0;
+	const totalComments = interactions?.totalComments ?? initialCommentCount;
 
 	const activeReactions = reactions.filter((r) => r.count > 0);
 	// Show all 6 ghost buttons when data not loaded; only zero-count ones after load

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -114,11 +114,10 @@ export function CardInteractionBar({
 					return {
 						success: true,
 						data: {
-							reactions: REACTION_EMOJIS.map((emoji) => ({
-								emoji,
-								count: 0,
-								hasReacted: false,
-							})),
+							reactions: REACTION_EMOJIS.map((emoji) => {
+								const initial = initialReactions?.find((r) => r.emoji === emoji);
+								return initial ?? { emoji, count: 0, hasReacted: false };
+							}),
 							comments,
 							totalComments: comments.length,
 						},

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -94,7 +94,21 @@ export function CardInteractionBar({
 		queryClient.setQueryData<{ success: boolean; data: CardInteractions }>(
 			["card-interactions", cardId],
 			(old) => {
-				if (!old?.data) return old;
+				// Seed cache from scratch if the lazy query hasn't fired yet
+				if (!old?.data) {
+					return {
+						success: true,
+						data: {
+							reactions: REACTION_EMOJIS.map((emoji) => ({
+								emoji,
+								count: 0,
+								hasReacted: false,
+							})),
+							comments,
+							totalComments: comments.length,
+						},
+					};
+				}
 				return {
 					...old,
 					data: { ...old.data, comments, totalComments: comments.length },

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { MessageCircle, ChevronDown, ChevronUp } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -30,6 +30,8 @@ export function CardInteractionBar({
 	const [showComments, setShowComments] = useState(false);
 	// Lazy: only fetch when user first hovers (desktop) or interacts (mobile)
 	const [fetchEnabled, setFetchEnabled] = useState(false);
+	// Track in-flight emoji toggles to prevent double-tap race
+	const pendingToggles = useRef(new Set<string>());
 
 	const { data } = useQuery<{ success: boolean; data: CardInteractions }>({
 		queryKey: ["card-interactions", cardId, currentUserId],
@@ -45,6 +47,10 @@ export function CardInteractionBar({
 	const interactions = data?.data;
 
 	function handleReaction(emoji: string) {
+		// Prevent double-tap race: skip if a toggle for this emoji is already in flight
+		if (pendingToggles.current.has(emoji)) return;
+		pendingToggles.current.add(emoji);
+
 		// Ensure the query is (or will be) active
 		setFetchEnabled(true);
 
@@ -52,6 +58,7 @@ export function CardInteractionBar({
 			// Data not loaded yet — action handles add/remove atomically on server;
 			// invalidate after so the query picks up the new state
 			toggleReactionAction(cardId, emoji).then((result) => {
+				pendingToggles.current.delete(emoji);
 				if (!result.success) {
 					toast.error(result.error);
 				}
@@ -79,6 +86,7 @@ export function CardInteractionBar({
 		);
 
 		toggleReactionAction(cardId, emoji).then((result) => {
+			pendingToggles.current.delete(emoji);
 			if (!result.success) {
 				toast.error(result.error);
 			}
@@ -94,11 +102,13 @@ export function CardInteractionBar({
 
 	async function handleCommentsChange(comments: CardComment[]) {
 		await queryClient.cancelQueries({ queryKey: ["card-interactions", cardId, currentUserId] });
+		let seededFromScratch = false;
 		queryClient.setQueryData<{ success: boolean; data: CardInteractions }>(
 			["card-interactions", cardId, currentUserId],
 			(old) => {
 				// Seed cache from scratch if the lazy query hasn't fired yet
 				if (!old?.data) {
+					seededFromScratch = true;
 					return {
 						success: true,
 						data: {
@@ -118,6 +128,10 @@ export function CardInteractionBar({
 				};
 			},
 		);
+		// Refetch to reconcile pre-existing reactions/comments the seed doesn't know about
+		if (seededFromScratch) {
+			queryClient.invalidateQueries({ queryKey: ["card-interactions", cardId, currentUserId] });
+		}
 	}
 
 	const reactions = interactions?.reactions ?? [];

--- a/app/(dashboard)/dashboard/recognition/_components/comment-thread.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/comment-thread.tsx
@@ -154,7 +154,7 @@ function CommentItem({
 						{comment.updatedAt !== comment.createdAt && " · edited"}
 					</span>
 					{!isEditing && (canEdit || canDelete) && (
-						<div className="flex gap-1 opacity-0 group-hover/comment:opacity-100 transition-opacity">
+						<div className="flex gap-1 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover/comment:opacity-100 transition-opacity">
 							{canEdit && (
 								<button
 									type="button"

--- a/app/(dashboard)/dashboard/recognition/_components/comment-thread.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/comment-thread.tsx
@@ -5,6 +5,7 @@ import { Pencil, Trash2, Check, X } from "lucide-react";
 import { toast } from "sonner";
 import { cn, getInitials } from "@/lib/utils";
 import type { CardComment } from "@/lib/recognition";
+import { useSession } from "@/lib/auth-client";
 import {
 	addCommentAction,
 	editCommentAction,
@@ -43,7 +44,9 @@ function CommentItem({
 }: CommentItemProps) {
 	const [isEditing, setIsEditing] = useState(false);
 	const [editValue, setEditValue] = useState(comment.body);
-	const [isPending, startTransition] = useTransition();
+	const [confirmDelete, setConfirmDelete] = useState(false);
+	const [isEditPending, startEditTransition] = useTransition();
+	const [isDeletePending, startDeleteTransition] = useTransition();
 
 	const isOwner = comment.userId === currentUserId;
 	const canEdit = isOwner;
@@ -54,7 +57,7 @@ function CommentItem({
 			setIsEditing(false);
 			return;
 		}
-		startTransition(async () => {
+		startEditTransition(async () => {
 			const result = await editCommentAction(comment.id, editValue.trim());
 			if (result.success) {
 				onEdit({
@@ -70,7 +73,7 @@ function CommentItem({
 	}
 
 	function handleDelete() {
-		startTransition(async () => {
+		startDeleteTransition(async () => {
 			const result = await deleteCommentAction(comment.id);
 			if (result.success) {
 				onDelete(comment.id);
@@ -104,7 +107,7 @@ function CommentItem({
 								onChange={(e) => setEditValue(e.target.value)}
 								maxLength={500}
 								rows={2}
-								disabled={isPending}
+								disabled={isEditPending}
 								className="flex-1 resize-none text-sm bg-transparent outline-none text-foreground placeholder:text-muted-foreground"
 								// biome-ignore lint/a11y/noAutofocus: intentional focus on edit mode
 								autoFocus
@@ -123,7 +126,7 @@ function CommentItem({
 								<button
 									type="button"
 									onClick={handleSaveEdit}
-									disabled={isPending}
+									disabled={isEditPending}
 									className="rounded-full p-1 text-primary hover:bg-primary/10 transition-colors"
 									aria-label="Save edit"
 								>
@@ -165,14 +168,34 @@ function CommentItem({
 								</button>
 							)}
 							{canDelete && (
-								<button
-									type="button"
-									onClick={handleDelete}
-									disabled={isPending}
-									className="text-[10px] text-muted-foreground hover:text-destructive transition-colors"
-								>
-									<Trash2 size={11} />
-								</button>
+								confirmDelete ? (
+									<span className="inline-flex items-center gap-1">
+										<button
+											type="button"
+											onClick={handleDelete}
+											disabled={isDeletePending}
+											className="text-[10px] text-destructive font-medium transition-colors"
+										>
+											Delete?
+										</button>
+										<button
+											type="button"
+											onClick={() => setConfirmDelete(false)}
+											className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+										>
+											<X size={11} />
+										</button>
+									</span>
+								) : (
+									<button
+										type="button"
+										onClick={() => setConfirmDelete(true)}
+										disabled={isDeletePending}
+										className="text-[10px] text-muted-foreground hover:text-destructive transition-colors"
+									>
+										<Trash2 size={11} />
+									</button>
+								)
 							)}
 						</div>
 					)}
@@ -197,6 +220,7 @@ export function CommentThread({
 	isAdmin,
 	onCommentsChange,
 }: CommentThreadProps) {
+	const { data: session } = useSession();
 	const [input, setInput] = useState("");
 	const [isPending, startTransition] = useTransition();
 
@@ -248,7 +272,9 @@ export function CommentThread({
 			{/* Comment input */}
 			<div className="flex gap-2.5 items-end">
 				<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-[10px] font-semibold">
-					Me
+					{session?.user
+						? getInitials(session.user.firstName, session.user.lastName)
+						: "Me"}
 				</div>
 				<div
 					className={cn(

--- a/app/(dashboard)/dashboard/recognition/_components/comment-thread.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/comment-thread.tsx
@@ -30,7 +30,7 @@ interface CommentItemProps {
 	comment: CardComment;
 	currentUserId: string;
 	isAdmin: boolean;
-	onEdit: (commentId: string, newBody: string) => void;
+	onEdit: (updated: CardComment) => void;
 	onDelete: (commentId: string) => void;
 }
 
@@ -57,7 +57,11 @@ function CommentItem({
 		startTransition(async () => {
 			const result = await editCommentAction(comment.id, editValue.trim());
 			if (result.success) {
-				onEdit(comment.id, editValue.trim());
+				onEdit({
+					...comment,
+					body: result.data.body,
+					updatedAt: result.data.updatedAt.toISOString(),
+				});
 				setIsEditing(false);
 			} else {
 				toast.error(result.error);
@@ -218,9 +222,9 @@ export function CommentThread({
 		});
 	}
 
-	function handleEdit(commentId: string, newBody: string) {
+	function handleEdit(updated: CardComment) {
 		onCommentsChange(
-			comments.map((c) => (c.id === commentId ? { ...c, body: newBody } : c)),
+			comments.map((c) => (c.id === updated.id ? updated : c)),
 		);
 	}
 

--- a/app/(dashboard)/dashboard/recognition/_components/comment-thread.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/comment-thread.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Pencil, Trash2, Check, X } from "lucide-react";
+import { toast } from "sonner";
+import { cn, getInitials } from "@/lib/utils";
+import type { CardComment } from "@/lib/recognition";
+import {
+	addCommentAction,
+	editCommentAction,
+	deleteCommentAction,
+} from "@/lib/actions/interaction-actions";
+
+function timeAgo(dateString: string) {
+	const diff = Date.now() - new Date(dateString).getTime();
+	const minutes = Math.floor(diff / 60_000);
+	if (minutes < 1) return "just now";
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	if (days < 7) return `${days}d ago`;
+	return new Date(dateString).toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+	});
+}
+
+interface CommentItemProps {
+	comment: CardComment;
+	currentUserId: string;
+	isAdmin: boolean;
+	onEdit: (commentId: string, newBody: string) => void;
+	onDelete: (commentId: string) => void;
+}
+
+function CommentItem({
+	comment,
+	currentUserId,
+	isAdmin,
+	onEdit,
+	onDelete,
+}: CommentItemProps) {
+	const [isEditing, setIsEditing] = useState(false);
+	const [editValue, setEditValue] = useState(comment.body);
+	const [isPending, startTransition] = useTransition();
+
+	const isOwner = comment.userId === currentUserId;
+	const canEdit = isOwner;
+	const canDelete = isOwner || isAdmin;
+
+	function handleSaveEdit() {
+		if (!editValue.trim() || editValue.trim() === comment.body) {
+			setIsEditing(false);
+			return;
+		}
+		startTransition(async () => {
+			const result = await editCommentAction(comment.id, editValue.trim());
+			if (result.success) {
+				onEdit(comment.id, editValue.trim());
+				setIsEditing(false);
+			} else {
+				toast.error(result.error);
+			}
+		});
+	}
+
+	function handleDelete() {
+		startTransition(async () => {
+			const result = await deleteCommentAction(comment.id);
+			if (result.success) {
+				onDelete(comment.id);
+			} else {
+				toast.error(result.error);
+			}
+		});
+	}
+
+	return (
+		<div className="flex gap-2.5 group/comment">
+			<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-[10px] font-semibold">
+				{getInitials(comment.user.firstName, comment.user.lastName)}
+			</div>
+			<div className="flex-1 min-w-0">
+				<div className="rounded-2xl rounded-tl-sm bg-muted/60 dark:bg-white/5 px-3 py-2">
+					<div className="flex items-baseline gap-1.5 mb-0.5">
+						<span className="text-xs font-semibold text-foreground">
+							{comment.user.firstName} {comment.user.lastName}
+						</span>
+						{comment.user.position && (
+							<span className="text-[10px] text-muted-foreground truncate">
+								· {comment.user.position}
+							</span>
+						)}
+					</div>
+					{isEditing ? (
+						<div className="flex gap-1.5 items-end">
+							<textarea
+								value={editValue}
+								onChange={(e) => setEditValue(e.target.value)}
+								maxLength={500}
+								rows={2}
+								disabled={isPending}
+								className="flex-1 resize-none text-sm bg-transparent outline-none text-foreground placeholder:text-muted-foreground"
+								// biome-ignore lint/a11y/noAutofocus: intentional focus on edit mode
+								autoFocus
+								onKeyDown={(e) => {
+									if (e.key === "Enter" && !e.shiftKey) {
+										e.preventDefault();
+										handleSaveEdit();
+									}
+									if (e.key === "Escape") {
+										setIsEditing(false);
+										setEditValue(comment.body);
+									}
+								}}
+							/>
+							<div className="flex gap-1 shrink-0">
+								<button
+									type="button"
+									onClick={handleSaveEdit}
+									disabled={isPending}
+									className="rounded-full p-1 text-primary hover:bg-primary/10 transition-colors"
+									aria-label="Save edit"
+								>
+									<Check size={13} />
+								</button>
+								<button
+									type="button"
+									onClick={() => {
+										setIsEditing(false);
+										setEditValue(comment.body);
+									}}
+									className="rounded-full p-1 text-muted-foreground hover:bg-muted transition-colors"
+									aria-label="Cancel edit"
+								>
+									<X size={13} />
+								</button>
+							</div>
+						</div>
+					) : (
+						<p className="text-sm text-foreground/80 leading-relaxed break-words">
+							{comment.body}
+						</p>
+					)}
+				</div>
+				<div className="flex items-center gap-2 mt-0.5 px-1">
+					<span className="text-[10px] text-muted-foreground">
+						{timeAgo(comment.createdAt)}
+						{comment.updatedAt !== comment.createdAt && " · edited"}
+					</span>
+					{!isEditing && (canEdit || canDelete) && (
+						<div className="flex gap-1 opacity-0 group-hover/comment:opacity-100 transition-opacity">
+							{canEdit && (
+								<button
+									type="button"
+									onClick={() => setIsEditing(true)}
+									className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+								>
+									<Pencil size={11} />
+								</button>
+							)}
+							{canDelete && (
+								<button
+									type="button"
+									onClick={handleDelete}
+									disabled={isPending}
+									className="text-[10px] text-muted-foreground hover:text-destructive transition-colors"
+								>
+									<Trash2 size={11} />
+								</button>
+							)}
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface CommentThreadProps {
+	cardId: string;
+	comments: CardComment[];
+	currentUserId: string;
+	isAdmin: boolean;
+	onCommentsChange: (comments: CardComment[]) => void;
+}
+
+export function CommentThread({
+	cardId,
+	comments,
+	currentUserId,
+	isAdmin,
+	onCommentsChange,
+}: CommentThreadProps) {
+	const [input, setInput] = useState("");
+	const [isPending, startTransition] = useTransition();
+
+	function handleSubmit() {
+		const trimmed = input.trim();
+		if (!trimmed) return;
+
+		startTransition(async () => {
+			const result = await addCommentAction(cardId, trimmed);
+			if (result.success) {
+				onCommentsChange([
+					...comments,
+					{
+						...result.data,
+						createdAt: result.data.createdAt.toISOString(),
+						updatedAt: result.data.updatedAt.toISOString(),
+					},
+				]);
+				setInput("");
+			} else {
+				toast.error(result.error);
+			}
+		});
+	}
+
+	function handleEdit(commentId: string, newBody: string) {
+		onCommentsChange(
+			comments.map((c) => (c.id === commentId ? { ...c, body: newBody } : c)),
+		);
+	}
+
+	function handleDelete(commentId: string) {
+		onCommentsChange(comments.filter((c) => c.id !== commentId));
+	}
+
+	return (
+		<div className="space-y-2.5 pt-2">
+			{comments.map((comment) => (
+				<CommentItem
+					key={comment.id}
+					comment={comment}
+					currentUserId={currentUserId}
+					isAdmin={isAdmin}
+					onEdit={handleEdit}
+					onDelete={handleDelete}
+				/>
+			))}
+
+			{/* Comment input */}
+			<div className="flex gap-2.5 items-end">
+				<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-[10px] font-semibold">
+					Me
+				</div>
+				<div
+					className={cn(
+						"flex flex-1 items-end gap-2 rounded-2xl rounded-bl-sm border border-border/60 bg-muted/40 dark:bg-white/5 px-3 py-2 transition-colors",
+						"focus-within:border-primary/40 focus-within:bg-background",
+					)}
+				>
+					<textarea
+						value={input}
+						onChange={(e) => setInput(e.target.value)}
+						placeholder="Write a comment…"
+						maxLength={500}
+						rows={1}
+						disabled={isPending}
+						className="flex-1 resize-none bg-transparent text-sm outline-none text-foreground placeholder:text-muted-foreground leading-relaxed"
+						onKeyDown={(e) => {
+							if (e.key === "Enter" && !e.shiftKey) {
+								e.preventDefault();
+								handleSubmit();
+							}
+						}}
+					/>
+					<button
+						type="button"
+						onClick={handleSubmit}
+						disabled={!input.trim() || isPending}
+						className="shrink-0 rounded-full bg-primary px-3 py-1 text-[11px] font-medium text-primary-foreground disabled:opacity-40 transition-opacity"
+					>
+						Post
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed-client.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed-client.tsx
@@ -7,6 +7,7 @@ import { ShareDialog } from "./share-dialog";
 interface RecognitionFeedClientProps {
 	filter: "received" | "sent";
 	currentUserId: string;
+	isAdmin: boolean;
 	emptyTitle: string;
 	emptyDescription: string;
 }
@@ -14,6 +15,7 @@ interface RecognitionFeedClientProps {
 export function RecognitionFeedClient({
 	filter,
 	currentUserId,
+	isAdmin,
 	emptyTitle,
 	emptyDescription,
 }: RecognitionFeedClientProps) {
@@ -27,6 +29,7 @@ export function RecognitionFeedClient({
 				showTitle={false}
 				showActions
 				currentUserId={currentUserId}
+				isAdmin={isAdmin}
 				emptyTitle={emptyTitle}
 				emptyDescription={emptyDescription}
 				onShare={setShareCardId}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -12,6 +12,7 @@ import {
 import { usePreferencesStore } from "@/stores/use-preferences-store";
 import { useUnreadCardIds } from "@/hooks/use-unread-card-ids";
 import { RecognitionCardMini } from "./recognition-card-mini";
+import { CardInteractionBar } from "./card-interaction-bar";
 
 function CardSkeleton() {
 	return (
@@ -82,6 +83,7 @@ interface RecognitionFeedProps {
 	showTitle?: boolean;
 	showActions?: boolean;
 	currentUserId?: string;
+	isAdmin?: boolean;
 	cardMaxWidth?: string;
 	emptyTitle?: string;
 	emptyDescription?: string;
@@ -92,7 +94,8 @@ export function RecognitionFeed({
 	filter = "all",
 	showTitle = true,
 	showActions = false,
-	currentUserId,
+	currentUserId = "",
+	isAdmin = false,
 	cardMaxWidth,
 	emptyTitle = "No recognition cards yet",
 	emptyDescription = "Be the first to recognize a colleague!",
@@ -176,17 +179,26 @@ export function RecognitionFeed({
 				if (cardView === "physical") {
 					const isNew = filter === "received" && unreadCardIds.has(card.id);
 					return (
-						<div key={card.id} className={cn("group relative", cardMaxWidth)}>
-							<RecognitionCardMini
-								card={card}
-								size={cardSize}
-								isNew={isNew}
-							/>
-							{actions && (
-								<div className="absolute top-3 right-3 z-10">
-									{actions}
-								</div>
-							)}
+						<div key={card.id} className={cn("group relative rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] overflow-hidden", cardMaxWidth)}>
+							<div className="relative">
+								<RecognitionCardMini
+									card={card}
+									size={cardSize}
+									isNew={isNew}
+								/>
+								{actions && (
+									<div className="absolute top-3 right-3 z-10">
+										{actions}
+									</div>
+								)}
+							</div>
+							<div className="px-5 pb-4">
+								<CardInteractionBar
+									cardId={card.id}
+									currentUserId={currentUserId}
+									isAdmin={isAdmin}
+								/>
+							</div>
 						</div>
 					);
 				}
@@ -264,6 +276,12 @@ export function RecognitionFeed({
 								{formatRecognitionDate(card.date)}
 							</span>
 						</div>
+
+						<CardInteractionBar
+							cardId={card.id}
+							currentUserId={currentUserId}
+							isAdmin={isAdmin}
+						/>
 					</div>
 				);
 			})}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -203,6 +203,7 @@ export function RecognitionFeed({
 										cardId={card.id}
 										currentUserId={currentUserId}
 										isAdmin={isAdmin}
+										initialCommentCount={card.interactionCounts.comments}
 									/>
 								</div>
 							)}
@@ -289,6 +290,7 @@ export function RecognitionFeed({
 								cardId={card.id}
 								currentUserId={currentUserId}
 								isAdmin={isAdmin}
+								initialCommentCount={card.interactionCounts.comments}
 							/>
 						)}
 					</div>

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -176,6 +176,11 @@ export function RecognitionFeed({
 					/>
 				) : null;
 
+				const isParticipant =
+					currentUserId === card.sender.id ||
+					currentUserId === card.recipient.id;
+				const canInteract = isParticipant || isAdmin;
+
 				if (cardView === "physical") {
 					const isNew = filter === "received" && unreadCardIds.has(card.id);
 					return (
@@ -192,13 +197,15 @@ export function RecognitionFeed({
 									</div>
 								)}
 							</div>
-							<div className="px-5 pb-4">
-								<CardInteractionBar
-									cardId={card.id}
-									currentUserId={currentUserId}
-									isAdmin={isAdmin}
-								/>
-							</div>
+							{canInteract && (
+								<div className="px-5 pb-4">
+									<CardInteractionBar
+										cardId={card.id}
+										currentUserId={currentUserId}
+										isAdmin={isAdmin}
+									/>
+								</div>
+							)}
 						</div>
 					);
 				}
@@ -277,11 +284,13 @@ export function RecognitionFeed({
 							</span>
 						</div>
 
-						<CardInteractionBar
-							cardId={card.id}
-							currentUserId={currentUserId}
-							isAdmin={isAdmin}
-						/>
+						{canInteract && (
+							<CardInteractionBar
+								cardId={card.id}
+								currentUserId={currentUserId}
+								isAdmin={isAdmin}
+							/>
+						)}
 					</div>
 				);
 			})}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -203,7 +203,8 @@ export function RecognitionFeed({
 										cardId={card.id}
 										currentUserId={currentUserId}
 										isAdmin={isAdmin}
-										initialCommentCount={card.interactionCounts.comments}
+										initialCommentCount={card.interactionCounts?.comments ?? 0}
+										initialReactions={card.reactionSummary}
 									/>
 								</div>
 							)}
@@ -290,7 +291,8 @@ export function RecognitionFeed({
 								cardId={card.id}
 								currentUserId={currentUserId}
 								isAdmin={isAdmin}
-								initialCommentCount={card.interactionCounts.comments}
+								initialCommentCount={card.interactionCounts?.comments ?? 0}
+								initialReactions={card.reactionSummary}
 							/>
 						)}
 					</div>

--- a/app/api/recognition/[cardId]/interactions/route.ts
+++ b/app/api/recognition/[cardId]/interactions/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { getServerSession } from "@/lib/auth-utils";
+import { hasMinRole } from "@/lib/permissions";
 import { REACTION_EMOJIS } from "@/lib/recognition";
+import type { Role } from "@/app/generated/prisma/client";
 
 export async function GET(
 	_req: Request,
@@ -20,13 +22,23 @@ export async function GET(
 
 		const card = await prisma.recognitionCard.findUnique({
 			where: { id: cardId },
-			select: { id: true },
+			select: { id: true, senderId: true, recipientId: true },
 		});
 
 		if (!card) {
 			return NextResponse.json(
 				{ success: false, error: "Card not found" },
 				{ status: 404 },
+			);
+		}
+
+		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+		const isParticipant =
+			card.senderId === session.user.id || card.recipientId === session.user.id;
+		if (!isParticipant && !isAdmin) {
+			return NextResponse.json(
+				{ success: false, error: "Forbidden" },
+				{ status: 403 },
 			);
 		}
 

--- a/app/api/recognition/[cardId]/interactions/route.ts
+++ b/app/api/recognition/[cardId]/interactions/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { getServerSession } from "@/lib/auth-utils";
+import { requireSession } from "@/lib/auth-utils";
 import { hasMinRole } from "@/lib/permissions";
 import { REACTION_EMOJIS } from "@/lib/recognition";
 import type { Role } from "@/app/generated/prisma/client";
@@ -9,15 +9,17 @@ export async function GET(
 	_req: Request,
 	{ params }: { params: Promise<{ cardId: string }> },
 ) {
+	let session: Awaited<ReturnType<typeof requireSession>>;
 	try {
-		const session = await getServerSession();
-		if (!session) {
-			return NextResponse.json(
-				{ success: false, error: "Unauthorized" },
-				{ status: 401 },
-			);
-		}
+		session = await requireSession();
+	} catch {
+		return NextResponse.json(
+			{ success: false, error: "Unauthorized" },
+			{ status: 401 },
+		);
+	}
 
+	try {
 		const { cardId } = await params;
 
 		const card = await prisma.recognitionCard.findUnique({

--- a/app/api/recognition/[cardId]/interactions/route.ts
+++ b/app/api/recognition/[cardId]/interactions/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getServerSession } from "@/lib/auth-utils";
+import { REACTION_EMOJIS } from "@/lib/recognition";
+
+export async function GET(
+	_req: Request,
+	{ params }: { params: Promise<{ cardId: string }> },
+) {
+	try {
+		const session = await getServerSession();
+		if (!session) {
+			return NextResponse.json(
+				{ success: false, error: "Unauthorized" },
+				{ status: 401 },
+			);
+		}
+
+		const { cardId } = await params;
+
+		const card = await prisma.recognitionCard.findUnique({
+			where: { id: cardId },
+			select: { id: true },
+		});
+
+		if (!card) {
+			return NextResponse.json(
+				{ success: false, error: "Card not found" },
+				{ status: 404 },
+			);
+		}
+
+		const [allReactions, comments] = await Promise.all([
+			prisma.cardReaction.findMany({
+				where: { cardId },
+				select: { emoji: true, userId: true },
+			}),
+			prisma.cardComment.findMany({
+				where: { cardId },
+				select: {
+					id: true,
+					body: true,
+					createdAt: true,
+					updatedAt: true,
+					userId: true,
+					user: {
+						select: {
+							id: true,
+							firstName: true,
+							lastName: true,
+							avatar: true,
+							position: true,
+						},
+					},
+				},
+				orderBy: { createdAt: "asc" },
+			}),
+		]);
+
+		const reactionMap = new Map<string, { count: number; hasReacted: boolean }>();
+		for (const emoji of REACTION_EMOJIS) {
+			reactionMap.set(emoji, { count: 0, hasReacted: false });
+		}
+		for (const r of allReactions) {
+			const entry = reactionMap.get(r.emoji);
+			if (entry) {
+				entry.count += 1;
+				if (r.userId === session.user.id) entry.hasReacted = true;
+			}
+		}
+
+		const reactions = Array.from(reactionMap.entries()).map(
+			([emoji, { count, hasReacted }]) => ({ emoji, count, hasReacted }),
+		);
+
+		return NextResponse.json({
+			success: true,
+			data: {
+				reactions,
+				comments,
+				totalComments: comments.length,
+			},
+		});
+	} catch {
+		return NextResponse.json(
+			{ success: false, error: "Failed to fetch interactions" },
+			{ status: 500 },
+		);
+	}
+}

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -189,7 +189,56 @@ export async function GET(request: NextRequest) {
 			take: 50,
 		});
 
-		return Response.json({ success: true, data: cards.map(mapCounts) });
+		const cardIds = cards.map((c) => c.id);
+
+		// Batch fetch per-emoji reaction counts + current user's reactions (2 queries, not N+1)
+		const [reactionCounts, userReactions] = await Promise.all([
+			prisma.cardReaction.groupBy({
+				by: ["cardId", "emoji"],
+				where: { cardId: { in: cardIds } },
+				_count: true,
+			}),
+			prisma.cardReaction.findMany({
+				where: { cardId: { in: cardIds }, userId: session.user.id },
+				select: { cardId: true, emoji: true },
+			}),
+		]);
+
+		const userReactionSet = new Set(
+			userReactions.map((r) => `${r.cardId}:${r.emoji}`),
+		);
+
+		const reactionsByCard = new Map<
+			string,
+			{ emoji: string; count: number; hasReacted: boolean }[]
+		>();
+		for (const rc of reactionCounts) {
+			if (!reactionsByCard.has(rc.cardId)) {
+				reactionsByCard.set(rc.cardId, []);
+			}
+			reactionsByCard.get(rc.cardId)!.push({
+				emoji: rc.emoji,
+				count: rc._count,
+				hasReacted: userReactionSet.has(`${rc.cardId}:${rc.emoji}`),
+			});
+		}
+
+		return Response.json({
+			success: true,
+			data: cards.map((card) => {
+				const mapped = mapCounts(card);
+				const isCardParticipant =
+					card.senderId === session.user.id ||
+					card.recipientId === session.user.id ||
+					isAdmin;
+				return {
+					...mapped,
+					reactionSummary: isCardParticipant
+						? reactionsByCard.get(card.id) ?? []
+						: undefined,
+				};
+			}),
+		});
 	} catch {
 		return Response.json(
 			{ success: false, error: "Internal server error" },

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -68,9 +68,18 @@ export async function GET(request: NextRequest) {
 			},
 		};
 
-		const mapCounts = <T extends { _count: { reactions: number; comments: number } }>(
+		const mapCounts = <T extends { _count: { reactions: number; comments: number }; senderId: string; recipientId: string }>(
 			{ _count, ...card }: T,
-		) => ({ ...card, interactionCounts: _count });
+		) => ({
+			...card,
+			// Only expose interaction counts to participants (sender/recipient/admin)
+			interactionCounts:
+				card.senderId === session.user.id ||
+				card.recipientId === session.user.id ||
+				isAdmin
+					? _count
+					: null,
+		});
 
 		const isExport = request.nextUrl.searchParams.get("export") === "true";
 

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -63,7 +63,14 @@ export async function GET(request: NextRequest) {
 					position: true,
 				},
 			},
+			_count: {
+				select: { reactions: true, comments: true },
+			},
 		};
+
+		const mapCounts = <T extends { _count: { reactions: number; comments: number } }>(
+			{ _count, ...card }: T,
+		) => ({ ...card, interactionCounts: _count });
 
 		const isExport = request.nextUrl.searchParams.get("export") === "true";
 
@@ -156,7 +163,7 @@ export async function GET(request: NextRequest) {
 
 			return Response.json({
 				success: true,
-				data: cards,
+				data: cards.map(mapCounts),
 				pagination: {
 					page,
 					pageSize,
@@ -173,7 +180,7 @@ export async function GET(request: NextRequest) {
 			take: 50,
 		});
 
-		return Response.json({ success: true, data: cards });
+		return Response.json({ success: true, data: cards.map(mapCounts) });
 	} catch {
 		return Response.json(
 			{ success: false, error: "Internal server error" },

--- a/lib/actions/interaction-actions.ts
+++ b/lib/actions/interaction-actions.ts
@@ -43,25 +43,35 @@ export async function toggleReactionAction(cardId: string, emoji: string) {
 			return { success: false as const, error: "Forbidden" };
 		}
 
-		const existing = await prisma.cardReaction.findUnique({
-			where: {
-				cardId_userId_emoji: {
-					cardId,
-					userId: session.user.id,
-					emoji,
-				},
-			},
+		// Atomic toggle: attempt delete first, then create if nothing was removed.
+		// Catches unique constraint (P2002) from concurrent double-taps.
+		const deleted = await prisma.cardReaction.deleteMany({
+			where: { cardId, userId: session.user.id, emoji },
 		});
 
-		if (existing) {
-			await prisma.cardReaction.delete({ where: { id: existing.id } });
+		if (deleted.count > 0) {
 			return { success: true as const, action: "removed" as const };
 		}
 
-		await prisma.cardReaction.create({
-			data: { cardId, userId: session.user.id, emoji },
-		});
-		return { success: true as const, action: "added" as const };
+		try {
+			await prisma.cardReaction.create({
+				data: { cardId, userId: session.user.id, emoji },
+			});
+			return { success: true as const, action: "added" as const };
+		} catch (err) {
+			// Concurrent toggle already created it — treat as remove
+			if (
+				err instanceof Error &&
+				"code" in err &&
+				(err as { code: string }).code === "P2002"
+			) {
+				await prisma.cardReaction.deleteMany({
+					where: { cardId, userId: session.user.id, emoji },
+				});
+				return { success: true as const, action: "removed" as const };
+			}
+			throw err;
+		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "Failed to update reaction";
 		return { success: false as const, error: message };
@@ -128,12 +138,24 @@ export async function editCommentAction(commentId: string, body: string) {
 
 		const comment = await prisma.cardComment.findUnique({
 			where: { id: commentId },
-			select: { userId: true },
+			select: {
+				userId: true,
+				card: { select: { senderId: true, recipientId: true } },
+			},
 		});
 
 		if (!comment) {
 			return { success: false as const, error: "Comment not found" };
 		}
+
+		const isEditAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+		const isEditParticipant =
+			comment.card.senderId === session.user.id ||
+			comment.card.recipientId === session.user.id;
+		if (!isEditParticipant && !isEditAdmin) {
+			return { success: false as const, error: "Forbidden" };
+		}
+
 		if (comment.userId !== session.user.id) {
 			return { success: false as const, error: "You can only edit your own comments" };
 		}
@@ -172,7 +194,10 @@ export async function deleteCommentAction(commentId: string) {
 
 		const comment = await prisma.cardComment.findUnique({
 			where: { id: commentId },
-			select: { userId: true },
+			select: {
+				userId: true,
+				card: { select: { senderId: true, recipientId: true } },
+			},
 		});
 
 		if (!comment) {
@@ -180,6 +205,13 @@ export async function deleteCommentAction(commentId: string) {
 		}
 
 		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+		const isDeleteParticipant =
+			comment.card.senderId === session.user.id ||
+			comment.card.recipientId === session.user.id;
+		if (!isDeleteParticipant && !isAdmin) {
+			return { success: false as const, error: "Forbidden" };
+		}
+
 		if (comment.userId !== session.user.id && !isAdmin) {
 			return { success: false as const, error: "Not allowed" };
 		}

--- a/lib/actions/interaction-actions.ts
+++ b/lib/actions/interaction-actions.ts
@@ -1,0 +1,179 @@
+"use server";
+
+import { prisma } from "@/lib/db";
+import { requireSession } from "@/lib/auth-utils";
+import { hasMinRole } from "@/lib/permissions";
+import { REACTION_EMOJIS } from "@/lib/recognition";
+import type { Role } from "@/app/generated/prisma/client";
+import { z } from "zod";
+
+const reactionSchema = z.object({
+	cardId: z.string().min(1),
+	emoji: z.string().refine((e) => (REACTION_EMOJIS as readonly string[]).includes(e), {
+		message: "Invalid emoji",
+	}),
+});
+
+const commentBodySchema = z
+	.string()
+	.min(1, "Comment cannot be empty")
+	.max(500, "Comment cannot exceed 500 characters")
+	.trim();
+
+export async function toggleReactionAction(cardId: string, emoji: string) {
+	try {
+		const session = await requireSession();
+		const parsed = reactionSchema.safeParse({ cardId, emoji });
+		if (!parsed.success) {
+			return { success: false as const, error: "Invalid input" };
+		}
+
+		const card = await prisma.recognitionCard.findUnique({
+			where: { id: cardId },
+			select: { id: true },
+		});
+		if (!card) {
+			return { success: false as const, error: "Card not found" };
+		}
+
+		const existing = await prisma.cardReaction.findUnique({
+			where: {
+				cardId_userId_emoji: {
+					cardId,
+					userId: session.user.id,
+					emoji,
+				},
+			},
+		});
+
+		if (existing) {
+			await prisma.cardReaction.delete({ where: { id: existing.id } });
+			return { success: true as const, action: "removed" as const };
+		}
+
+		await prisma.cardReaction.create({
+			data: { cardId, userId: session.user.id, emoji },
+		});
+		return { success: true as const, action: "added" as const };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to update reaction";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function addCommentAction(cardId: string, body: string) {
+	try {
+		const session = await requireSession();
+		const parsedBody = commentBodySchema.safeParse(body);
+		if (!parsedBody.success) {
+			return { success: false as const, error: parsedBody.error.issues[0].message };
+		}
+
+		const card = await prisma.recognitionCard.findUnique({
+			where: { id: cardId },
+			select: { id: true },
+		});
+		if (!card) {
+			return { success: false as const, error: "Card not found" };
+		}
+
+		const comment = await prisma.cardComment.create({
+			data: { cardId, userId: session.user.id, body: parsedBody.data },
+			select: {
+				id: true,
+				body: true,
+				createdAt: true,
+				updatedAt: true,
+				userId: true,
+				user: {
+					select: {
+						id: true,
+						firstName: true,
+						lastName: true,
+						avatar: true,
+						position: true,
+					},
+				},
+			},
+		});
+
+		return { success: true as const, data: comment };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to add comment";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function editCommentAction(commentId: string, body: string) {
+	try {
+		const session = await requireSession();
+		const parsedBody = commentBodySchema.safeParse(body);
+		if (!parsedBody.success) {
+			return { success: false as const, error: parsedBody.error.issues[0].message };
+		}
+
+		const comment = await prisma.cardComment.findUnique({
+			where: { id: commentId },
+			select: { userId: true },
+		});
+
+		if (!comment) {
+			return { success: false as const, error: "Comment not found" };
+		}
+		if (comment.userId !== session.user.id) {
+			return { success: false as const, error: "You can only edit your own comments" };
+		}
+
+		const updated = await prisma.cardComment.update({
+			where: { id: commentId },
+			data: { body: parsedBody.data },
+			select: {
+				id: true,
+				body: true,
+				createdAt: true,
+				updatedAt: true,
+				userId: true,
+				user: {
+					select: {
+						id: true,
+						firstName: true,
+						lastName: true,
+						avatar: true,
+						position: true,
+					},
+				},
+			},
+		});
+
+		return { success: true as const, data: updated };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to edit comment";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function deleteCommentAction(commentId: string) {
+	try {
+		const session = await requireSession();
+
+		const comment = await prisma.cardComment.findUnique({
+			where: { id: commentId },
+			select: { userId: true },
+		});
+
+		if (!comment) {
+			return { success: false as const, error: "Comment not found" };
+		}
+
+		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+		if (comment.userId !== session.user.id && !isAdmin) {
+			return { success: false as const, error: "Not allowed" };
+		}
+
+		await prisma.cardComment.delete({ where: { id: commentId } });
+		return { success: true as const };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to delete comment";
+		return { success: false as const, error: message };
+	}
+}

--- a/lib/actions/interaction-actions.ts
+++ b/lib/actions/interaction-actions.ts
@@ -30,10 +30,17 @@ export async function toggleReactionAction(cardId: string, emoji: string) {
 
 		const card = await prisma.recognitionCard.findUnique({
 			where: { id: cardId },
-			select: { id: true },
+			select: { id: true, senderId: true, recipientId: true },
 		});
 		if (!card) {
 			return { success: false as const, error: "Card not found" };
+		}
+
+		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+		const isParticipant =
+			card.senderId === session.user.id || card.recipientId === session.user.id;
+		if (!isParticipant && !isAdmin) {
+			return { success: false as const, error: "Forbidden" };
 		}
 
 		const existing = await prisma.cardReaction.findUnique({
@@ -71,10 +78,17 @@ export async function addCommentAction(cardId: string, body: string) {
 
 		const card = await prisma.recognitionCard.findUnique({
 			where: { id: cardId },
-			select: { id: true },
+			select: { id: true, senderId: true, recipientId: true },
 		});
 		if (!card) {
 			return { success: false as const, error: "Card not found" };
+		}
+
+		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+		const isParticipant =
+			card.senderId === session.user.id || card.recipientId === session.user.id;
+		if (!isParticipant && !isAdmin) {
+			return { success: false as const, error: "Forbidden" };
 		}
 
 		const comment = await prisma.cardComment.create({

--- a/lib/recognition.ts
+++ b/lib/recognition.ts
@@ -50,7 +50,8 @@ export interface RecognitionCard {
 	valuesRespect: boolean;
 	valuesCommunication: boolean;
 	valuesContinuousImprovement: boolean;
-	interactionCounts: { reactions: number; comments: number };
+	interactionCounts: { reactions: number; comments: number } | null;
+	reactionSummary?: { emoji: string; count: number; hasReacted: boolean }[];
 }
 
 export const COMPANY_VALUES = [

--- a/lib/recognition.ts
+++ b/lib/recognition.ts
@@ -1,3 +1,35 @@
+export const REACTION_EMOJIS = ["👏", "❤️", "🔥", "🎉", "💪", "😊"] as const;
+export type ReactionEmoji = (typeof REACTION_EMOJIS)[number];
+
+export interface CardReactionSummary {
+	emoji: string;
+	count: number;
+	hasReacted: boolean;
+}
+
+export interface CardCommentUser {
+	id: string;
+	firstName: string;
+	lastName: string;
+	avatar: string | null;
+	position: string | null;
+}
+
+export interface CardComment {
+	id: string;
+	body: string;
+	createdAt: string;
+	updatedAt: string;
+	userId: string;
+	user: CardCommentUser;
+}
+
+export interface CardInteractions {
+	reactions: CardReactionSummary[];
+	comments: CardComment[];
+	totalComments: number;
+}
+
 export interface RecognitionUser {
 	id: string;
 	firstName: string;

--- a/lib/recognition.ts
+++ b/lib/recognition.ts
@@ -50,6 +50,7 @@ export interface RecognitionCard {
 	valuesRespect: boolean;
 	valuesCommunication: boolean;
 	valuesContinuousImprovement: boolean;
+	interactionCounts: { reactions: number; comments: number };
 }
 
 export const COMPANY_VALUES = [

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,8 @@ model User {
   sentRecognitions     RecognitionCard[] @relation("sender")
   receivedRecognitions RecognitionCard[] @relation("recipient")
   notifications        Notification[]
+  cardReactions        CardReaction[]
+  cardComments         CardComment[]
 
   @@map("users")
 }
@@ -138,8 +140,40 @@ model RecognitionCard {
   valuesContinuousImprovement Boolean @default(false) @map("values_continuous_improvement")
 
   notifications Notification[]
+  reactions     CardReaction[]
+  comments      CardComment[]
 
   @@map("recognition_cards")
+}
+
+model CardReaction {
+  id        String   @id @default(uuid())
+  emoji     String
+  createdAt DateTime @default(now()) @map("created_at")
+
+  cardId String          @map("card_id")
+  card   RecognitionCard @relation(fields: [cardId], references: [id], onDelete: Cascade)
+  userId String          @map("user_id")
+  user   User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([cardId, userId, emoji])
+  @@index([cardId])
+  @@map("card_reactions")
+}
+
+model CardComment {
+  id        String   @id @default(uuid())
+  body      String
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  cardId String          @map("card_id")
+  card   RecognitionCard @relation(fields: [cardId], references: [id], onDelete: Cascade)
+  userId String          @map("user_id")
+  user   User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([cardId, createdAt])
+  @@map("card_comments")
 }
 
 model Notification {


### PR DESCRIPTION
Closes #19

## Summary
- Fixed emoji reactions (👏 ❤️ 🔥 🎉 💪 😊) on every recognition card with optimistic UI updates
- Collapsible comment thread per card — collapsed by default, expandable inline
- Comment authors + ADMIN+ can delete comments; authors can edit their own

## Changes

### Schema
- `CardReaction` model — unique constraint per `(cardId, userId, emoji)`, cascade delete
- `CardComment` model — indexed by `(cardId, createdAt)`, cascade delete

### API
- `GET /api/recognition/[cardId]/interactions` — returns reactions grouped with counts + `hasReacted` flag, and full comment thread

### Server Actions (`lib/actions/interaction-actions.ts`)
- `toggleReactionAction` — upsert/remove reaction (validated against fixed emoji set)
- `addCommentAction` / `editCommentAction` / `deleteCommentAction` — author-only edit, author+ADMIN delete

### UI Components
- `CardInteractionBar` — reaction pills with counts, ghost buttons for zero-count emojis, comment count toggle; React Query with optimistic reaction updates
- `CommentThread` — chronological comment list with add/edit/delete, inline edit mode, `timeAgo` timestamps

### Wired into
- Dashboard recognition feed (both digital + physical card views)
- Received and Sent inbox pages

## Test plan
- [ ] React to a card with each of the 6 emojis — count increments, pill highlights
- [ ] Click a highlighted emoji again — reaction removed, count decrements
- [ ] Open comments, post a comment — appears immediately
- [ ] Edit own comment — inline edit with Enter to save, Esc to cancel
- [ ] Delete own comment — disappears immediately
- [ ] As ADMIN, delete another user's comment
- [ ] As STAFF, confirm delete button is not shown on others' comments
- [ ] Verify both physical card and digital card views show the interaction bar
- [ ] Verify on mobile layout