### PR TITLE
feat(recognition): configurable Most Recognized limit in admin settings

### DIFF
--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -1,8 +1,33 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Send, Inbox, Calendar, Trophy } from "lucide-react";
+import { Send, Inbox, Calendar, Trophy, Medal } from "lucide-react";
 import { getInitials } from "@/lib/utils";
+import { cn } from "@/lib/utils";
+
+const PODIUM_STYLES = [
+	{
+		ring: "ring-2 ring-amber-400/60",
+		bg: "bg-amber-50 dark:bg-amber-400/15",
+		text: "text-amber-600 dark:text-amber-400",
+		medal: "text-amber-500",
+		countBg: "bg-amber-50 dark:bg-amber-400/10 text-amber-600 dark:text-amber-400",
+	},
+	{
+		ring: "ring-2 ring-gray-300/80 dark:ring-gray-400/40",
+		bg: "bg-gray-100 dark:bg-gray-400/15",
+		text: "text-gray-500 dark:text-gray-300",
+		medal: "text-gray-400 dark:text-gray-300",
+		countBg: "bg-gray-100 dark:bg-gray-400/10 text-gray-500 dark:text-gray-300",
+	},
+	{
+		ring: "ring-2 ring-orange-400/50 dark:ring-orange-500/40",
+		bg: "bg-orange-50 dark:bg-orange-400/15",
+		text: "text-orange-600 dark:text-orange-400",
+		medal: "text-orange-500 dark:text-orange-400",
+		countBg: "bg-orange-50 dark:bg-orange-400/10 text-orange-600 dark:text-orange-400",
+	},
+] as const;
 
 interface StatsData {
 	sent: number;
@@ -131,29 +156,67 @@ export function StatsWidget() {
 							Most Recognized
 						</h4>
 					</div>
-					<ol className="space-y-3 max-h-80 overflow-y-auto pr-1">
-						{stats.topRecipients.map((person, index) => (
-							<li
-								key={`${person.firstName}-${person.lastName}`}
-								className="flex items-center gap-3"
-							>
-								<span className="w-5 text-xs font-semibold text-muted-foreground text-right shrink-0">
-									{index + 1}
-								</span>
-								<div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold shrink-0">
-									{getInitials(
-										person.firstName,
-										person.lastName,
+					<ol className="space-y-2 max-h-80 overflow-y-auto pr-1">
+						{stats.topRecipients.map((person, index) => {
+							const isPodium = index < 3;
+							const style = isPodium ? PODIUM_STYLES[index] : null;
+
+							return (
+								<li
+									key={`${person.firstName}-${person.lastName}`}
+									className={cn(
+										"flex items-center gap-3 rounded-xl px-3 py-2.5 transition-colors",
+										isPodium
+											? "bg-card border border-gray-200/60 dark:border-white/10 shadow-sm"
+											: "px-3 py-2",
 									)}
-								</div>
-								<span className="text-sm font-medium text-foreground flex-1 truncate">
-									{person.firstName} {person.lastName}
-								</span>
-								<span className="text-sm font-semibold text-primary shrink-0">
-									{person.count}
-								</span>
-							</li>
-						))}
+								>
+									{isPodium ? (
+										<Medal
+											size={18}
+											className={cn("shrink-0", style?.medal)}
+										/>
+									) : (
+										<span className="w-[18px] text-xs font-semibold text-muted-foreground text-center shrink-0">
+											{index + 1}
+										</span>
+									)}
+									<div
+										className={cn(
+											"flex items-center justify-center rounded-full text-xs font-semibold shrink-0",
+											isPodium
+												? cn("h-9 w-9", style?.ring, style?.bg, style?.text)
+												: "h-8 w-8 bg-primary/10 text-primary",
+										)}
+									>
+										{getInitials(
+											person.firstName,
+											person.lastName,
+										)}
+									</div>
+									<span
+										className={cn(
+											"flex-1 truncate",
+											isPodium
+												? "text-sm font-semibold text-foreground"
+												: "text-sm font-medium text-foreground",
+										)}
+									>
+										{person.firstName} {person.lastName}
+									</span>
+									<span
+										className={cn(
+											"shrink-0 text-sm font-bold tabular-nums",
+											isPodium
+												? cn("rounded-full px-2.5 py-0.5", style?.countBg)
+												: "text-primary",
+										)}
+									>
+										{person.count}
+									</span>
+								</li>
+							);
+						})}
 					</ol>
 				</div>
 			)}

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -131,22 +131,25 @@ export function StatsWidget() {
 							Most Recognized
 						</h4>
 					</div>
-					<ol className="space-y-3">
-						{stats.topRecipients.map((person) => (
+					<ol className="space-y-3 max-h-80 overflow-y-auto pr-1">
+						{stats.topRecipients.map((person, index) => (
 							<li
 								key={`${person.firstName}-${person.lastName}`}
 								className="flex items-center gap-3"
 							>
-								<div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold">
+								<span className="w-5 text-xs font-semibold text-muted-foreground text-right shrink-0">
+									{index + 1}
+								</span>
+								<div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-semibold shrink-0">
 									{getInitials(
 										person.firstName,
 										person.lastName,
 									)}
 								</div>
-								<span className="text-sm font-medium text-foreground flex-1">
+								<span className="text-sm font-medium text-foreground flex-1 truncate">
 									{person.firstName} {person.lastName}
 								</span>
-								<span className="text-sm font-semibold text-primary">
+								<span className="text-sm font-semibold text-primary shrink-0">
 									{person.count}
 								</span>
 							</li>

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -66,7 +66,7 @@ function StatItem({
 
 function StatsWidgetSkeleton() {
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] animate-pulse space-y-6" aria-busy="true" aria-label="Loading recognition stats">
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] animate-pulse space-y-6 h-full" aria-busy="true" aria-label="Loading recognition stats">
 			<div className="h-5 w-32 bg-gray-200 dark:bg-white/10 rounded" />
 			<div className="grid grid-cols-3 gap-4">
 				{[1, 2, 3].map((i) => (
@@ -111,7 +111,7 @@ export function StatsWidget() {
 
 	if (isError || !data?.data) {
 		return (
-			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] h-full">
 				<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight mb-2">
 					Recognition Stats
 				</h3>
@@ -125,12 +125,12 @@ export function StatsWidget() {
 	const stats = data.data;
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] space-y-6">
-			<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight">
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] flex flex-col gap-6 h-full">
+			<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight shrink-0">
 				Recognition Stats
 			</h3>
 
-			<div className="grid grid-cols-3 gap-4">
+			<div className="grid grid-cols-3 gap-4 shrink-0">
 				<StatItem
 					icon={Send}
 					label="Cards Sent"
@@ -149,14 +149,14 @@ export function StatsWidget() {
 			</div>
 
 			{stats?.topRecipients && stats.topRecipients.length > 0 && (
-				<div>
-					<div className="flex items-center gap-2 mb-3">
+				<div className="flex flex-col min-h-0 flex-1">
+					<div className="flex items-center gap-2 mb-3 shrink-0">
 						<Trophy size={16} className="text-primary" />
 						<h4 className="text-sm font-medium text-foreground/70">
 							Most Recognized
 						</h4>
 					</div>
-					<ol className="space-y-2 max-h-80 overflow-y-auto pr-1">
+					<ol className="space-y-2 overflow-y-auto pr-1 flex-1 min-h-0">
 						{stats.topRecipients.map((person, index) => {
 							const isPodium = index < 3;
 							const style = isPodium ? PODIUM_STYLES[index] : null;

--- a/app/(dashboard)/dashboard/admin-settings/_components/recognition-settings.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/recognition-settings.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { updateTopRecognizedLimit } from "@/lib/actions/settings-actions";
+
+const LIMIT_OPTIONS = [1, 3, 5, 10, 15, 20, 25, 30, 40, 50];
+
+export function RecognitionSettingsPanel({
+	initialLimit,
+}: {
+	initialLimit: number;
+}) {
+	const [limit, setLimit] = useState(initialLimit);
+	const [isPending, startTransition] = useTransition();
+
+	function handleChange(newValue: number) {
+		const previous = limit;
+		setLimit(newValue);
+
+		startTransition(async () => {
+			const result = await updateTopRecognizedLimit(newValue);
+			if (!result.success) {
+				setLimit(previous);
+				toast.error(result.error ?? "Failed to update setting");
+			} else {
+				toast.success(`Most Recognized limit updated to ${newValue}`);
+			}
+		});
+	}
+
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
+			<div className="px-8 pt-8 pb-2">
+				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
+					Recognition Settings
+				</h3>
+				<p className="mt-2 text-sm text-muted-foreground">
+					Configure how recognition stats are displayed on the dashboard.
+				</p>
+			</div>
+
+			<div className="px-8 py-6">
+				<div className="flex items-center justify-between rounded-2xl border border-gray-200 dark:border-white/10 p-5">
+					<div>
+						<p className="text-sm font-medium text-foreground">
+							Most Recognized Limit
+						</p>
+						<p className="text-xs text-muted-foreground">
+							Number of top recipients shown in the dashboard stats
+							widget.
+						</p>
+					</div>
+
+					<Select
+						value={limit}
+						onValueChange={(val) => {
+							if (val !== null) handleChange(val);
+						}}
+						disabled={isPending}
+					>
+						<SelectTrigger className="w-20">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{LIMIT_OPTIONS.map((opt) => (
+								<SelectItem key={opt} value={opt}>
+									{opt}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/_components/recognition-settings.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/recognition-settings.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	Select,
 	SelectContent,
@@ -20,18 +21,25 @@ export function RecognitionSettingsPanel({
 }) {
 	const [limit, setLimit] = useState(initialLimit);
 	const [isPending, startTransition] = useTransition();
+	const queryClient = useQueryClient();
 
 	function handleChange(newValue: number) {
 		const previous = limit;
 		setLimit(newValue);
 
 		startTransition(async () => {
-			const result = await updateTopRecognizedLimit(newValue);
-			if (!result.success) {
+			try {
+				const result = await updateTopRecognizedLimit(newValue);
+				if (!result.success) {
+					setLimit(previous);
+					toast.error(result.error ?? "Failed to update setting");
+				} else {
+					toast.success(`Most Recognized limit updated to ${newValue}`);
+					queryClient.invalidateQueries({ queryKey: ["recognition-stats"] });
+				}
+			} catch {
 				setLimit(previous);
-				toast.error(result.error ?? "Failed to update setting");
-			} else {
-				toast.success(`Most Recognized limit updated to ${newValue}`);
+				toast.error("Failed to update setting");
 			}
 		});
 	}

--- a/app/(dashboard)/dashboard/admin-settings/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/page.tsx
@@ -1,6 +1,7 @@
 import { requireRole } from "@/lib/auth-utils";
 import { redirect } from "next/navigation";
-import { Settings } from "lucide-react";
+import { getTopRecognizedLimit } from "@/lib/actions/settings-actions";
+import { RecognitionSettingsPanel } from "./_components/recognition-settings";
 
 export default async function AdminSettingsPage() {
 	try {
@@ -8,6 +9,8 @@ export default async function AdminSettingsPage() {
 	} catch {
 		redirect("/dashboard");
 	}
+
+	const topLimit = await getTopRecognizedLimit();
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-8 mt-2">
@@ -19,20 +22,8 @@ export default async function AdminSettingsPage() {
 					Manage application settings and configurations.
 				</p>
 			</div>
-			<div className="flex flex-col items-center justify-center rounded-[2rem] border border-gray-200 dark:border-white/10 bg-card p-16 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
-				<div className="mb-6 rounded-full bg-background p-6">
-					<Settings
-						size={48}
-						className="text-muted-foreground opacity-40"
-					/>
-				</div>
-				<p className="text-[1.5rem] font-medium text-foreground">
-					Admin settings coming soon
-				</p>
-				<p className="mt-2 text-base text-muted-foreground">
-					Application configuration options will appear here.
-				</p>
-			</div>
+
+			<RecognitionSettingsPanel initialLimit={topLimit} />
 		</div>
 	);
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -8,11 +8,11 @@ export default async function DashboardLayout({ children }: { children: React.Re
 	if (!session) redirect("/login");
 
 	return (
-		<div className="flex h-screen overflow-hidden bg-background">
+		<div className="flex min-h-screen bg-background">
 			<DashboardSidebar />
-			<div className="flex flex-1 flex-col overflow-hidden bg-card sm:my-2 sm:mr-2 sm:rounded-l-[2rem] shadow-sm border border-gray-100 dark:border-white/5">
+			<div className="flex flex-1 flex-col bg-card sm:my-2 sm:mr-2 sm:rounded-l-[2rem] shadow-sm border border-gray-100 dark:border-white/5">
 				<DashboardHeader />
-				<main className="flex-1 overflow-y-auto px-4 pb-8 sm:px-8">
+				<main className="flex-1 px-4 pb-8 sm:px-8">
 					{children}
 				</main>
 			</div>

--- a/app/api/recognition/stats/route.ts
+++ b/app/api/recognition/stats/route.ts
@@ -1,5 +1,6 @@
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
+import { getTopRecognizedLimit } from "@/lib/actions/settings-actions";
 
 export async function GET() {
 	let session: Awaited<ReturnType<typeof requireSession>>;
@@ -16,6 +17,7 @@ export async function GET() {
 		const userId = session.user.id;
 		const now = new Date();
 		const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+		const topLimit = await getTopRecognizedLimit();
 
 		const [sent, received, monthlyTotal, topRecipientsRaw] =
 			await Promise.all([
@@ -32,7 +34,7 @@ export async function GET() {
 					by: ["recipientId"],
 					_count: { recipientId: true },
 					orderBy: { _count: { recipientId: "desc" } },
-					take: 3,
+					take: topLimit,
 				}),
 			]);
 

--- a/components/shared/dashboard-header.tsx
+++ b/components/shared/dashboard-header.tsx
@@ -34,7 +34,7 @@ export function DashboardHeader() {
 	}
 
 	return (
-		<header className="flex h-20 items-center justify-between px-4 sm:px-8">
+		<header className="sticky top-0 z-10 flex h-20 items-center justify-between bg-card px-4 sm:px-8">
 			<div className="flex items-center md:hidden">
 				<MobileSidebarTrigger />
 			</div>

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -144,7 +144,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
 
 export function DashboardSidebar() {
 	return (
-		<aside className="hidden w-72 flex-col p-4 pr-2 md:flex">
+		<aside className="hidden w-72 sticky top-0 h-screen flex-col p-4 pr-2 md:flex">
 			<SidebarNav />
 		</aside>
 	);

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -13,6 +13,14 @@ let cachedSettings: OAuthSettings | null = null;
 let cacheExpiry = 0;
 const CACHE_TTL_MS = 30_000;
 
+const TOP_RECOGNIZED_KEY = "top_recognized_limit";
+const TOP_RECOGNIZED_DEFAULT = 10;
+const TOP_RECOGNIZED_MIN = 1;
+const TOP_RECOGNIZED_MAX = 50;
+
+let cachedTopLimit: number | null = null;
+let topLimitCacheExpiry = 0;
+
 export async function getOAuthSettings(): Promise<OAuthSettings> {
 	if (cachedSettings && Date.now() < cacheExpiry) {
 		return cachedSettings;
@@ -66,6 +74,63 @@ export async function updateOAuthSetting(
 	});
 
 	invalidateOAuthCache();
+
+	return { success: true };
+}
+
+/* ── Top Recognized Limit ────────────────────────────── */
+
+function invalidateTopLimitCache() {
+	cachedTopLimit = null;
+	topLimitCacheExpiry = 0;
+}
+
+export async function getTopRecognizedLimit(): Promise<number> {
+	if (cachedTopLimit !== null && Date.now() < topLimitCacheExpiry) {
+		return cachedTopLimit;
+	}
+
+	const row = await prisma.appSetting.findUnique({
+		where: { key: TOP_RECOGNIZED_KEY },
+	});
+
+	const parsed = row ? Number.parseInt(row.value, 10) : Number.NaN;
+	cachedTopLimit =
+		Number.isNaN(parsed) || parsed < TOP_RECOGNIZED_MIN || parsed > TOP_RECOGNIZED_MAX
+			? TOP_RECOGNIZED_DEFAULT
+			: parsed;
+	topLimitCacheExpiry = Date.now() + CACHE_TTL_MS;
+
+	return cachedTopLimit;
+}
+
+export async function updateTopRecognizedLimit(
+	limit: number,
+): Promise<{ success: boolean; error?: string }> {
+	try {
+		await requireRole("ADMIN");
+	} catch {
+		return { success: false, error: "Unauthorized" };
+	}
+
+	if (
+		!Number.isInteger(limit) ||
+		limit < TOP_RECOGNIZED_MIN ||
+		limit > TOP_RECOGNIZED_MAX
+	) {
+		return {
+			success: false,
+			error: `Limit must be between ${TOP_RECOGNIZED_MIN} and ${TOP_RECOGNIZED_MAX}`,
+		};
+	}
+
+	await prisma.appSetting.upsert({
+		where: { key: TOP_RECOGNIZED_KEY },
+		update: { value: String(limit) },
+		create: { key: TOP_RECOGNIZED_KEY, value: String(limit) },
+	});
+
+	invalidateTopLimitCache();
 
 	return { success: true };
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -413,6 +413,15 @@ async function seed() {
 	}
 
 	console.log(`Created ${allCards.length} notifications`);
+
+	console.log("Seeding app settings...");
+	await prisma.appSetting.upsert({
+		where: { key: "top_recognized_limit" },
+		update: {},
+		create: { key: "top_recognized_limit", value: "10" },
+	});
+	console.log("Set top_recognized_limit = 10");
+
 	console.log("Seed complete!");
 }
 


### PR DESCRIPTION
## Summary

- Increases the "Most Recognized" leaderboard from hardcoded top 3 to a **default of 10**
- Adds an admin-configurable limit (1–50) via a new **Recognition Settings** panel on `/dashboard/admin-settings`
- Uses the existing `AppSetting` key-value table (`top_recognized_limit` key) with a 30s in-memory cache
- Stats widget now shows **rank numbers** and a **scrollable list** to handle larger sets

## Changes

| File | What changed |
|---|---|
| `lib/actions/settings-actions.ts` | Added `getTopRecognizedLimit()` and `updateTopRecognizedLimit()` server actions |
| `app/api/recognition/stats/route.ts` | Replaced `take: 3` with dynamic `topLimit` from AppSetting |
| `admin-settings/page.tsx` | Replaced placeholder with server component that fetches current limit |
| `admin-settings/_components/recognition-settings.tsx` | New client component with select dropdown (ADMIN role required) |
| `dashboard/_components/stats-widget.tsx` | Added rank numbers, `truncate` on names, scrollable `max-h-80` container |
| `prisma/seed.ts` | Seeds `top_recognized_limit = 10` for dev environments |

## Test plan

- [ ] Log in as ADMIN, go to `/dashboard/admin-settings` — verify Recognition Settings panel renders with current limit
- [ ] Change the limit via the dropdown — verify toast confirmation and value persists on page reload
- [ ] Go to `/dashboard` — verify "Most Recognized" shows the configured number of recipients
- [ ] Log in as STAFF — verify `/dashboard/admin-settings` redirects to `/dashboard`
- [ ] With no `top_recognized_limit` row in DB, verify default of 10 is used

Closes #21