### PR TITLE
feat(recognition): add emoji reactions and comments to card detail view

### DIFF
--- a/app/(dashboard)/dashboard/recognition/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/page.tsx
@@ -4,11 +4,8 @@ import { getServerSession } from "@/lib/auth-utils";
 import { hasMinRole } from "@/lib/permissions";
 import { prisma } from "@/lib/db";
 import type { Role } from "@/app/generated/prisma/client";
-import {
-	COMPANY_VALUES,
-	REACTION_EMOJIS,
-	formatRecognitionDate,
-} from "@/lib/recognition";
+import { COMPANY_VALUES, formatRecognitionDate } from "@/lib/recognition";
+import { getCardReactionSummary } from "@/lib/interactions";
 import {
 	AccessGroupLogo,
 	AccessBusinessLogo,
@@ -102,30 +99,9 @@ export default async function RecognitionDetailPage({
 	const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
 	const canInteract = isSender || isRecipient || isAdmin;
 
-	const [reactionCounts, userReactions, commentCount] = canInteract
-		? await Promise.all([
-				prisma.cardReaction.groupBy({
-					by: ["emoji"],
-					where: { cardId: id },
-					_count: true,
-				}),
-				prisma.cardReaction.findMany({
-					where: { cardId: id, userId: session.user.id },
-					select: { emoji: true },
-				}),
-				prisma.cardComment.count({ where: { cardId: id } }),
-			])
-		: [[], [], 0];
-
-	const userReactionSet = new Set(userReactions.map((r) => r.emoji));
-	const reactionMap = new Map(
-		reactionCounts.map((r) => [r.emoji, r._count]),
-	);
-	const initialReactions = REACTION_EMOJIS.map((emoji) => ({
-		emoji,
-		count: reactionMap.get(emoji) ?? 0,
-		hasReacted: userReactionSet.has(emoji),
-	})).filter((r) => r.count > 0 || r.hasReacted);
+	const { initialReactions, commentCount } = canInteract
+		? await getCardReactionSummary(id, session.user.id)
+		: { initialReactions: [], commentCount: 0 };
 
 	if (!isSender && !isRecipient && !isAdmin) notFound();
 

--- a/app/(dashboard)/dashboard/recognition/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/page.tsx
@@ -4,7 +4,11 @@ import { getServerSession } from "@/lib/auth-utils";
 import { hasMinRole } from "@/lib/permissions";
 import { prisma } from "@/lib/db";
 import type { Role } from "@/app/generated/prisma/client";
-import { COMPANY_VALUES, formatRecognitionDate } from "@/lib/recognition";
+import {
+	COMPANY_VALUES,
+	REACTION_EMOJIS,
+	formatRecognitionDate,
+} from "@/lib/recognition";
 import {
 	AccessGroupLogo,
 	AccessBusinessLogo,
@@ -14,6 +18,7 @@ import { Check, ArrowLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FitText } from "@/components/shared/fit-text";
 import { FlipCard } from "@/app/recognition/[id]/flip-card";
+import { CardInteractionBar } from "../_components/card-interaction-bar";
 import { CardDetailActions } from "./_components/card-detail-actions";
 import { MarkNotificationsRead } from "./_components/mark-notifications-read";
 
@@ -95,6 +100,32 @@ export default async function RecognitionDetailPage({
 	const isSender = card.sender.id === session.user.id;
 	const isRecipient = card.recipient.id === session.user.id;
 	const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+	const canInteract = isSender || isRecipient || isAdmin;
+
+	const [reactionCounts, userReactions, commentCount] = canInteract
+		? await Promise.all([
+				prisma.cardReaction.groupBy({
+					by: ["emoji"],
+					where: { cardId: id },
+					_count: true,
+				}),
+				prisma.cardReaction.findMany({
+					where: { cardId: id, userId: session.user.id },
+					select: { emoji: true },
+				}),
+				prisma.cardComment.count({ where: { cardId: id } }),
+			])
+		: [[], [], 0];
+
+	const userReactionSet = new Set(userReactions.map((r) => r.emoji));
+	const reactionMap = new Map(
+		reactionCounts.map((r) => [r.emoji, r._count]),
+	);
+	const initialReactions = REACTION_EMOJIS.map((emoji) => ({
+		emoji,
+		count: reactionMap.get(emoji) ?? 0,
+		hasReacted: userReactionSet.has(emoji),
+	})).filter((r) => r.count > 0 || r.hasReacted);
 
 	if (!isSender && !isRecipient && !isAdmin) notFound();
 
@@ -229,6 +260,18 @@ export default async function RecognitionDetailPage({
 			<div className="flex justify-center">
 				<FlipCard front={card1Front} back={card2Back} />
 			</div>
+
+			{canInteract && (
+				<div className="max-w-4xl mx-auto rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+					<CardInteractionBar
+						cardId={id}
+						currentUserId={session.user.id}
+						isAdmin={isAdmin}
+						initialCommentCount={commentCount}
+						initialReactions={initialReactions}
+					/>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/recognition/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/page.tsx
@@ -262,7 +262,7 @@ export default async function RecognitionDetailPage({
 			</div>
 
 			{canInteract && (
-				<div className="max-w-4xl mx-auto rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+				<div className="relative z-10 max-w-4xl mx-auto rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
 					<CardInteractionBar
 						cardId={id}
 						currentUserId={session.user.id}

--- a/app/recognition/[id]/flip-card.tsx
+++ b/app/recognition/[id]/flip-card.tsx
@@ -26,7 +26,7 @@ export function FlipCard({
 
 			{/* Card container with perspective */}
 			<div
-				className="relative w-full"
+				className="relative z-0 w-full"
 				style={{ perspective: "2000px" }}
 			>
 				<div

--- a/app/recognition/[id]/interaction-bar-readonly.tsx
+++ b/app/recognition/[id]/interaction-bar-readonly.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { MessageCircle } from "lucide-react";
+
+interface InteractionBarReadonlyProps {
+	reactions: { emoji: string; count: number }[];
+	commentCount: number;
+}
+
+export function InteractionBarReadonly({
+	reactions,
+	commentCount,
+}: InteractionBarReadonlyProps) {
+	const pathname = usePathname();
+	const loginUrl = `/login?callbackUrl=${encodeURIComponent(pathname)}`;
+
+	const activeReactions = reactions.filter((r) => r.count > 0);
+
+	return (
+		<div className="pt-3 mt-3 border-t border-gray-200">
+			<div className="flex flex-wrap items-center gap-1.5">
+				{activeReactions.map((r) => (
+					<Link
+						key={r.emoji}
+						href={loginUrl}
+						className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors"
+					>
+						<span>{r.emoji}</span>
+						<span className="text-xs tabular-nums">{r.count}</span>
+					</Link>
+				))}
+
+				<Link
+					href={loginUrl}
+					className="ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+				>
+					<MessageCircle size={13} />
+					<span>
+						{commentCount > 0
+							? `${commentCount} comment${commentCount !== 1 ? "s" : ""}`
+							: "Comment"}
+					</span>
+				</Link>
+			</div>
+		</div>
+	);
+}

--- a/app/recognition/[id]/page.tsx
+++ b/app/recognition/[id]/page.tsx
@@ -396,7 +396,7 @@ export default async function SharePage({
 						initialReactions={initialReactions}
 					/>
 				</div>
-			) : (publicReactions.length > 0 || commentCount > 0) ? (
+			) : !session ? (
 				<div className="relative z-10 w-full max-w-4xl mt-4 rounded-[2rem] border border-gray-200/60 bg-white px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
 					<InteractionBarReadonly
 						reactions={publicReactions}

--- a/app/recognition/[id]/page.tsx
+++ b/app/recognition/[id]/page.tsx
@@ -2,8 +2,15 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { cache } from "react";
+import { getServerSession } from "@/lib/auth-utils";
+import { hasMinRole } from "@/lib/permissions";
 import { prisma } from "@/lib/db";
-import { COMPANY_VALUES, formatRecognitionDate } from "@/lib/recognition";
+import type { Role } from "@/app/generated/prisma/client";
+import {
+	COMPANY_VALUES,
+	REACTION_EMOJIS,
+	formatRecognitionDate,
+} from "@/lib/recognition";
 import {
 	AccessGroupLogo,
 	AccessBusinessLogo,
@@ -12,6 +19,7 @@ import {
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FitText } from "@/components/shared/fit-text";
+import { CardInteractionBar } from "@/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar";
 import { FlipCard } from "./flip-card";
 
 const getCard = cache(async function getCard(id: string) {
@@ -20,6 +28,7 @@ const getCard = cache(async function getCard(id: string) {
 		include: {
 			sender: {
 				select: {
+					id: true,
 					firstName: true,
 					lastName: true,
 					position: true,
@@ -28,6 +37,7 @@ const getCard = cache(async function getCard(id: string) {
 			},
 			recipient: {
 				select: {
+					id: true,
 					firstName: true,
 					lastName: true,
 					position: true,
@@ -126,9 +136,42 @@ export default async function SharePage({
 	params: Promise<{ id: string }>;
 }) {
 	const { id } = await params;
-	const card = await getCard(id);
+	const [card, session] = await Promise.all([getCard(id), getServerSession()]);
 
 	if (!card) notFound();
+
+	const userId = session?.user.id;
+	const isSender = userId === card.sender.id;
+	const isRecipient = userId === card.recipient.id;
+	const isAdmin = session
+		? hasMinRole(session.user.role as Role, "ADMIN")
+		: false;
+	const canInteract = session && (isSender || isRecipient || isAdmin);
+
+	const [reactionCounts, userReactions, commentCount] = canInteract && userId
+		? await Promise.all([
+				prisma.cardReaction.groupBy({
+					by: ["emoji"],
+					where: { cardId: id },
+					_count: true,
+				}),
+				prisma.cardReaction.findMany({
+					where: { cardId: id, userId },
+					select: { emoji: true },
+				}),
+				prisma.cardComment.count({ where: { cardId: id } }),
+			])
+		: [[], [], 0];
+
+	const userReactionSet = new Set(userReactions.map((r) => r.emoji));
+	const reactionMap = new Map(
+		reactionCounts.map((r) => [r.emoji, r._count]),
+	);
+	const initialReactions = REACTION_EMOJIS.map((emoji) => ({
+		emoji,
+		count: reactionMap.get(emoji) ?? 0,
+		hasReacted: userReactionSet.has(emoji),
+	})).filter((r) => r.count > 0 || r.hasReacted);
 
 	const recipientName = `${card.recipient.firstName} ${card.recipient.lastName}`;
 	const senderName = `${card.sender.firstName} ${card.sender.lastName}`;
@@ -338,6 +381,18 @@ export default async function SharePage({
 	return (
 		<div className="min-h-screen bg-[#f5f5f5] flex flex-col items-center justify-center py-8 px-4">
 			<FlipCard front={card1Front} back={card2Back} />
+
+			{canInteract && userId && (
+				<div className="w-full max-w-4xl mt-4 rounded-[2rem] border border-gray-200/60 bg-white px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+					<CardInteractionBar
+						cardId={id}
+						currentUserId={userId}
+						isAdmin={isAdmin}
+						initialCommentCount={commentCount}
+						initialReactions={initialReactions}
+					/>
+				</div>
+			)}
 
 			<div className="mt-8 text-center">
 				<p className="text-sm text-gray-500">

--- a/app/recognition/[id]/page.tsx
+++ b/app/recognition/[id]/page.tsx
@@ -387,7 +387,7 @@ export default async function SharePage({
 			<FlipCard front={card1Front} back={card2Back} />
 
 			{canInteract && userId ? (
-				<div className="w-full max-w-4xl mt-4 rounded-[2rem] border border-gray-200/60 bg-white px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+				<div className="relative z-10 w-full max-w-4xl mt-4 rounded-[2rem] border border-gray-200/60 bg-white px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
 					<CardInteractionBar
 						cardId={id}
 						currentUserId={userId}
@@ -397,7 +397,7 @@ export default async function SharePage({
 					/>
 				</div>
 			) : (publicReactions.length > 0 || commentCount > 0) ? (
-				<div className="w-full max-w-4xl mt-4 rounded-[2rem] border border-gray-200/60 bg-white px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+				<div className="relative z-10 w-full max-w-4xl mt-4 rounded-[2rem] border border-gray-200/60 bg-white px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
 					<InteractionBarReadonly
 						reactions={publicReactions}
 						commentCount={commentCount}

--- a/app/recognition/[id]/page.tsx
+++ b/app/recognition/[id]/page.tsx
@@ -6,11 +6,8 @@ import { getServerSession } from "@/lib/auth-utils";
 import { hasMinRole } from "@/lib/permissions";
 import { prisma } from "@/lib/db";
 import type { Role } from "@/app/generated/prisma/client";
-import {
-	COMPANY_VALUES,
-	REACTION_EMOJIS,
-	formatRecognitionDate,
-} from "@/lib/recognition";
+import { COMPANY_VALUES, formatRecognitionDate } from "@/lib/recognition";
+import { getCardReactionSummary } from "@/lib/interactions";
 import {
 	AccessGroupLogo,
 	AccessBusinessLogo,
@@ -149,33 +146,8 @@ export default async function SharePage({
 		: false;
 	const canInteract = session && (isSender || isRecipient || isAdmin);
 
-	const [reactionCounts, userReactions, commentCount] = await Promise.all([
-		prisma.cardReaction.groupBy({
-			by: ["emoji"],
-			where: { cardId: id },
-			_count: true,
-		}),
-		canInteract && userId
-			? prisma.cardReaction.findMany({
-					where: { cardId: id, userId },
-					select: { emoji: true },
-				})
-			: Promise.resolve([]),
-		prisma.cardComment.count({ where: { cardId: id } }),
-	]);
-
-	const userReactionSet = new Set(userReactions.map((r) => r.emoji));
-	const reactionMap = new Map(
-		reactionCounts.map((r) => [r.emoji, r._count]),
-	);
-	const publicReactions = REACTION_EMOJIS.map((emoji) => ({
-		emoji,
-		count: reactionMap.get(emoji) ?? 0,
-	})).filter((r) => r.count > 0);
-	const initialReactions = publicReactions.map((r) => ({
-		...r,
-		hasReacted: userReactionSet.has(r.emoji),
-	}));
+	const { publicReactions, initialReactions, commentCount } =
+		await getCardReactionSummary(id, canInteract ? userId : undefined);
 
 	const recipientName = `${card.recipient.firstName} ${card.recipient.lastName}`;
 	const senderName = `${card.sender.firstName} ${card.sender.lastName}`;

--- a/app/recognition/[id]/page.tsx
+++ b/app/recognition/[id]/page.tsx
@@ -20,6 +20,7 @@ import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FitText } from "@/components/shared/fit-text";
 import { CardInteractionBar } from "@/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar";
+import { InteractionBarReadonly } from "./interaction-bar-readonly";
 import { FlipCard } from "./flip-card";
 
 const getCard = cache(async function getCard(id: string) {
@@ -148,30 +149,33 @@ export default async function SharePage({
 		: false;
 	const canInteract = session && (isSender || isRecipient || isAdmin);
 
-	const [reactionCounts, userReactions, commentCount] = canInteract && userId
-		? await Promise.all([
-				prisma.cardReaction.groupBy({
-					by: ["emoji"],
-					where: { cardId: id },
-					_count: true,
-				}),
-				prisma.cardReaction.findMany({
+	const [reactionCounts, userReactions, commentCount] = await Promise.all([
+		prisma.cardReaction.groupBy({
+			by: ["emoji"],
+			where: { cardId: id },
+			_count: true,
+		}),
+		canInteract && userId
+			? prisma.cardReaction.findMany({
 					where: { cardId: id, userId },
 					select: { emoji: true },
-				}),
-				prisma.cardComment.count({ where: { cardId: id } }),
-			])
-		: [[], [], 0];
+				})
+			: Promise.resolve([]),
+		prisma.cardComment.count({ where: { cardId: id } }),
+	]);
 
 	const userReactionSet = new Set(userReactions.map((r) => r.emoji));
 	const reactionMap = new Map(
 		reactionCounts.map((r) => [r.emoji, r._count]),
 	);
-	const initialReactions = REACTION_EMOJIS.map((emoji) => ({
+	const publicReactions = REACTION_EMOJIS.map((emoji) => ({
 		emoji,
 		count: reactionMap.get(emoji) ?? 0,
-		hasReacted: userReactionSet.has(emoji),
-	})).filter((r) => r.count > 0 || r.hasReacted);
+	})).filter((r) => r.count > 0);
+	const initialReactions = publicReactions.map((r) => ({
+		...r,
+		hasReacted: userReactionSet.has(r.emoji),
+	}));
 
 	const recipientName = `${card.recipient.firstName} ${card.recipient.lastName}`;
 	const senderName = `${card.sender.firstName} ${card.sender.lastName}`;
@@ -382,7 +386,7 @@ export default async function SharePage({
 		<div className="min-h-screen bg-[#f5f5f5] flex flex-col items-center justify-center py-8 px-4">
 			<FlipCard front={card1Front} back={card2Back} />
 
-			{canInteract && userId && (
+			{canInteract && userId ? (
 				<div className="w-full max-w-4xl mt-4 rounded-[2rem] border border-gray-200/60 bg-white px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
 					<CardInteractionBar
 						cardId={id}
@@ -392,7 +396,14 @@ export default async function SharePage({
 						initialReactions={initialReactions}
 					/>
 				</div>
-			)}
+			) : (publicReactions.length > 0 || commentCount > 0) ? (
+				<div className="w-full max-w-4xl mt-4 rounded-[2rem] border border-gray-200/60 bg-white px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+					<InteractionBarReadonly
+						reactions={publicReactions}
+						commentCount={commentCount}
+					/>
+				</div>
+			) : null}
 
 			<div className="mt-8 text-center">
 				<p className="text-sm text-gray-500">

--- a/lib/interactions.ts
+++ b/lib/interactions.ts
@@ -1,0 +1,39 @@
+import { prisma } from "@/lib/db";
+import { REACTION_EMOJIS } from "@/lib/recognition";
+
+export async function getCardReactionSummary(
+	cardId: string,
+	userId?: string,
+) {
+	const [reactionCounts, userReactions, commentCount] = await Promise.all([
+		prisma.cardReaction.groupBy({
+			by: ["emoji"],
+			where: { cardId },
+			_count: true,
+		}),
+		userId
+			? prisma.cardReaction.findMany({
+					where: { cardId, userId },
+					select: { emoji: true },
+				})
+			: Promise.resolve([]),
+		prisma.cardComment.count({ where: { cardId } }),
+	]);
+
+	const userReactionSet = new Set(userReactions.map((r) => r.emoji));
+	const reactionMap = new Map(
+		reactionCounts.map((r) => [r.emoji, r._count]),
+	);
+
+	const publicReactions = REACTION_EMOJIS.map((emoji) => ({
+		emoji,
+		count: reactionMap.get(emoji) ?? 0,
+	})).filter((r) => r.count > 0);
+
+	const initialReactions = publicReactions.map((r) => ({
+		...r,
+		hasReacted: userReactionSet.has(r.emoji),
+	}));
+
+	return { publicReactions, initialReactions, commentCount };
+}


### PR DESCRIPTION
## Summary
- Adds `CardInteractionBar` (emoji reactions + collapsible comment thread) to the authenticated card detail page (`/dashboard/recognition/[id]`), placed below the FlipCard.
- Adds the same interactive bar to the public share page (`/recognition/[id]`) for authenticated participants/admins.
- Unauthenticated visitors see a read-only interaction bar with reaction counts and a "Comment" CTA — clicking any element redirects to `/login?callbackUrl=...` for post-login redirect back.
- Authenticated non-participants see no interaction UI (no dead login loops).
- Fetches initial reaction counts, per-user `hasReacted` flags, and comment count server-side via a shared `getCardReactionSummary` helper to avoid loading flash.
- Fixes FlipCard z-index overlap with the interaction bar below it.

Closes #26

## Test plan
- [ ] Navigate to `/dashboard/recognition/<id>` — interaction bar renders below the FlipCard.
- [ ] Reaction pills show correct counts and highlighted state matching the feed view for the same card.
- [ ] Click an emoji — count updates optimistically, persists on page refresh.
- [ ] Toggle comments — thread expands inline below the reactions.
- [ ] Post, edit, and delete a comment — same behavior as in the feed.
- [ ] As ADMIN, delete another user's comment on the detail view.
- [ ] As a non-participant non-admin (authenticated), confirm no interaction bar is visible on either page.
- [ ] Visit `/recognition/<id>` while logged out — read-only bar shows reaction counts and "Comment" CTA.
- [ ] Click a reaction pill or "Comment" while logged out — redirected to login, then back to the card.
- [ ] Visit a zero-activity card while logged out — "Comment" CTA still appears.
- [ ] Flip the card to front — interaction bar stays below the card, no overlap.
- [ ] Check mobile layout — interaction bar stays within bounds.