### PR TITLE
fix(recognition): auto-shrink long names in FROM/TO card boxes

### DIFF
--- a/app/(dashboard)/dashboard/recognition/_components/recognition-card-mini.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-card-mini.tsx
@@ -12,6 +12,7 @@ import {
 	AccessBusinessLogo,
 	BackgroundGraphic,
 } from "@/components/shared/access-logos";
+import { FitText } from "@/components/shared/fit-text";
 import type { CardSize } from "@/stores/use-preferences-store";
 
 const SIZE_CONFIG = {
@@ -158,9 +159,9 @@ export function RecognitionCardMini({
 					<span className={cn("font-black text-black mb-0.5", s.labelText)}>
 						TO
 					</span>
-					<span className={cn("text-[#222]", s.valueText)}>
-						{card.recipient.firstName} {card.recipient.lastName}
-					</span>
+					<FitText className={cn("text-[#222]", s.valueText)}>
+						{`${card.recipient.firstName} ${card.recipient.lastName}`}
+					</FitText>
 				</div>
 
 				{/* WHAT YOU DID */}
@@ -228,9 +229,9 @@ export function RecognitionCardMini({
 						<span className={cn("font-black text-black mb-0.5", s.labelText)}>
 							FROM
 						</span>
-						<span className={cn("text-[#222]", s.valueText)}>
-							{card.sender.firstName} {card.sender.lastName}
-						</span>
+						<FitText className={cn("text-[#222]", s.valueText)}>
+							{`${card.sender.firstName} ${card.sender.lastName}`}
+						</FitText>
 					</div>
 					<div
 						className={cn(

--- a/components/shared/fit-text.tsx
+++ b/components/shared/fit-text.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface FitTextProps {
+	children: string;
+	className?: string;
+	minFontSize?: number;
+}
+
+export function FitText({
+	children,
+	className,
+	minFontSize = 10,
+}: FitTextProps) {
+	const ref = useRef<HTMLSpanElement>(null);
+	const [fontSize, setFontSize] = useState<number | null>(null);
+
+	useLayoutEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		const parent = el.parentElement;
+		if (!parent) return;
+
+		const measure = () => {
+			el.style.fontSize = "";
+			const baseSize = Number.parseFloat(getComputedStyle(el).fontSize);
+			const style = getComputedStyle(parent);
+			const available =
+				parent.clientWidth -
+				Number.parseFloat(style.paddingLeft) -
+				Number.parseFloat(style.paddingRight);
+
+			if (el.scrollWidth > available && available > 0) {
+				const scaled = (available / el.scrollWidth) * baseSize * 0.98;
+				setFontSize(Math.max(minFontSize, scaled));
+			} else {
+				setFontSize(null);
+			}
+		};
+
+		measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(parent);
+		return () => ro.disconnect();
+	}, [children, minFontSize]);
+
+	return (
+		<span
+			ref={ref}
+			className={cn("block whitespace-nowrap", className)}
+			style={fontSize ? { fontSize: `${fontSize}px` } : undefined}
+		>
+			{children}
+		</span>
+	);
+}

--- a/components/shared/fit-text.tsx
+++ b/components/shared/fit-text.tsx
@@ -3,6 +3,8 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
+const SAFETY_FACTOR = 0.98;
+
 interface FitTextProps {
 	children: string;
 	className?: string;
@@ -12,7 +14,7 @@ interface FitTextProps {
 export function FitText({
 	children,
 	className,
-	minFontSize = 10,
+	minFontSize = 11,
 }: FitTextProps) {
 	const ref = useRef<HTMLSpanElement>(null);
 	const [fontSize, setFontSize] = useState<number | null>(null);
@@ -33,7 +35,7 @@ export function FitText({
 				Number.parseFloat(style.paddingRight);
 
 			if (el.scrollWidth > available && available > 0) {
-				const scaled = (available / el.scrollWidth) * baseSize * 0.98;
+				const scaled = (available / el.scrollWidth) * baseSize * SAFETY_FACTOR;
 				setFontSize(Math.max(minFontSize, scaled));
 			} else {
 				setFontSize(null);
@@ -49,7 +51,10 @@ export function FitText({
 	return (
 		<span
 			ref={ref}
-			className={cn("block whitespace-nowrap", className)}
+			className={cn(
+				"block whitespace-nowrap overflow-hidden text-ellipsis",
+				className,
+			)}
 			style={fontSize ? { fontSize: `${fontSize}px` } : undefined}
 		>
 			{children}


### PR DESCRIPTION
## Summary
- Long sender/recipient names (e.g. "Christian Diomampo", "Tamer Abdelatty") overflowed the fixed-height FROM/TO boxes on the recognition card, with the last word wrapping below the white card boundary.
- Adds a `FitText` client component that uses `useLayoutEffect` + `ResizeObserver` to measure available width and scale `font-size` down until the text fits on a single line (configurable floor, defaults to 10px).
- Applied to both TO and FROM name spans in `RecognitionCardMini`. DATE field is unchanged.

Closes #23

## Test plan
- [ ] Open `/dashboard` and confirm Recognition Feed cards render.
- [ ] Verify "Christian Diomampo" fits inside the FROM box on a single line (no overflow below the white boundary) at `compact`, `normal`, and `expanded` card sizes.
- [ ] Verify the same for TO names (e.g. "Kate Bickley", long names).
- [ ] Resize the browser from mobile (≤640px) to desktop; text rescales without overflow or flicker.
- [ ] Short names ("Ace Urmeneta") render at the default `s.valueText` size (no unnecessary shrinking).
- [ ] DATE field layout and sizing is unchanged.