### PR TITLE
feat(leaderboard): monthly reset + reveal window + archive (1/2)

### DIFF
--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Send, Inbox, Calendar, Trophy, Medal } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { Calendar, Heart, Inbox, Lock, Medal, Send, Trophy } from "lucide-react";
 import { UserAvatar } from "@/components/shared/user-avatar";
+import { cn } from "@/lib/utils";
 
 const PODIUM_STYLES = [
 	{
@@ -29,6 +29,15 @@ const PODIUM_STYLES = [
 	},
 ] as const;
 
+type LeaderboardVisibilityMode = "always" | "last_n_days_of_month" | "custom_range";
+
+interface LeaderboardVisibility {
+	visible: boolean;
+	mode: LeaderboardVisibilityMode;
+	revealStart: string | null;
+	revealEnd: string | null;
+}
+
 interface StatsData {
 	sent: number;
 	received: number;
@@ -39,8 +48,21 @@ interface StatsData {
 		avatar: string | null;
 		count: number;
 	}[];
+	leaderboardVisibility: LeaderboardVisibility;
 }
 
+const REVEAL_DATE_FORMATTER = new Intl.DateTimeFormat("en-AU", {
+	timeZone: "Asia/Manila",
+	month: "short",
+	day: "numeric",
+});
+
+function formatRevealRange(startIso: string, endIso: string): string {
+	const start = new Date(startIso);
+	// revealEnd is exclusive — subtract 1ms to display the inclusive last day
+	const lastDay = new Date(new Date(endIso).getTime() - 1);
+	return `${REVEAL_DATE_FORMATTER.format(start)} – ${REVEAL_DATE_FORMATTER.format(lastDay)}`;
+}
 
 function StatItem({
 	icon: Icon,
@@ -66,7 +88,11 @@ function StatItem({
 
 function StatsWidgetSkeleton() {
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] animate-pulse space-y-6 h-full" aria-busy="true" aria-label="Loading recognition stats">
+		<div
+			className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] animate-pulse space-y-6 h-full"
+			aria-busy="true"
+			aria-label="Loading recognition stats"
+		>
 			<div className="h-5 w-32 bg-gray-200 dark:bg-white/10 rounded" />
 			<div className="grid grid-cols-3 gap-4">
 				{[1, 2, 3].map((i) => (
@@ -86,6 +112,39 @@ function StatsWidgetSkeleton() {
 						<div className="h-4 w-24 bg-gray-200 dark:bg-white/10 rounded" />
 					</div>
 				))}
+			</div>
+		</div>
+	);
+}
+
+function LockedLeaderboard({ visibility }: { visibility: LeaderboardVisibility }) {
+	const hasRange = visibility.revealStart && visibility.revealEnd;
+	const rangeLabel = hasRange
+		? formatRevealRange(visibility.revealStart as string, visibility.revealEnd as string)
+		: null;
+
+	return (
+		<div className="flex flex-col min-h-0 flex-1">
+			<div className="flex items-center gap-2 mb-3 shrink-0">
+				<Lock size={16} className="text-muted-foreground" />
+				<h4 className="text-sm font-medium text-foreground/70">Most Recognized</h4>
+			</div>
+			<div className="flex flex-1 flex-col items-center justify-center rounded-2xl border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-6 py-8 text-center">
+				<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 mb-3">
+					<Lock size={18} className="text-primary" />
+				</div>
+				{rangeLabel ? (
+					<>
+						<p className="text-sm font-medium text-foreground">Rankings revealed</p>
+						<p className="text-sm text-muted-foreground mt-0.5">{rangeLabel}</p>
+					</>
+				) : (
+					<p className="text-sm font-medium text-foreground">Rankings hidden</p>
+				)}
+				<div className="mt-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+					<Heart size={12} className="text-primary" />
+					<span>Keep recognizing</span>
+				</div>
 			</div>
 		</div>
 	);
@@ -123,6 +182,9 @@ export function StatsWidget() {
 	}
 
 	const stats = data.data;
+	const visibility = stats.leaderboardVisibility;
+	const showList = visibility.visible && stats.topRecipients.length > 0;
+	const showLocked = !visibility.visible;
 
 	return (
 		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] flex flex-col gap-6 h-full">
@@ -131,30 +193,16 @@ export function StatsWidget() {
 			</h3>
 
 			<div className="grid grid-cols-3 gap-4 shrink-0">
-				<StatItem
-					icon={Send}
-					label="Cards Sent"
-					value={stats?.sent ?? 0}
-				/>
-				<StatItem
-					icon={Inbox}
-					label="Cards Received"
-					value={stats?.received ?? 0}
-				/>
-				<StatItem
-					icon={Calendar}
-					label="This Month"
-					value={stats?.monthlyTotal ?? 0}
-				/>
+				<StatItem icon={Send} label="Cards Sent" value={stats?.sent ?? 0} />
+				<StatItem icon={Inbox} label="Cards Received" value={stats?.received ?? 0} />
+				<StatItem icon={Calendar} label="This Month" value={stats?.monthlyTotal ?? 0} />
 			</div>
 
-			{stats?.topRecipients && stats.topRecipients.length > 0 && (
+			{showList ? (
 				<div className="flex flex-col min-h-0 flex-1">
 					<div className="flex items-center gap-2 mb-3 shrink-0">
 						<Trophy size={16} className="text-primary" />
-						<h4 className="text-sm font-medium text-foreground/70">
-							Most Recognized
-						</h4>
+						<h4 className="text-sm font-medium text-foreground/70">Most Recognized</h4>
 					</div>
 					<ol className="space-y-2 overflow-y-auto pr-1 flex-1 min-h-0">
 						{stats.topRecipients.map((person, index) => {
@@ -172,10 +220,7 @@ export function StatsWidget() {
 									)}
 								>
 									{isPodium ? (
-										<Medal
-											size={18}
-											className={cn("shrink-0", style?.medal)}
-										/>
+										<Medal size={18} className={cn("shrink-0", style?.medal)} />
 									) : (
 										<span className="w-[18px] text-xs font-semibold text-muted-foreground text-center shrink-0">
 											{index + 1}
@@ -205,9 +250,7 @@ export function StatsWidget() {
 									<span
 										className={cn(
 											"shrink-0 text-sm font-bold tabular-nums",
-											isPodium
-												? cn("rounded-full px-2.5 py-0.5", style?.countBg)
-												: "text-primary",
+											isPodium ? cn("rounded-full px-2.5 py-0.5", style?.countBg) : "text-primary",
 										)}
 									>
 										{person.count}
@@ -217,7 +260,9 @@ export function StatsWidget() {
 						})}
 					</ol>
 				</div>
-			)}
+			) : showLocked ? (
+				<LockedLeaderboard visibility={visibility} />
+			) : null}
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -73,9 +73,9 @@ function formatCountdown(msRemaining: number): string {
 	const minutes = Math.floor((totalSeconds % 3600) / 60);
 	const seconds = totalSeconds % 60;
 
-	if (days > 0) return `${days}d ${hours}h`;
-	if (hours > 0) return `${hours}h ${minutes}m`;
-	if (minutes > 0) return `${minutes}m ${seconds}s`;
+	if (days > 0) return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+	if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+	if (minutes > 0) return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 	return `${seconds}s`;
 }
 
@@ -112,8 +112,22 @@ function useCountdown(targetIso: string | null) {
 			timeoutId = window.setTimeout(tick, nextDelay);
 		}
 
+		// Re-tick immediately when the tab regains focus — browsers throttle
+		// timers in background tabs, so the scheduled tick may land well after
+		// the boundary otherwise.
+		function handleVisibility() {
+			if (document.visibilityState !== "visible") return;
+			if (timeoutId !== undefined) {
+				window.clearTimeout(timeoutId);
+				timeoutId = undefined;
+			}
+			tick();
+		}
+
 		tick();
+		document.addEventListener("visibilitychange", handleVisibility);
 		return () => {
+			document.removeEventListener("visibilitychange", handleVisibility);
 			if (timeoutId !== undefined) window.clearTimeout(timeoutId);
 		};
 	}, [targetIso, queryClient]);
@@ -264,6 +278,7 @@ export function StatsWidget() {
 	const resolvedVisibility = stats.leaderboardVisibility;
 	const showList = resolvedVisibility.visible && stats.topRecipients.length > 0;
 	const showLocked = !resolvedVisibility.visible;
+	const showEmpty = resolvedVisibility.visible && stats.topRecipients.length === 0;
 
 	return (
 		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] flex flex-col gap-6 h-full">
@@ -341,6 +356,18 @@ export function StatsWidget() {
 				</div>
 			) : showLocked ? (
 				<LockedLeaderboard visibility={resolvedVisibility} msRemaining={msRemaining} />
+			) : showEmpty ? (
+				<div className="flex flex-col min-h-0 flex-1">
+					<div className="flex items-center gap-2 mb-3 shrink-0">
+						<Trophy size={16} className="text-primary" />
+						<h4 className="text-sm font-medium text-foreground/70">Most Recognized</h4>
+					</div>
+					<div className="flex flex-1 items-center justify-center rounded-2xl border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-6 py-8 text-center">
+						<p className="text-sm text-muted-foreground">
+							No recognitions yet this month — be the first!
+						</p>
+					</div>
+				</div>
 			) : null}
 		</div>
 	);

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Calendar, Heart, Inbox, Lock, Medal, Send, Trophy } from "lucide-react";
+import { useEffect, useState } from "react";
 import { UserAvatar } from "@/components/shared/user-avatar";
 import { cn } from "@/lib/utils";
 
@@ -64,6 +65,51 @@ function formatRevealRange(startIso: string, endIso: string): string {
 	return `${REVEAL_DATE_FORMATTER.format(start)} – ${REVEAL_DATE_FORMATTER.format(lastDay)}`;
 }
 
+function formatCountdown(msRemaining: number): string {
+	if (msRemaining <= 0) return "any moment";
+	const totalSeconds = Math.floor(msRemaining / 1000);
+	const days = Math.floor(totalSeconds / 86400);
+	const hours = Math.floor((totalSeconds % 86400) / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+
+	if (days > 0) return `${days}d ${hours}h`;
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	if (minutes > 0) return `${minutes}m ${seconds}s`;
+	return `${seconds}s`;
+}
+
+function useCountdown(targetIso: string | null) {
+	const [msRemaining, setMsRemaining] = useState<number | null>(() => {
+		if (!targetIso) return null;
+		return new Date(targetIso).getTime() - Date.now();
+	});
+	const queryClient = useQueryClient();
+
+	useEffect(() => {
+		if (!targetIso) {
+			setMsRemaining(null);
+			return;
+		}
+		const target = new Date(targetIso).getTime();
+
+		function tick() {
+			const remaining = target - Date.now();
+			setMsRemaining(remaining);
+			if (remaining <= 0) {
+				queryClient.invalidateQueries({ queryKey: ["recognition-stats"] });
+			}
+		}
+
+		tick();
+		const intervalMs = target - Date.now() > 60 * 60 * 1000 ? 60_000 : 1_000;
+		const id = window.setInterval(tick, intervalMs);
+		return () => window.clearInterval(id);
+	}, [targetIso, queryClient]);
+
+	return msRemaining;
+}
+
 function StatItem({
 	icon: Icon,
 	label,
@@ -122,6 +168,8 @@ function LockedLeaderboard({ visibility }: { visibility: LeaderboardVisibility }
 	const rangeLabel = hasRange
 		? formatRevealRange(visibility.revealStart as string, visibility.revealEnd as string)
 		: null;
+	const msRemaining = useCountdown(visibility.revealStart);
+	const showCountdown = msRemaining !== null && msRemaining > 0;
 
 	return (
 		<div className="flex flex-col min-h-0 flex-1">
@@ -140,6 +188,11 @@ function LockedLeaderboard({ visibility }: { visibility: LeaderboardVisibility }
 					</>
 				) : (
 					<p className="text-sm font-medium text-foreground">Rankings hidden</p>
+				)}
+				{showCountdown && (
+					<p className="mt-3 text-sm font-semibold tabular-nums text-primary" aria-live="polite">
+						in {formatCountdown(msRemaining)}
+					</p>
 				)}
 				<div className="mt-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground">
 					<Heart size={12} className="text-primary" />

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -92,19 +92,30 @@ function useCountdown(targetIso: string | null) {
 			return;
 		}
 		const target = new Date(targetIso).getTime();
+		// Skip invalidation on the first tick if we mount already past the boundary
+		// — that state is authoritative from the server and doesn't need a refetch.
+		let startedPast = target - Date.now() <= 0;
+		let timeoutId: number | undefined;
 
 		function tick() {
 			const remaining = target - Date.now();
 			setMsRemaining(remaining);
 			if (remaining <= 0) {
-				queryClient.invalidateQueries({ queryKey: ["recognition-stats"] });
+				if (!startedPast) {
+					queryClient.invalidateQueries({ queryKey: ["recognition-stats"] });
+				}
+				return;
 			}
+			startedPast = false;
+			// Recompute delay every tick so the interval adapts as the boundary nears.
+			const nextDelay = remaining > 60 * 60 * 1000 ? 60_000 : 1_000;
+			timeoutId = window.setTimeout(tick, nextDelay);
 		}
 
 		tick();
-		const intervalMs = target - Date.now() > 60 * 60 * 1000 ? 60_000 : 1_000;
-		const id = window.setInterval(tick, intervalMs);
-		return () => window.clearInterval(id);
+		return () => {
+			if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+		};
 	}, [targetIso, queryClient]);
 
 	return msRemaining;
@@ -163,12 +174,17 @@ function StatsWidgetSkeleton() {
 	);
 }
 
-function LockedLeaderboard({ visibility }: { visibility: LeaderboardVisibility }) {
+function LockedLeaderboard({
+	visibility,
+	msRemaining,
+}: {
+	visibility: LeaderboardVisibility;
+	msRemaining: number | null;
+}) {
 	const hasRange = visibility.revealStart && visibility.revealEnd;
 	const rangeLabel = hasRange
 		? formatRevealRange(visibility.revealStart as string, visibility.revealEnd as string)
 		: null;
-	const msRemaining = useCountdown(visibility.revealStart);
 	const showCountdown = msRemaining !== null && msRemaining > 0;
 
 	return (
@@ -217,6 +233,16 @@ export function StatsWidget() {
 		staleTime: 30_000,
 	});
 
+	const visibility = data?.data?.leaderboardVisibility ?? null;
+	// Always watch the next boundary: revealEnd if the leaderboard is currently
+	// visible (so we hide it at month-end / range-end), otherwise revealStart.
+	const nextBoundaryIso = visibility
+		? visibility.visible
+			? visibility.revealEnd
+			: visibility.revealStart
+		: null;
+	const msRemaining = useCountdown(nextBoundaryIso);
+
 	if (isPending) {
 		return <StatsWidgetSkeleton />;
 	}
@@ -235,9 +261,9 @@ export function StatsWidget() {
 	}
 
 	const stats = data.data;
-	const visibility = stats.leaderboardVisibility;
-	const showList = visibility.visible && stats.topRecipients.length > 0;
-	const showLocked = !visibility.visible;
+	const resolvedVisibility = stats.leaderboardVisibility;
+	const showList = resolvedVisibility.visible && stats.topRecipients.length > 0;
+	const showLocked = !resolvedVisibility.visible;
 
 	return (
 		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] flex flex-col gap-6 h-full">
@@ -314,7 +340,7 @@ export function StatsWidget() {
 					</ol>
 				</div>
 			) : showLocked ? (
-				<LockedLeaderboard visibility={visibility} />
+				<LockedLeaderboard visibility={resolvedVisibility} msRemaining={msRemaining} />
 			) : null}
 		</div>
 	);

--- a/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { updateLeaderboardVisibilitySettings } from "@/lib/actions/settings-actions";
+import {
+	type LeaderboardVisibilityMode,
+	REVEAL_DAYS_MAX,
+	REVEAL_DAYS_MIN,
+} from "@/lib/leaderboard/visibility";
+
+const MODE_LABELS: Record<LeaderboardVisibilityMode, string> = {
+	always: "Always visible",
+	last_n_days_of_month: "Last N days of month",
+	custom_range: "Custom date range",
+};
+
+const MODE_DESCRIPTIONS: Record<LeaderboardVisibilityMode, string> = {
+	always: "Show the leaderboard all month.",
+	last_n_days_of_month: "Only reveal during the last N days of each month (Asia/Manila).",
+	custom_range: "Only show between a specific start and end date.",
+};
+
+export interface LeaderboardVisibilityPanelProps {
+	initialMode: LeaderboardVisibilityMode;
+	initialDays: number;
+	initialCustomStart: string | null;
+	initialCustomEnd: string | null;
+}
+
+export function LeaderboardVisibilityPanel({
+	initialMode,
+	initialDays,
+	initialCustomStart,
+	initialCustomEnd,
+}: LeaderboardVisibilityPanelProps) {
+	const [mode, setMode] = useState<LeaderboardVisibilityMode>(initialMode);
+	const [days, setDays] = useState<number>(initialDays);
+	const [customStart, setCustomStart] = useState<string>(initialCustomStart ?? "");
+	const [customEnd, setCustomEnd] = useState<string>(initialCustomEnd ?? "");
+	const [isPending, startTransition] = useTransition();
+	const queryClient = useQueryClient();
+
+	function save(next: {
+		mode: LeaderboardVisibilityMode;
+		days: number;
+		customStart: string;
+		customEnd: string;
+	}) {
+		startTransition(async () => {
+			try {
+				const result = await updateLeaderboardVisibilitySettings({
+					mode: next.mode,
+					revealDays: next.days,
+					customStart: next.customStart || null,
+					customEnd: next.customEnd || null,
+				});
+
+				if (!result.success) {
+					toast.error(result.error ?? "Failed to update visibility settings");
+					return;
+				}
+
+				toast.success("Leaderboard visibility updated");
+				queryClient.invalidateQueries({ queryKey: ["recognition-stats"] });
+			} catch {
+				toast.error("Failed to update visibility settings");
+			}
+		});
+	}
+
+	function handleModeChange(newMode: LeaderboardVisibilityMode) {
+		setMode(newMode);
+		save({ mode: newMode, days, customStart, customEnd });
+	}
+
+	function handleDaysBlur() {
+		const clamped = Math.min(
+			Math.max(Number.isFinite(days) ? days : REVEAL_DAYS_MIN, REVEAL_DAYS_MIN),
+			REVEAL_DAYS_MAX,
+		);
+		if (clamped !== days) setDays(clamped);
+		save({ mode, days: clamped, customStart, customEnd });
+	}
+
+	function handleCustomStartBlur() {
+		save({ mode, days, customStart, customEnd });
+	}
+
+	function handleCustomEndBlur() {
+		if (customStart && customEnd && customStart > customEnd) {
+			toast.error("Start date must be on or before end date");
+			return;
+		}
+		save({ mode, days, customStart, customEnd });
+	}
+
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
+			<div className="px-8 pt-8 pb-2">
+				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
+					Leaderboard Visibility
+				</h3>
+				<p className="mt-2 text-sm text-muted-foreground">
+					Control when the "Most Recognized" leaderboard is revealed on the dashboard. The
+					leaderboard resets each calendar month.
+				</p>
+			</div>
+
+			<div className="px-8 py-6 space-y-4">
+				<div className="flex items-center justify-between rounded-2xl border border-gray-200 dark:border-white/10 p-5 gap-4">
+					<div className="min-w-0">
+						<p className="text-sm font-medium text-foreground">Visibility mode</p>
+						<p className="text-xs text-muted-foreground">{MODE_DESCRIPTIONS[mode]}</p>
+					</div>
+					<Select
+						value={mode}
+						onValueChange={(val) => handleModeChange(val as LeaderboardVisibilityMode)}
+						disabled={isPending}
+					>
+						<SelectTrigger className="w-56 shrink-0">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="always">{MODE_LABELS.always}</SelectItem>
+							<SelectItem value="last_n_days_of_month">
+								{MODE_LABELS.last_n_days_of_month}
+							</SelectItem>
+							<SelectItem value="custom_range">{MODE_LABELS.custom_range}</SelectItem>
+						</SelectContent>
+					</Select>
+				</div>
+
+				{mode === "last_n_days_of_month" && (
+					<div className="flex items-center justify-between rounded-2xl border border-gray-200 dark:border-white/10 p-5 gap-4">
+						<div className="min-w-0">
+							<p className="text-sm font-medium text-foreground">Reveal days</p>
+							<p className="text-xs text-muted-foreground">
+								How many days before month-end to reveal the leaderboard.
+							</p>
+						</div>
+						<Input
+							type="number"
+							min={REVEAL_DAYS_MIN}
+							max={REVEAL_DAYS_MAX}
+							value={days}
+							onChange={(e) => setDays(Number.parseInt(e.target.value, 10))}
+							onBlur={handleDaysBlur}
+							disabled={isPending}
+							className="w-24 shrink-0"
+						/>
+					</div>
+				)}
+
+				{mode === "custom_range" && (
+					<div className="rounded-2xl border border-gray-200 dark:border-white/10 p-5 space-y-4">
+						<div className="flex items-center justify-between gap-4">
+							<div>
+								<Label
+									htmlFor="leaderboard-custom-start"
+									className="text-sm font-medium text-foreground"
+								>
+									Start date
+								</Label>
+								<p className="text-xs text-muted-foreground mt-0.5">Asia/Manila, inclusive.</p>
+							</div>
+							<Input
+								id="leaderboard-custom-start"
+								type="date"
+								value={customStart}
+								onChange={(e) => setCustomStart(e.target.value)}
+								onBlur={handleCustomStartBlur}
+								disabled={isPending}
+								className="w-48 shrink-0"
+							/>
+						</div>
+						<div className="flex items-center justify-between gap-4">
+							<div>
+								<Label
+									htmlFor="leaderboard-custom-end"
+									className="text-sm font-medium text-foreground"
+								>
+									End date
+								</Label>
+								<p className="text-xs text-muted-foreground mt-0.5">Asia/Manila, inclusive.</p>
+							</div>
+							<Input
+								id="leaderboard-custom-end"
+								type="date"
+								value={customEnd}
+								onChange={(e) => setCustomEnd(e.target.value)}
+								onBlur={handleCustomEndBlur}
+								disabled={isPending}
+								className="w-48 shrink-0"
+							/>
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
@@ -113,7 +113,8 @@ export function LeaderboardVisibilityPanel({
 				</h3>
 				<p className="mt-2 text-sm text-muted-foreground">
 					Control when the "Most Recognized" leaderboard is revealed on the dashboard. The
-					leaderboard resets each calendar month.
+					leaderboard resets each calendar month. All dates and month boundaries are interpreted in
+					Asia/Manila time.
 				</p>
 			</div>
 

--- a/app/(dashboard)/dashboard/admin-settings/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/page.tsx
@@ -1,6 +1,10 @@
-import { requireRole } from "@/lib/auth-utils";
 import { redirect } from "next/navigation";
-import { getTopRecognizedLimit } from "@/lib/actions/settings-actions";
+import {
+	getLeaderboardVisibilitySettings,
+	getTopRecognizedLimit,
+} from "@/lib/actions/settings-actions";
+import { requireRole } from "@/lib/auth-utils";
+import { LeaderboardVisibilityPanel } from "./_components/leaderboard-visibility";
 import { RecognitionSettingsPanel } from "./_components/recognition-settings";
 
 export default async function AdminSettingsPage() {
@@ -10,7 +14,10 @@ export default async function AdminSettingsPage() {
 		redirect("/dashboard");
 	}
 
-	const topLimit = await getTopRecognizedLimit();
+	const [topLimit, visibility] = await Promise.all([
+		getTopRecognizedLimit(),
+		getLeaderboardVisibilitySettings(),
+	]);
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-8 mt-2">
@@ -24,6 +31,13 @@ export default async function AdminSettingsPage() {
 			</div>
 
 			<RecognitionSettingsPanel initialLimit={topLimit} />
+
+			<LeaderboardVisibilityPanel
+				initialMode={visibility.mode}
+				initialDays={visibility.revealDays}
+				initialCustomStart={visibility.customStart}
+				initialCustomEnd={visibility.customEnd}
+			/>
 		</div>
 	);
 }

--- a/app/api/recognition/stats/route.ts
+++ b/app/api/recognition/stats/route.ts
@@ -1,67 +1,97 @@
+import {
+	getLeaderboardVisibilitySettings,
+	getTopRecognizedLimit,
+} from "@/lib/actions/settings-actions";
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
-import { getTopRecognizedLimit } from "@/lib/actions/settings-actions";
+import { getCurrentMonthBoundaries } from "@/lib/leaderboard/month";
+import { maybeSnapshotPreviousMonth } from "@/lib/leaderboard/snapshot";
+import { computeLeaderboardVisibility } from "@/lib/leaderboard/visibility";
 
 export async function GET() {
 	let session: Awaited<ReturnType<typeof requireSession>>;
 	try {
 		session = await requireSession();
 	} catch {
-		return Response.json(
-			{ success: false, error: "Unauthorized" },
-			{ status: 401 },
-		);
+		return Response.json({ success: false, error: "Unauthorized" }, { status: 401 });
 	}
 
 	try {
 		const userId = session.user.id;
 		const now = new Date();
-		const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-		const topLimit = await getTopRecognizedLimit();
+		const { start: startOfMonth, end: endOfMonth } = getCurrentMonthBoundaries(now);
 
-		const [sent, received, monthlyTotal, topRecipientsRaw] =
-			await Promise.all([
-				prisma.recognitionCard.count({
-					where: { senderId: userId },
-				}),
-				prisma.recognitionCard.count({
-					where: { recipientId: userId },
-				}),
-				prisma.recognitionCard.count({
-					where: { createdAt: { gte: startOfMonth } },
-				}),
-				prisma.recognitionCard.groupBy({
-					by: ["recipientId"],
-					_count: { recipientId: true },
-					orderBy: { _count: { recipientId: "desc" } },
-					take: topLimit,
-				}),
-			]);
-
-		const recipientIds = topRecipientsRaw.map((r) => r.recipientId);
-		const recipients = await prisma.user.findMany({
-			where: { id: { in: recipientIds } },
-			select: { id: true, firstName: true, lastName: true, avatar: true },
+		await maybeSnapshotPreviousMonth(now).catch(() => {
+			// Snapshot failures must not break the stats response.
 		});
 
-		const topRecipients = topRecipientsRaw.map((r) => {
-			const user = recipients.find((u) => u.id === r.recipientId);
-			return {
-				firstName: user?.firstName ?? "",
-				lastName: user?.lastName ?? "",
-				avatar: user?.avatar ?? null,
-				count: r._count.recipientId,
-			};
-		});
+		const [visibilitySettings, topLimit] = await Promise.all([
+			getLeaderboardVisibilitySettings(),
+			getTopRecognizedLimit(),
+		]);
+		const visibility = computeLeaderboardVisibility(visibilitySettings, now);
+
+		const [sent, received, monthlyTotal] = await Promise.all([
+			prisma.recognitionCard.count({
+				where: { senderId: userId },
+			}),
+			prisma.recognitionCard.count({
+				where: { recipientId: userId },
+			}),
+			prisma.recognitionCard.count({
+				where: { createdAt: { gte: startOfMonth, lt: endOfMonth } },
+			}),
+		]);
+
+		let topRecipients: Array<{
+			firstName: string;
+			lastName: string;
+			avatar: string | null;
+			count: number;
+		}> = [];
+
+		if (visibility.visible) {
+			const grouped = await prisma.recognitionCard.groupBy({
+				by: ["recipientId"],
+				where: { createdAt: { gte: startOfMonth, lt: endOfMonth } },
+				_count: { recipientId: true },
+				orderBy: { _count: { recipientId: "desc" } },
+				take: topLimit,
+			});
+
+			if (grouped.length > 0) {
+				const recipients = await prisma.user.findMany({
+					where: { id: { in: grouped.map((g) => g.recipientId) } },
+					select: { id: true, firstName: true, lastName: true, avatar: true },
+				});
+				topRecipients = grouped.map((g) => {
+					const user = recipients.find((u) => u.id === g.recipientId);
+					return {
+						firstName: user?.firstName ?? "",
+						lastName: user?.lastName ?? "",
+						avatar: user?.avatar ?? null,
+						count: g._count.recipientId,
+					};
+				});
+			}
+		}
 
 		return Response.json({
 			success: true,
-			data: { sent, received, monthlyTotal, topRecipients },
+			data: {
+				sent,
+				received,
+				monthlyTotal,
+				topRecipients,
+				leaderboardVisibility: {
+					visible: visibility.visible,
+					mode: visibility.mode,
+					revealStart: visibility.revealStart?.toISOString() ?? null,
+					revealEnd: visibility.revealEnd?.toISOString() ?? null,
+				},
+			},
 		});
 	} catch {
-		return Response.json(
-			{ success: false, error: "Internal server error" },
-			{ status: 500 },
-		);
+		return Response.json({ success: false, error: "Internal server error" }, { status: 500 });
 	}
 }

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -4,6 +4,11 @@ import { env } from "@/env";
 import { requireRole } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import {
+	TOP_RECOGNIZED_DEFAULT,
+	TOP_RECOGNIZED_MAX,
+	TOP_RECOGNIZED_MIN,
+} from "@/lib/leaderboard/constants";
+import {
 	LEADERBOARD_VISIBILITY_MODES,
 	type LeaderboardVisibilityMode,
 	type LeaderboardVisibilitySettings,
@@ -22,9 +27,6 @@ let cacheExpiry = 0;
 const CACHE_TTL_MS = 30_000;
 
 const TOP_RECOGNIZED_KEY = "top_recognized_limit";
-const TOP_RECOGNIZED_DEFAULT = 10;
-const TOP_RECOGNIZED_MIN = 1;
-const TOP_RECOGNIZED_MAX = 50;
 
 let cachedTopLimit: number | null = null;
 let topLimitCacheExpiry = 0;
@@ -161,7 +163,10 @@ function invalidateLeaderboardCache() {
 }
 
 function isValidIsoDate(value: string): boolean {
-	return /^\d{4}-\d{2}-\d{2}$/.test(value);
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+	// Round-trip to reject impossible calendar dates like 2026-02-31.
+	const parsed = new Date(`${value}T00:00:00Z`);
+	return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(value);
 }
 
 function isLeaderboardMode(value: string): value is LeaderboardVisibilityMode {

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -221,11 +221,15 @@ export async function updateLeaderboardVisibilitySettings(
 		return { success: false, error: "Invalid visibility mode" };
 	}
 
-	if (
-		!Number.isInteger(input.revealDays) ||
-		input.revealDays < REVEAL_DAYS_MIN ||
-		input.revealDays > REVEAL_DAYS_MAX
-	) {
+	const revealDaysIsValid =
+		Number.isInteger(input.revealDays) &&
+		input.revealDays >= REVEAL_DAYS_MIN &&
+		input.revealDays <= REVEAL_DAYS_MAX;
+
+	// Only block the save on revealDays errors when the chosen mode actually
+	// consumes that field. Otherwise an admin switching to `always` / `custom_range`
+	// with a still-editing Reveal days input would be blocked on a now-hidden field.
+	if (input.mode === "last_n_days_of_month" && !revealDaysIsValid) {
 		return {
 			success: false,
 			error: `Reveal days must be between ${REVEAL_DAYS_MIN} and ${REVEAL_DAYS_MAX}`,
@@ -252,6 +256,7 @@ export async function updateLeaderboardVisibilitySettings(
 		}
 	}
 
+	const normalizedDays = revealDaysIsValid ? input.revealDays : REVEAL_DAYS_DEFAULT;
 	const normalizedStart =
 		input.customStart && isValidIsoDate(input.customStart) ? input.customStart : "";
 	const normalizedEnd = input.customEnd && isValidIsoDate(input.customEnd) ? input.customEnd : "";
@@ -264,8 +269,8 @@ export async function updateLeaderboardVisibilitySettings(
 		}),
 		prisma.appSetting.upsert({
 			where: { key: LEADERBOARD_DAYS_KEY },
-			update: { value: String(input.revealDays) },
-			create: { key: LEADERBOARD_DAYS_KEY, value: String(input.revealDays) },
+			update: { value: String(normalizedDays) },
+			create: { key: LEADERBOARD_DAYS_KEY, value: String(normalizedDays) },
 		}),
 		prisma.appSetting.upsert({
 			where: { key: LEADERBOARD_CUSTOM_START_KEY },

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -1,8 +1,16 @@
 "use server";
 
-import { prisma } from "@/lib/db";
-import { requireRole } from "@/lib/auth-utils";
 import { env } from "@/env";
+import { requireRole } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+import {
+	LEADERBOARD_VISIBILITY_MODES,
+	type LeaderboardVisibilityMode,
+	type LeaderboardVisibilitySettings,
+	REVEAL_DAYS_DEFAULT,
+	REVEAL_DAYS_MAX,
+	REVEAL_DAYS_MIN,
+} from "@/lib/leaderboard/visibility";
 
 const OAUTH_KEYS = ["oauth_google_enabled", "oauth_microsoft_enabled"] as const;
 type OAuthKey = (typeof OAUTH_KEYS)[number];
@@ -113,11 +121,7 @@ export async function updateTopRecognizedLimit(
 		return { success: false, error: "Unauthorized" };
 	}
 
-	if (
-		!Number.isInteger(limit) ||
-		limit < TOP_RECOGNIZED_MIN ||
-		limit > TOP_RECOGNIZED_MAX
-	) {
+	if (!Number.isInteger(limit) || limit < TOP_RECOGNIZED_MIN || limit > TOP_RECOGNIZED_MAX) {
 		return {
 			success: false,
 			error: `Limit must be between ${TOP_RECOGNIZED_MIN} and ${TOP_RECOGNIZED_MAX}`,
@@ -131,6 +135,151 @@ export async function updateTopRecognizedLimit(
 	});
 
 	invalidateTopLimitCache();
+
+	return { success: true };
+}
+
+/* ── Leaderboard Visibility ──────────────────────────── */
+
+const LEADERBOARD_MODE_KEY = "leaderboard_visibility_mode";
+const LEADERBOARD_DAYS_KEY = "leaderboard_reveal_days";
+const LEADERBOARD_CUSTOM_START_KEY = "leaderboard_custom_start";
+const LEADERBOARD_CUSTOM_END_KEY = "leaderboard_custom_end";
+const LEADERBOARD_KEYS = [
+	LEADERBOARD_MODE_KEY,
+	LEADERBOARD_DAYS_KEY,
+	LEADERBOARD_CUSTOM_START_KEY,
+	LEADERBOARD_CUSTOM_END_KEY,
+];
+
+let cachedLeaderboard: LeaderboardVisibilitySettings | null = null;
+let leaderboardCacheExpiry = 0;
+
+function invalidateLeaderboardCache() {
+	cachedLeaderboard = null;
+	leaderboardCacheExpiry = 0;
+}
+
+function isValidIsoDate(value: string): boolean {
+	return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function isLeaderboardMode(value: string): value is LeaderboardVisibilityMode {
+	return (LEADERBOARD_VISIBILITY_MODES as string[]).includes(value);
+}
+
+export async function getLeaderboardVisibilitySettings(): Promise<LeaderboardVisibilitySettings> {
+	if (cachedLeaderboard && Date.now() < leaderboardCacheExpiry) {
+		return cachedLeaderboard;
+	}
+
+	const rows = await prisma.appSetting.findMany({
+		where: { key: { in: LEADERBOARD_KEYS } },
+	});
+	const map = new Map(rows.map((r) => [r.key, r.value]));
+
+	const rawMode = map.get(LEADERBOARD_MODE_KEY) ?? "always";
+	const mode: LeaderboardVisibilityMode = isLeaderboardMode(rawMode) ? rawMode : "always";
+
+	const parsedDays = Number.parseInt(map.get(LEADERBOARD_DAYS_KEY) ?? "", 10);
+	const revealDays =
+		Number.isFinite(parsedDays) && parsedDays >= REVEAL_DAYS_MIN && parsedDays <= REVEAL_DAYS_MAX
+			? parsedDays
+			: REVEAL_DAYS_DEFAULT;
+
+	const rawStart = map.get(LEADERBOARD_CUSTOM_START_KEY) ?? null;
+	const rawEnd = map.get(LEADERBOARD_CUSTOM_END_KEY) ?? null;
+
+	cachedLeaderboard = {
+		mode,
+		revealDays,
+		customStart: rawStart && isValidIsoDate(rawStart) ? rawStart : null,
+		customEnd: rawEnd && isValidIsoDate(rawEnd) ? rawEnd : null,
+	};
+	leaderboardCacheExpiry = Date.now() + CACHE_TTL_MS;
+
+	return cachedLeaderboard;
+}
+
+export interface UpdateLeaderboardVisibilityInput {
+	mode: LeaderboardVisibilityMode;
+	revealDays: number;
+	customStart: string | null;
+	customEnd: string | null;
+}
+
+export async function updateLeaderboardVisibilitySettings(
+	input: UpdateLeaderboardVisibilityInput,
+): Promise<{ success: boolean; error?: string }> {
+	try {
+		await requireRole("ADMIN");
+	} catch {
+		return { success: false, error: "Unauthorized" };
+	}
+
+	if (!isLeaderboardMode(input.mode)) {
+		return { success: false, error: "Invalid visibility mode" };
+	}
+
+	if (
+		!Number.isInteger(input.revealDays) ||
+		input.revealDays < REVEAL_DAYS_MIN ||
+		input.revealDays > REVEAL_DAYS_MAX
+	) {
+		return {
+			success: false,
+			error: `Reveal days must be between ${REVEAL_DAYS_MIN} and ${REVEAL_DAYS_MAX}`,
+		};
+	}
+
+	if (input.mode === "custom_range") {
+		if (
+			!input.customStart ||
+			!input.customEnd ||
+			!isValidIsoDate(input.customStart) ||
+			!isValidIsoDate(input.customEnd)
+		) {
+			return {
+				success: false,
+				error: "Custom range requires valid start and end dates",
+			};
+		}
+		if (input.customStart > input.customEnd) {
+			return {
+				success: false,
+				error: "Start date must be on or before end date",
+			};
+		}
+	}
+
+	const normalizedStart =
+		input.customStart && isValidIsoDate(input.customStart) ? input.customStart : "";
+	const normalizedEnd = input.customEnd && isValidIsoDate(input.customEnd) ? input.customEnd : "";
+
+	await prisma.$transaction([
+		prisma.appSetting.upsert({
+			where: { key: LEADERBOARD_MODE_KEY },
+			update: { value: input.mode },
+			create: { key: LEADERBOARD_MODE_KEY, value: input.mode },
+		}),
+		prisma.appSetting.upsert({
+			where: { key: LEADERBOARD_DAYS_KEY },
+			update: { value: String(input.revealDays) },
+			create: { key: LEADERBOARD_DAYS_KEY, value: String(input.revealDays) },
+		}),
+		prisma.appSetting.upsert({
+			where: { key: LEADERBOARD_CUSTOM_START_KEY },
+			update: { value: normalizedStart },
+			create: { key: LEADERBOARD_CUSTOM_START_KEY, value: normalizedStart },
+		}),
+		prisma.appSetting.upsert({
+			where: { key: LEADERBOARD_CUSTOM_END_KEY },
+			update: { value: normalizedEnd },
+			create: { key: LEADERBOARD_CUSTOM_END_KEY, value: normalizedEnd },
+		}),
+	]);
+
+	invalidateLeaderboardCache();
 
 	return { success: true };
 }

--- a/lib/leaderboard/constants.ts
+++ b/lib/leaderboard/constants.ts
@@ -1,0 +1,3 @@
+export const TOP_RECOGNIZED_MIN = 1;
+export const TOP_RECOGNIZED_MAX = 50;
+export const TOP_RECOGNIZED_DEFAULT = 10;

--- a/lib/leaderboard/month.ts
+++ b/lib/leaderboard/month.ts
@@ -1,0 +1,57 @@
+const TZ_OFFSET_HOURS = 8;
+const TZ_OFFSET_MS = TZ_OFFSET_HOURS * 60 * 60 * 1000;
+
+export interface MonthBoundaries {
+	start: Date;
+	end: Date;
+	monthKey: string;
+	year: number;
+	month: number;
+	daysInMonth: number;
+}
+
+export function toMonthKey(year: number, monthIndex: number): string {
+	return `${year}-${String(monthIndex + 1).padStart(2, "0")}`;
+}
+
+export function parseMonthKey(key: string): { year: number; month: number } {
+	const [yStr, mStr] = key.split("-");
+	const year = Number.parseInt(yStr ?? "", 10);
+	const month = Number.parseInt(mStr ?? "", 10) - 1;
+	if (Number.isNaN(year) || Number.isNaN(month) || month < 0 || month > 11) {
+		throw new Error(`Invalid month key: ${key}`);
+	}
+	return { year, month };
+}
+
+function getManilaParts(now: Date): { year: number; month: number } {
+	const shifted = new Date(now.getTime() + TZ_OFFSET_MS);
+	return {
+		year: shifted.getUTCFullYear(),
+		month: shifted.getUTCMonth(),
+	};
+}
+
+function manilaMidnightToUtc(year: number, monthIndex: number, day: number): Date {
+	return new Date(Date.UTC(year, monthIndex, day, 0, 0, 0, 0) - TZ_OFFSET_MS);
+}
+
+export function getMonthBoundariesForKey(monthKey: string): MonthBoundaries {
+	const { year, month } = parseMonthKey(monthKey);
+	const start = manilaMidnightToUtc(year, month, 1);
+	const end = manilaMidnightToUtc(year, month + 1, 1);
+	const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+	return { start, end, monthKey, year, month, daysInMonth };
+}
+
+export function getCurrentMonthBoundaries(now: Date = new Date()): MonthBoundaries {
+	const { year, month } = getManilaParts(now);
+	return getMonthBoundariesForKey(toMonthKey(year, month));
+}
+
+export function getPreviousMonthKey(now: Date = new Date()): string {
+	const { year, month } = getManilaParts(now);
+	const prevYear = month === 0 ? year - 1 : year;
+	const prevMonth = month === 0 ? 11 : month - 1;
+	return toMonthKey(prevYear, prevMonth);
+}

--- a/lib/leaderboard/snapshot.ts
+++ b/lib/leaderboard/snapshot.ts
@@ -1,0 +1,71 @@
+import type { Prisma } from "@/app/generated/prisma/client";
+import { getTopRecognizedLimit } from "@/lib/actions/settings-actions";
+import { prisma } from "@/lib/db";
+import { getMonthBoundariesForKey, getPreviousMonthKey } from "./month";
+
+export interface SnapshotRecipient {
+	userId: string;
+	firstName: string;
+	lastName: string;
+	avatar: string | null;
+	count: number;
+	rank: number;
+}
+
+export async function computeMonthRecipients(
+	monthKey: string,
+	topLimit: number,
+): Promise<SnapshotRecipient[]> {
+	const { start, end } = getMonthBoundariesForKey(monthKey);
+
+	const grouped = await prisma.recognitionCard.groupBy({
+		by: ["recipientId"],
+		where: { createdAt: { gte: start, lt: end } },
+		_count: { recipientId: true },
+		orderBy: { _count: { recipientId: "desc" } },
+		take: topLimit,
+	});
+
+	if (grouped.length === 0) return [];
+
+	const users = await prisma.user.findMany({
+		where: { id: { in: grouped.map((g) => g.recipientId) } },
+		select: { id: true, firstName: true, lastName: true, avatar: true },
+	});
+
+	return grouped.map((g, index) => {
+		const user = users.find((u) => u.id === g.recipientId);
+		return {
+			userId: g.recipientId,
+			firstName: user?.firstName ?? "",
+			lastName: user?.lastName ?? "",
+			avatar: user?.avatar ?? null,
+			count: g._count.recipientId,
+			rank: index + 1,
+		};
+	});
+}
+
+export async function maybeSnapshotPreviousMonth(now: Date = new Date()): Promise<void> {
+	const prevKey = getPreviousMonthKey(now);
+
+	const existing = await prisma.monthlyLeaderboardSnapshot.findUnique({
+		where: { month: prevKey },
+		select: { id: true },
+	});
+	if (existing) return;
+
+	const topLimit = await getTopRecognizedLimit();
+	const recipients = await computeMonthRecipients(prevKey, topLimit);
+	if (recipients.length === 0) return;
+
+	await prisma.monthlyLeaderboardSnapshot.upsert({
+		where: { month: prevKey },
+		create: {
+			month: prevKey,
+			recipients: recipients as unknown as Prisma.InputJsonValue,
+			topLimit,
+		},
+		update: {},
+	});
+}

--- a/lib/leaderboard/snapshot.ts
+++ b/lib/leaderboard/snapshot.ts
@@ -1,12 +1,16 @@
 import type { Prisma } from "@/app/generated/prisma/client";
 import { prisma } from "@/lib/db";
+import { TOP_RECOGNIZED_MAX } from "./constants";
 import { getMonthBoundariesForKey, getPreviousMonthKey } from "./month";
 
 // Archive up to the maximum possible top-N so the snapshot is authoritative
-// regardless of how admins change `top_recognized_limit` later. Must match
-// TOP_RECOGNIZED_MAX in lib/actions/settings-actions.ts. History consumers
-// should trim to the current limit at display time.
-const SNAPSHOT_TOP_N = 50;
+// regardless of how admins change `top_recognized_limit` later. History
+// consumers should trim to the current limit at display time.
+const SNAPSHOT_TOP_N = TOP_RECOGNIZED_MAX;
+
+// Remember the previous-month key we've already verified/written this process
+// lifetime, so the hot path skips a DB round-trip on every stats fetch.
+let resolvedMonthKey: string | null = null;
 
 export interface SnapshotRecipient {
 	userId: string;
@@ -53,15 +57,23 @@ export async function computeMonthRecipients(
 
 export async function maybeSnapshotPreviousMonth(now: Date = new Date()): Promise<void> {
 	const prevKey = getPreviousMonthKey(now);
+	if (resolvedMonthKey === prevKey) return;
 
 	const existing = await prisma.monthlyLeaderboardSnapshot.findUnique({
 		where: { month: prevKey },
 		select: { id: true },
 	});
-	if (existing) return;
+	if (existing) {
+		resolvedMonthKey = prevKey;
+		return;
+	}
 
 	const recipients = await computeMonthRecipients(prevKey, SNAPSHOT_TOP_N);
-	if (recipients.length === 0) return;
+	if (recipients.length === 0) {
+		// No data to archive — mark resolved so we don't re-query every request.
+		resolvedMonthKey = prevKey;
+		return;
+	}
 
 	await prisma.monthlyLeaderboardSnapshot.upsert({
 		where: { month: prevKey },
@@ -72,4 +84,5 @@ export async function maybeSnapshotPreviousMonth(now: Date = new Date()): Promis
 		},
 		update: {},
 	});
+	resolvedMonthKey = prevKey;
 }

--- a/lib/leaderboard/snapshot.ts
+++ b/lib/leaderboard/snapshot.ts
@@ -1,7 +1,12 @@
 import type { Prisma } from "@/app/generated/prisma/client";
-import { getTopRecognizedLimit } from "@/lib/actions/settings-actions";
 import { prisma } from "@/lib/db";
 import { getMonthBoundariesForKey, getPreviousMonthKey } from "./month";
+
+// Archive up to the maximum possible top-N so the snapshot is authoritative
+// regardless of how admins change `top_recognized_limit` later. Must match
+// TOP_RECOGNIZED_MAX in lib/actions/settings-actions.ts. History consumers
+// should trim to the current limit at display time.
+const SNAPSHOT_TOP_N = 50;
 
 export interface SnapshotRecipient {
 	userId: string;
@@ -55,8 +60,7 @@ export async function maybeSnapshotPreviousMonth(now: Date = new Date()): Promis
 	});
 	if (existing) return;
 
-	const topLimit = await getTopRecognizedLimit();
-	const recipients = await computeMonthRecipients(prevKey, topLimit);
+	const recipients = await computeMonthRecipients(prevKey, SNAPSHOT_TOP_N);
 	if (recipients.length === 0) return;
 
 	await prisma.monthlyLeaderboardSnapshot.upsert({
@@ -64,7 +68,7 @@ export async function maybeSnapshotPreviousMonth(now: Date = new Date()): Promis
 		create: {
 			month: prevKey,
 			recipients: recipients as unknown as Prisma.InputJsonValue,
-			topLimit,
+			topLimit: SNAPSHOT_TOP_N,
 		},
 		update: {},
 	});

--- a/lib/leaderboard/visibility.ts
+++ b/lib/leaderboard/visibility.ts
@@ -1,0 +1,95 @@
+import { getCurrentMonthBoundaries } from "./month";
+
+export type LeaderboardVisibilityMode = "always" | "last_n_days_of_month" | "custom_range";
+
+export const LEADERBOARD_VISIBILITY_MODES: LeaderboardVisibilityMode[] = [
+	"always",
+	"last_n_days_of_month",
+	"custom_range",
+];
+
+export const REVEAL_DAYS_MIN = 1;
+export const REVEAL_DAYS_MAX = 14;
+export const REVEAL_DAYS_DEFAULT = 7;
+
+export interface LeaderboardVisibilitySettings {
+	mode: LeaderboardVisibilityMode;
+	revealDays: number;
+	customStart: string | null;
+	customEnd: string | null;
+}
+
+export interface LeaderboardVisibilityState {
+	visible: boolean;
+	revealStart: Date | null;
+	revealEnd: Date | null;
+	mode: LeaderboardVisibilityMode;
+}
+
+const TZ_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+function manilaIsoDateToUtcStart(dateStr: string): Date | null {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+	if (!match) return null;
+	const year = Number.parseInt(match[1] ?? "", 10);
+	const month = Number.parseInt(match[2] ?? "", 10) - 1;
+	const day = Number.parseInt(match[3] ?? "", 10);
+	if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+		return null;
+	}
+	return new Date(Date.UTC(year, month, day, 0, 0, 0, 0) - TZ_OFFSET_MS);
+}
+
+function manilaIsoDateToUtcEndExclusive(dateStr: string): Date | null {
+	const start = manilaIsoDateToUtcStart(dateStr);
+	if (!start) return null;
+	return new Date(start.getTime() + 24 * 60 * 60 * 1000);
+}
+
+export function computeLeaderboardVisibility(
+	settings: LeaderboardVisibilitySettings,
+	now: Date = new Date(),
+): LeaderboardVisibilityState {
+	if (settings.mode === "always") {
+		return {
+			visible: true,
+			revealStart: null,
+			revealEnd: null,
+			mode: "always",
+		};
+	}
+
+	if (settings.mode === "last_n_days_of_month") {
+		const { end: monthEnd, year, month, daysInMonth } = getCurrentMonthBoundaries(now);
+		const clampedDays = Math.min(Math.max(settings.revealDays, REVEAL_DAYS_MIN), REVEAL_DAYS_MAX);
+		const firstRevealDay = Math.max(1, daysInMonth - clampedDays + 1);
+		const revealStart = new Date(Date.UTC(year, month, firstRevealDay, 0, 0, 0, 0) - TZ_OFFSET_MS);
+		const visible = now.getTime() >= revealStart.getTime() && now.getTime() < monthEnd.getTime();
+		return {
+			visible,
+			revealStart,
+			revealEnd: monthEnd,
+			mode: "last_n_days_of_month",
+		};
+	}
+
+	const start = settings.customStart ? manilaIsoDateToUtcStart(settings.customStart) : null;
+	const end = settings.customEnd ? manilaIsoDateToUtcEndExclusive(settings.customEnd) : null;
+
+	if (!start || !end || end.getTime() <= start.getTime()) {
+		return {
+			visible: false,
+			revealStart: null,
+			revealEnd: null,
+			mode: "custom_range",
+		};
+	}
+
+	const visible = now.getTime() >= start.getTime() && now.getTime() < end.getTime();
+	return {
+		visible,
+		revealStart: start,
+		revealEnd: end,
+		mode: "custom_range",
+	};
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,6 +153,8 @@ model RecognitionCard {
   reactions     CardReaction[]
   comments      CardComment[]
 
+  @@index([createdAt])
+  @@index([recipientId, createdAt])
   @@map("recognition_cards")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,6 +121,16 @@ model AppSetting {
   @@map("app_settings")
 }
 
+model MonthlyLeaderboardSnapshot {
+  id         String   @id @default(cuid())
+  month      String   @unique
+  recipients Json
+  topLimit   Int      @map("top_limit")
+  snapshotAt DateTime @default(now()) @map("snapshot_at")
+
+  @@map("monthly_leaderboard_snapshots")
+}
+
 model RecognitionCard {
   id        String   @id @default(uuid())
   message   String


### PR DESCRIPTION
## Summary

Part 1 of 2 for #33. Turns the Most Recognized leaderboard into a monthly contest with a configurable reveal window, and starts archiving each month's results. Personal stats (Cards Sent / Received / This Month) remain always visible — only the ranked leaderboard is gated.

- **Monthly reset** — leaderboard now scopes to the current Asia/Manila calendar month instead of all-time.
- **Configurable reveal window** — admin-settings lets admins pick `always`, `last N days of month` (N = 1–14), or a one-off `custom range`.
- **Locked state UI** — outside the window, the widget shows a lock icon and the reveal date range (e.g. _"Rankings revealed Apr 24 – Apr 30"_). Same UX for everyone — no admin bypass.
- **Lazy archive** — first `/api/recognition/stats` request after month rollover writes a `MonthlyLeaderboardSnapshot` for the prior month. No cron needed; upsert is idempotent so races are benign.

PR 2 will add the user-facing `/dashboard/leaderboard` history page that reads from these snapshots.

## Files touched

- `prisma/schema.prisma` — new `MonthlyLeaderboardSnapshot` model (keyed on `month` = `YYYY-MM`, JSON recipients payload)
- `lib/leaderboard/month.ts` — Asia/Manila boundary helpers + month-key parsing
- `lib/leaderboard/visibility.ts` — `computeLeaderboardVisibility()` across all 3 modes
- `lib/leaderboard/snapshot.ts` — `maybeSnapshotPreviousMonth()` lazy archiver
- `lib/actions/settings-actions.ts` — 4 new AppSetting keys + `get/updateLeaderboardVisibilitySettings`
- `app/api/recognition/stats/route.ts` — month-scoped leaderboard, visibility gating, snapshot call
- `app/(dashboard)/dashboard/_components/stats-widget.tsx` — locked card rendering
- `app/(dashboard)/dashboard/admin-settings/` — new visibility panel

## Deployment notes

- Schema is additive (one new table, no existing columns changed). Run `bunx prisma db push` (dev) or `bunx prisma migrate deploy` (prod) before merging.
- No new npm packages.
- Timezone is hardcoded to Asia/Manila as agreed.

## Test plan

- [ ] Run `bunx prisma db push` locally to apply the schema
- [ ] Visit `/dashboard/admin-settings` as ADMIN — verify the new "Leaderboard Visibility" panel renders, changing mode persists across reload
- [ ] Set mode to `always` — `/dashboard` shows Most Recognized (current-month only)
- [ ] Set mode to `last_n_days_of_month` with N = 1 on the last day of a month — widget shows the list; set N = 1 mid-month — widget shows the locked card with correct reveal range
- [ ] Set mode to `custom_range` with a future start date — widget shows locked card with that range
- [ ] Set mode to `custom_range` with dates in the past — widget shows "Rankings hidden" (no range)
- [ ] Verify non-admin users see the same locked state (no admin bypass)
- [ ] After a month rollover, inspect `monthly_leaderboard_snapshots` table — previous month should be written on first stats fetch
- [ ] `bun lint` + `bun run build` pass locally

Closes in part #33.