### PR TITLE
feat(auth): add password change and admin password reset

### DIFF
--- a/app/(dashboard)/dashboard/profile/_components/change-password-form.tsx
+++ b/app/(dashboard)/dashboard/profile/_components/change-password-form.tsx
@@ -35,6 +35,7 @@ export function ChangePasswordForm() {
 			const result = await changePassword({
 				currentPassword: data.currentPassword,
 				newPassword: data.newPassword,
+				revokeOtherSessions: true,
 			});
 
 			if (result.error) {

--- a/app/(dashboard)/dashboard/profile/_components/change-password-form.tsx
+++ b/app/(dashboard)/dashboard/profile/_components/change-password-form.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { changePassword } from "@/lib/auth-client";
+import {
+	changePasswordSchema,
+	type ChangePasswordInput,
+} from "@/lib/validations/auth";
+
+const inputClass =
+	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
+
+export function ChangePasswordForm() {
+	const [isLoading, setIsLoading] = useState(false);
+
+	const {
+		register,
+		handleSubmit,
+		reset,
+		formState: { errors },
+	} = useForm<ChangePasswordInput>({
+		resolver: zodResolver(changePasswordSchema),
+	});
+
+	async function onSubmit(data: ChangePasswordInput) {
+		setIsLoading(true);
+		try {
+			const result = await changePassword({
+				currentPassword: data.currentPassword,
+				newPassword: data.newPassword,
+			});
+
+			if (result.error) {
+				toast.error(result.error.message ?? "Failed to change password");
+				return;
+			}
+
+			toast.success("Password changed successfully");
+			reset();
+		} catch {
+			toast.error("Something went wrong");
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
+			<div className="px-8 pt-8 pb-2">
+				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
+					Change Password
+				</h3>
+				<p className="mt-1 text-sm text-muted-foreground">
+					Update your password to keep your account secure.
+				</p>
+			</div>
+
+			<form onSubmit={handleSubmit(onSubmit)}>
+				<div className="px-8 py-6 space-y-5">
+					<div>
+						<label
+							htmlFor="currentPassword"
+							className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+						>
+							Current Password
+						</label>
+						<input
+							id="currentPassword"
+							type="password"
+							className={inputClass}
+							{...register("currentPassword")}
+						/>
+						{errors.currentPassword && (
+							<p className="mt-1 text-sm text-destructive">
+								{errors.currentPassword.message}
+							</p>
+						)}
+					</div>
+
+					<div>
+						<label
+							htmlFor="newPassword"
+							className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+						>
+							New Password
+						</label>
+						<input
+							id="newPassword"
+							type="password"
+							className={inputClass}
+							{...register("newPassword")}
+						/>
+						{errors.newPassword && (
+							<p className="mt-1 text-sm text-destructive">
+								{errors.newPassword.message}
+							</p>
+						)}
+					</div>
+
+					<div>
+						<label
+							htmlFor="confirmPassword"
+							className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+						>
+							Confirm New Password
+						</label>
+						<input
+							id="confirmPassword"
+							type="password"
+							className={inputClass}
+							{...register("confirmPassword")}
+						/>
+						{errors.confirmPassword && (
+							<p className="mt-1 text-sm text-destructive">
+								{errors.confirmPassword.message}
+							</p>
+						)}
+					</div>
+				</div>
+
+				<div className="px-8 py-6 bg-gray-50/50 dark:bg-white/[0.02] border-t border-gray-200/60 dark:border-white/10 flex justify-end">
+					<button
+						type="submit"
+						disabled={isLoading}
+						className="inline-flex justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50"
+					>
+						{isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+						Update Password
+					</button>
+				</div>
+			</form>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/profile/_components/change-password-form.tsx
+++ b/app/(dashboard)/dashboard/profile/_components/change-password-form.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { changePassword } from "@/lib/auth-client";
 import {
 	changePasswordSchema,
@@ -12,10 +12,13 @@ import {
 } from "@/lib/validations/auth";
 
 const inputClass =
-	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
+	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 pr-11 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
 
 export function ChangePasswordForm() {
 	const [isLoading, setIsLoading] = useState(false);
+	const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+	const [showNewPassword, setShowNewPassword] = useState(false);
+	const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
 	const {
 		register,
@@ -68,12 +71,22 @@ export function ChangePasswordForm() {
 						>
 							Current Password
 						</label>
-						<input
-							id="currentPassword"
-							type="password"
-							className={inputClass}
-							{...register("currentPassword")}
-						/>
+						<div className="relative">
+							<input
+								id="currentPassword"
+								type={showCurrentPassword ? "text" : "password"}
+								className={inputClass}
+								{...register("currentPassword")}
+							/>
+							<button
+								type="button"
+								onClick={() => setShowCurrentPassword((prev) => !prev)}
+								className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+								tabIndex={-1}
+							>
+								{showCurrentPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+							</button>
+						</div>
 						{errors.currentPassword && (
 							<p className="mt-1 text-sm text-destructive">
 								{errors.currentPassword.message}
@@ -88,12 +101,22 @@ export function ChangePasswordForm() {
 						>
 							New Password
 						</label>
-						<input
-							id="newPassword"
-							type="password"
-							className={inputClass}
-							{...register("newPassword")}
-						/>
+						<div className="relative">
+							<input
+								id="newPassword"
+								type={showNewPassword ? "text" : "password"}
+								className={inputClass}
+								{...register("newPassword")}
+							/>
+							<button
+								type="button"
+								onClick={() => setShowNewPassword((prev) => !prev)}
+								className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+								tabIndex={-1}
+							>
+								{showNewPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+							</button>
+						</div>
 						{errors.newPassword && (
 							<p className="mt-1 text-sm text-destructive">
 								{errors.newPassword.message}
@@ -108,12 +131,22 @@ export function ChangePasswordForm() {
 						>
 							Confirm New Password
 						</label>
-						<input
-							id="confirmPassword"
-							type="password"
-							className={inputClass}
-							{...register("confirmPassword")}
-						/>
+						<div className="relative">
+							<input
+								id="confirmPassword"
+								type={showConfirmPassword ? "text" : "password"}
+								className={inputClass}
+								{...register("confirmPassword")}
+							/>
+							<button
+								type="button"
+								onClick={() => setShowConfirmPassword((prev) => !prev)}
+								className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+								tabIndex={-1}
+							>
+								{showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+							</button>
+						</div>
 						{errors.confirmPassword && (
 							<p className="mt-1 text-sm text-destructive">
 								{errors.confirmPassword.message}

--- a/app/(dashboard)/dashboard/profile/_components/profile-nav.tsx
+++ b/app/(dashboard)/dashboard/profile/_components/profile-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { User, Settings, Link2 } from "lucide-react";
+import { User, Settings, Link2, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS = [
@@ -10,6 +10,11 @@ const NAV_ITEMS = [
 		label: "Profile",
 		href: "/dashboard/profile",
 		icon: User,
+	},
+	{
+		label: "Security",
+		href: "/dashboard/profile/security",
+		icon: Lock,
 	},
 	{
 		label: "Connected Accounts",

--- a/app/(dashboard)/dashboard/profile/security/page.tsx
+++ b/app/(dashboard)/dashboard/profile/security/page.tsx
@@ -1,0 +1,5 @@
+import { ChangePasswordForm } from "../_components/change-password-form";
+
+export default function SecurityPage() {
+	return <ChangePasswordForm />;
+}

--- a/app/(dashboard)/dashboard/profile/security/page.tsx
+++ b/app/(dashboard)/dashboard/profile/security/page.tsx
@@ -1,5 +1,43 @@
+import { redirect } from "next/navigation";
+import { Link2 } from "lucide-react";
+import Link from "next/link";
+import { getServerSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
 import { ChangePasswordForm } from "../_components/change-password-form";
 
-export default function SecurityPage() {
+export default async function SecurityPage() {
+	const session = await getServerSession();
+	if (!session) redirect("/login");
+
+	const credentialAccount = await prisma.account.findFirst({
+		where: { userId: session.user.id, providerId: "credential" },
+		select: { id: true },
+	});
+
+	if (!credentialAccount) {
+		return (
+			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
+				<div className="px-8 pt-8 pb-2">
+					<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
+						Change Password
+					</h3>
+					<p className="mt-1 text-sm text-muted-foreground">
+						Your account does not have a password login. You currently sign in with a connected
+						account (Google or Microsoft). To set a password, contact an administrator.
+					</p>
+				</div>
+				<div className="px-8 py-6">
+					<Link
+						href="/dashboard/profile/connected-accounts"
+						className="inline-flex items-center gap-2 rounded-full border border-gray-200 dark:border-white/10 bg-card px-6 py-2.5 text-sm font-medium text-foreground hover:bg-gray-50 dark:hover:bg-white/5 transition-all duration-200"
+					>
+						<Link2 className="h-4 w-4" />
+						Manage Connected Accounts
+					</Link>
+				</div>
+			</div>
+		);
+	}
+
 	return <ChangePasswordForm />;
 }

--- a/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { canManageUsers } from "@/lib/permissions";
 import { prisma } from "@/lib/db";
 import type { Role } from "@/app/generated/prisma/client";
 import { UserForm } from "../../_components/user-form";
+import { ResetPasswordForm } from "../../_components/reset-password-form";
 
 export default async function EditUserPage({ params }: { params: Promise<{ id: string }> }) {
 	const session = await getServerSession();
@@ -20,22 +21,30 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 	if (!user) notFound();
 
 	return (
-		<UserForm
-			mode="edit"
-			userId={user.id}
-			currentUserRole={session.user.role as string}
-			departments={departments}
-			defaultValues={{
-				firstName: user.firstName,
-				lastName: user.lastName,
-				displayName: user.displayName ?? undefined,
-				phone: user.phone ?? undefined,
-				position: user.position ?? undefined,
-				branch: user.branch ?? null,
-				role: user.role,
-				departmentId: user.departmentId,
-				isActive: user.isActive,
-			}}
-		/>
+		<div className="space-y-8">
+			<UserForm
+				mode="edit"
+				userId={user.id}
+				currentUserRole={session.user.role as string}
+				departments={departments}
+				defaultValues={{
+					firstName: user.firstName,
+					lastName: user.lastName,
+					displayName: user.displayName ?? undefined,
+					phone: user.phone ?? undefined,
+					position: user.position ?? undefined,
+					branch: user.branch ?? null,
+					role: user.role,
+					departmentId: user.departmentId,
+					isActive: user.isActive,
+				}}
+			/>
+			<div className="max-w-2xl">
+				<ResetPasswordForm
+					userId={user.id}
+					userName={`${user.firstName} ${user.lastName}`}
+				/>
+			</div>
+		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
@@ -21,7 +21,7 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 	if (!user) notFound();
 
 	return (
-		<div className="space-y-8">
+		<div className="max-w-7xl mx-auto space-y-8 mt-2">
 			<UserForm
 				mode="edit"
 				userId={user.id}

--- a/app/(dashboard)/dashboard/users/_components/reset-password-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/reset-password-form.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { adminResetPasswordAction } from "@/lib/actions/user-actions";
 import {
 	adminResetPasswordSchema,
@@ -12,7 +12,7 @@ import {
 } from "@/lib/validations/auth";
 
 const inputClass =
-	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
+	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 pr-11 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
 
 interface ResetPasswordFormProps {
 	userId: string;
@@ -21,6 +21,8 @@ interface ResetPasswordFormProps {
 
 export function ResetPasswordForm({ userId, userName }: ResetPasswordFormProps) {
 	const [isLoading, setIsLoading] = useState(false);
+	const [showNewPassword, setShowNewPassword] = useState(false);
+	const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
 	const {
 		register,
@@ -74,12 +76,22 @@ export function ResetPasswordForm({ userId, userName }: ResetPasswordFormProps) 
 						>
 							New Password
 						</label>
-						<input
-							id="newPassword"
-							type="password"
-							className={inputClass}
-							{...register("newPassword")}
-						/>
+						<div className="relative">
+							<input
+								id="newPassword"
+								type={showNewPassword ? "text" : "password"}
+								className={inputClass}
+								{...register("newPassword")}
+							/>
+							<button
+								type="button"
+								onClick={() => setShowNewPassword((prev) => !prev)}
+								className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+								tabIndex={-1}
+							>
+								{showNewPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+							</button>
+						</div>
 						{errors.newPassword && (
 							<p className="mt-1 text-sm text-destructive">
 								{errors.newPassword.message}
@@ -94,12 +106,22 @@ export function ResetPasswordForm({ userId, userName }: ResetPasswordFormProps) 
 						>
 							Confirm New Password
 						</label>
-						<input
-							id="confirmPassword"
-							type="password"
-							className={inputClass}
-							{...register("confirmPassword")}
-						/>
+						<div className="relative">
+							<input
+								id="confirmPassword"
+								type={showConfirmPassword ? "text" : "password"}
+								className={inputClass}
+								{...register("confirmPassword")}
+							/>
+							<button
+								type="button"
+								onClick={() => setShowConfirmPassword((prev) => !prev)}
+								className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+								tabIndex={-1}
+							>
+								{showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+							</button>
+						</div>
 						{errors.confirmPassword && (
 							<p className="mt-1 text-sm text-destructive">
 								{errors.confirmPassword.message}

--- a/app/(dashboard)/dashboard/users/_components/reset-password-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/reset-password-form.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { adminResetPasswordAction } from "@/lib/actions/user-actions";
+import {
+	adminResetPasswordSchema,
+	type AdminResetPasswordInput,
+} from "@/lib/validations/auth";
+
+const inputClass =
+	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
+
+interface ResetPasswordFormProps {
+	userId: string;
+	userName: string;
+}
+
+export function ResetPasswordForm({ userId, userName }: ResetPasswordFormProps) {
+	const [isLoading, setIsLoading] = useState(false);
+
+	const {
+		register,
+		handleSubmit,
+		reset,
+		formState: { errors },
+	} = useForm<AdminResetPasswordInput>({
+		resolver: zodResolver(adminResetPasswordSchema),
+	});
+
+	async function onSubmit(data: AdminResetPasswordInput) {
+		setIsLoading(true);
+		try {
+			const result = await adminResetPasswordAction(userId, data);
+
+			if (!result.success) {
+				const errorMsg =
+					typeof result.error === "string"
+						? result.error
+						: "Failed to reset password";
+				toast.error(errorMsg);
+				return;
+			}
+
+			toast.success(`Password reset for ${userName}`);
+			reset();
+		} catch {
+			toast.error("Something went wrong");
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
+			<div className="px-8 pt-8 pb-2">
+				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
+					Reset Password
+				</h3>
+				<p className="mt-1 text-sm text-muted-foreground">
+					Set a new password for {userName}. They will need to use this password on their next login.
+				</p>
+			</div>
+
+			<form onSubmit={handleSubmit(onSubmit)}>
+				<div className="px-8 py-6 space-y-5">
+					<div>
+						<label
+							htmlFor="newPassword"
+							className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+						>
+							New Password
+						</label>
+						<input
+							id="newPassword"
+							type="password"
+							className={inputClass}
+							{...register("newPassword")}
+						/>
+						{errors.newPassword && (
+							<p className="mt-1 text-sm text-destructive">
+								{errors.newPassword.message}
+							</p>
+						)}
+					</div>
+
+					<div>
+						<label
+							htmlFor="confirmPassword"
+							className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+						>
+							Confirm New Password
+						</label>
+						<input
+							id="confirmPassword"
+							type="password"
+							className={inputClass}
+							{...register("confirmPassword")}
+						/>
+						{errors.confirmPassword && (
+							<p className="mt-1 text-sm text-destructive">
+								{errors.confirmPassword.message}
+							</p>
+						)}
+					</div>
+				</div>
+
+				<div className="px-8 py-6 bg-gray-50/50 dark:bg-white/[0.02] border-t border-gray-200/60 dark:border-white/10 flex justify-end">
+					<button
+						type="submit"
+						disabled={isLoading}
+						className="inline-flex justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50"
+					>
+						{isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+						Reset Password
+					</button>
+				</div>
+			</form>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/users/_components/user-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-form.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { createUserAction, updateUserAction } from "@/lib/actions/user-actions";
 import {
 	createUserSchema,
@@ -45,6 +45,7 @@ export function UserForm({
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const [isLoading, setIsLoading] = useState(false);
+	const [showPassword, setShowPassword] = useState(false);
 	const isCreate = mode === "create";
 
 	const {
@@ -152,7 +153,22 @@ export function UserForm({
 									<label htmlFor="password" className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5">
 										Password
 									</label>
-									<input id="password" type="password" className={inputClass} {...register("password")} />
+									<div className="relative">
+										<input
+											id="password"
+											type={showPassword ? "text" : "password"}
+											className={`${inputClass} pr-11`}
+											{...register("password")}
+										/>
+										<button
+											type="button"
+											onClick={() => setShowPassword((prev) => !prev)}
+											className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+											tabIndex={-1}
+										>
+											{showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+										</button>
+									</div>
 									{errors.password && (
 										<p className="mt-1 text-sm text-destructive">{errors.password.message}</p>
 									)}

--- a/app/(dashboard)/dashboard/users/new/page.tsx
+++ b/app/(dashboard)/dashboard/users/new/page.tsx
@@ -13,5 +13,9 @@ export default async function NewUserPage() {
 
 	const departments = await prisma.department.findMany({ orderBy: { name: "asc" } });
 
-	return <UserForm mode="create" currentUserRole={session.user.role as string} departments={departments} />;
+	return (
+		<div className="max-w-7xl mx-auto space-y-8 mt-2">
+			<UserForm mode="create" currentUserRole={session.user.role as string} departments={departments} />
+		</div>
+	);
 }

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -3,8 +3,10 @@
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import { requireRole, requireSession } from "@/lib/auth-utils";
+import { hashPassword } from "better-auth/crypto";
 import { canAssignRole } from "@/lib/permissions";
 import { createUserSchema, updateUserSchema } from "@/lib/validations/user";
+import { adminResetPasswordSchema } from "@/lib/validations/auth";
 import type { Role } from "@/app/generated/prisma/client";
 import { revalidatePath } from "next/cache";
 
@@ -119,6 +121,37 @@ export async function getUsersAction() {
 		return { success: true as const, data: users };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "Failed to fetch users";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function adminResetPasswordAction(userId: string, formData: unknown) {
+	try {
+		await requireRole("ADMIN");
+		const parsed = adminResetPasswordSchema.safeParse(formData);
+
+		if (!parsed.success) {
+			return { success: false as const, error: parsed.error.flatten().fieldErrors };
+		}
+
+		const account = await prisma.account.findFirst({
+			where: { userId, providerId: "credential" },
+		});
+
+		if (!account) {
+			return { success: false as const, error: "User does not have a password-based account" };
+		}
+
+		const hashedPassword = await hashPassword(parsed.data.newPassword);
+
+		await prisma.account.update({
+			where: { id: account.id },
+			data: { password: hashedPassword },
+		});
+
+		return { success: true as const, data: null };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to reset password";
 		return { success: false as const, error: message };
 	}
 }

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -127,11 +127,27 @@ export async function getUsersAction() {
 
 export async function adminResetPasswordAction(userId: string, formData: unknown) {
 	try {
-		await requireRole("ADMIN");
+		const session = await requireRole("ADMIN");
 		const parsed = adminResetPasswordSchema.safeParse(formData);
 
 		if (!parsed.success) {
 			return { success: false as const, error: parsed.error.flatten().fieldErrors };
+		}
+
+		const targetUser = await prisma.user.findUnique({
+			where: { id: userId },
+			select: { role: true },
+		});
+
+		if (!targetUser) {
+			return { success: false as const, error: "User not found" };
+		}
+
+		if (!canAssignRole(session.user.role as Role, targetUser.role)) {
+			return {
+				success: false as const,
+				error: "Insufficient permissions to reset this user's password",
+			};
 		}
 
 		const account = await prisma.account.findFirst({
@@ -144,10 +160,15 @@ export async function adminResetPasswordAction(userId: string, formData: unknown
 
 		const hashedPassword = await hashPassword(parsed.data.newPassword);
 
-		await prisma.account.update({
-			where: { id: account.id },
-			data: { password: hashedPassword },
-		});
+		await prisma.$transaction([
+			prisma.account.update({
+				where: { id: account.id },
+				data: { password: hashedPassword },
+			}),
+			prisma.session.deleteMany({
+				where: { userId },
+			}),
+		]);
 
 		return { success: true as const, data: null };
 	} catch (error) {

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -22,4 +22,4 @@ export const authClient = createAuthClient({
 	],
 });
 
-export const { signIn, signUp, signOut, useSession, linkSocial, unlinkAccount } = authClient;
+export const { signIn, signUp, signOut, useSession, linkSocial, unlinkAccount, changePassword } = authClient;

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -18,5 +18,28 @@ export const registerSchema = z
 		path: ["confirmPassword"],
 	});
 
+export const changePasswordSchema = z
+	.object({
+		currentPassword: z.string().min(1, "Current password is required"),
+		newPassword: z.string().min(8, "Password must be at least 8 characters"),
+		confirmPassword: z.string(),
+	})
+	.refine((data) => data.newPassword === data.confirmPassword, {
+		message: "Passwords do not match",
+		path: ["confirmPassword"],
+	});
+
+export const adminResetPasswordSchema = z
+	.object({
+		newPassword: z.string().min(8, "Password must be at least 8 characters"),
+		confirmPassword: z.string(),
+	})
+	.refine((data) => data.newPassword === data.confirmPassword, {
+		message: "Passwords do not match",
+		path: ["confirmPassword"],
+	});
+
 export type LoginInput = z.infer<typeof loginSchema>;
 export type RegisterInput = z.infer<typeof registerSchema>;
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
+export type AdminResetPasswordInput = z.infer<typeof adminResetPasswordSchema>;


### PR DESCRIPTION
## Summary
Closes #29

- **User: Change Own Password** — new "Security" tab under Profile (`/dashboard/profile/security`) with current password, new password, and confirm fields. Uses better-auth's built-in `changePassword` client API.
- **Admin: Reset User Password** — new "Reset Password" card on the admin user edit page (`/dashboard/users/[id]/edit`). Uses `hashPassword` from `better-auth/crypto` to hash and update the password directly in the accounts table.

### Files changed
- `lib/validations/auth.ts` — added `changePasswordSchema` and `adminResetPasswordSchema`
- `lib/auth-client.ts` — exported `changePassword`
- `lib/actions/user-actions.ts` — added `adminResetPasswordAction`
- `app/.../profile/_components/change-password-form.tsx` — new component
- `app/.../profile/_components/profile-nav.tsx` — added Security nav item
- `app/.../profile/security/page.tsx` — new page
- `app/.../users/_components/reset-password-form.tsx` — new component
- `app/.../users/[id]/edit/page.tsx` — added ResetPasswordForm

## Test plan
- [ ] User logs in → Profile → Security → changes password → logs out → logs in with new password
- [ ] User enters wrong current password → sees error
- [ ] User enters mismatched passwords → sees validation error
- [ ] Admin edits user → scrolls to Reset Password → sets new password → user can log in with it
- [ ] Admin enters mismatched passwords → sees validation error