### PR TITLE
feat(leaderboard): history page with month picker (2/2)

### DIFF
--- a/app/(dashboard)/dashboard/leaderboard/_components/leaderboard-list.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/_components/leaderboard-list.tsx
@@ -1,0 +1,189 @@
+import { Lock, Medal, Trophy } from "lucide-react";
+import { UserAvatar } from "@/components/shared/user-avatar";
+import { formatMonthLabel, type MonthLeaderboard } from "@/lib/leaderboard/history";
+import { cn } from "@/lib/utils";
+
+const PODIUM_STYLES = [
+	{
+		ring: "ring-2 ring-amber-400/60",
+		bg: "bg-amber-50 dark:bg-amber-400/15",
+		text: "text-amber-600 dark:text-amber-400",
+		medal: "text-amber-500",
+		countBg: "bg-amber-50 dark:bg-amber-400/10 text-amber-600 dark:text-amber-400",
+	},
+	{
+		ring: "ring-2 ring-gray-300/80 dark:ring-gray-400/40",
+		bg: "bg-gray-100 dark:bg-gray-400/15",
+		text: "text-gray-500 dark:text-gray-300",
+		medal: "text-gray-400 dark:text-gray-300",
+		countBg: "bg-gray-100 dark:bg-gray-400/10 text-gray-500 dark:text-gray-300",
+	},
+	{
+		ring: "ring-2 ring-orange-400/50 dark:ring-orange-500/40",
+		bg: "bg-orange-50 dark:bg-orange-400/15",
+		text: "text-orange-600 dark:text-orange-400",
+		medal: "text-orange-500 dark:text-orange-400",
+		countBg: "bg-orange-50 dark:bg-orange-400/10 text-orange-600 dark:text-orange-400",
+	},
+] as const;
+
+const REVEAL_DATE_FORMATTER = new Intl.DateTimeFormat("en-AU", {
+	timeZone: "Asia/Manila",
+	month: "short",
+	day: "numeric",
+});
+
+const SNAPSHOT_DATE_FORMATTER = new Intl.DateTimeFormat("en-AU", {
+	timeZone: "Asia/Manila",
+	dateStyle: "medium",
+});
+
+function formatRevealRange(start: Date, end: Date): string {
+	// revealEnd is exclusive — subtract 1ms to display the inclusive last day.
+	const lastDay = new Date(end.getTime() - 1);
+	return `${REVEAL_DATE_FORMATTER.format(start)} – ${REVEAL_DATE_FORMATTER.format(lastDay)}`;
+}
+
+function PanelShell({ children }: { children: React.ReactNode }) {
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+			{children}
+		</div>
+	);
+}
+
+function EmptyMessage({ title, body }: { title: string; body?: string }) {
+	return (
+		<PanelShell>
+			<div className="flex flex-col items-center justify-center px-8 py-16 text-center">
+				<div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 mb-4">
+					<Trophy size={22} className="text-primary" />
+				</div>
+				<p className="text-base font-medium text-foreground">{title}</p>
+				{body && <p className="mt-1 text-sm text-muted-foreground">{body}</p>}
+			</div>
+		</PanelShell>
+	);
+}
+
+export function LeaderboardList({ data }: { data: MonthLeaderboard }) {
+	if (data.kind === "missing") {
+		return (
+			<EmptyMessage
+				title={`No snapshot for ${formatMonthLabel(data.monthKey)}`}
+				body="This month isn't archived. It may predate the archive feature."
+			/>
+		);
+	}
+
+	if (data.kind === "locked") {
+		const { revealStart, revealEnd } = data.visibility;
+		const rangeLabel = revealStart && revealEnd ? formatRevealRange(revealStart, revealEnd) : null;
+		return (
+			<PanelShell>
+				<div className="flex flex-col items-center justify-center px-8 py-16 text-center">
+					<div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 mb-4">
+						<Lock size={22} className="text-primary" />
+					</div>
+					<p className="text-base font-medium text-foreground">
+						{rangeLabel ? "Rankings revealed" : "Rankings hidden"}
+					</p>
+					{rangeLabel && <p className="mt-1 text-sm text-muted-foreground">{rangeLabel}</p>}
+					<p className="mt-4 text-xs text-muted-foreground">
+						This month's leaderboard is not yet visible.
+					</p>
+				</div>
+			</PanelShell>
+		);
+	}
+
+	const { recipients } = data;
+	const isLive = data.kind === "live";
+	const badge = isLive ? "Live" : `Archived ${SNAPSHOT_DATE_FORMATTER.format(data.snapshotAt)}`;
+
+	if (recipients.length === 0) {
+		return (
+			<EmptyMessage
+				title={`No recognitions in ${formatMonthLabel(data.monthKey)}`}
+				body={isLive ? "Be the first to recognize a colleague this month!" : undefined}
+			/>
+		);
+	}
+
+	return (
+		<PanelShell>
+			<div className="px-6 py-6 sm:px-8 sm:py-8">
+				<div className="flex flex-wrap items-center gap-3 mb-6">
+					<Trophy size={20} className="text-primary" />
+					<h2 className="text-[1.25rem] font-medium text-foreground tracking-tight">
+						Most Recognized — {formatMonthLabel(data.monthKey)}
+					</h2>
+					<span
+						className={cn(
+							"inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+							isLive ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground",
+						)}
+					>
+						{badge}
+					</span>
+				</div>
+
+				<ol className="space-y-2">
+					{recipients.map((person, index) => {
+						const isPodium = index < 3;
+						const style = isPodium ? PODIUM_STYLES[index] : null;
+
+						return (
+							<li
+								key={person.userId}
+								className={cn(
+									"flex items-center gap-3 rounded-xl px-3 py-2.5 transition-colors",
+									isPodium
+										? "bg-card border border-gray-200/60 dark:border-white/10 shadow-sm"
+										: "px-3 py-2",
+								)}
+							>
+								{isPodium ? (
+									<Medal size={18} className={cn("shrink-0", style?.medal)} />
+								) : (
+									<span className="w-[18px] text-xs font-semibold text-muted-foreground text-center shrink-0">
+										{person.rank}
+									</span>
+								)}
+								<UserAvatar
+									firstName={person.firstName}
+									lastName={person.lastName}
+									avatar={person.avatar}
+									size={isPodium ? "md" : "sm"}
+									className={cn(
+										isPodium
+											? cn(style?.ring, style?.bg, style?.text)
+											: "bg-primary/10 text-primary",
+									)}
+								/>
+								<span
+									className={cn(
+										"flex-1 truncate",
+										isPodium
+											? "text-sm font-semibold text-foreground"
+											: "text-sm font-medium text-foreground",
+									)}
+								>
+									{person.firstName} {person.lastName}
+								</span>
+								<span
+									className={cn(
+										"shrink-0 text-sm font-bold tabular-nums",
+										isPodium ? cn("rounded-full px-2.5 py-0.5", style?.countBg) : "text-primary",
+									)}
+								>
+									{person.count}
+								</span>
+							</li>
+						);
+					})}
+				</ol>
+			</div>
+		</PanelShell>
+	);
+}

--- a/app/(dashboard)/dashboard/leaderboard/_components/month-picker.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/_components/month-picker.tsx
@@ -13,7 +13,6 @@ import {
 export interface MonthPickerItem {
 	key: string;
 	label: string;
-	isCurrent: boolean;
 }
 
 interface MonthPickerProps {
@@ -42,7 +41,6 @@ export function MonthPicker({ items, selected }: MonthPickerProps) {
 				{items.map((item) => (
 					<SelectItem key={item.key} value={item.key}>
 						{item.label}
-						{item.isCurrent ? " (live)" : ""}
 					</SelectItem>
 				))}
 			</SelectContent>

--- a/app/(dashboard)/dashboard/leaderboard/_components/month-picker.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/_components/month-picker.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+
+export interface MonthPickerItem {
+	key: string;
+	label: string;
+	isCurrent: boolean;
+}
+
+interface MonthPickerProps {
+	items: MonthPickerItem[];
+	selected: string;
+}
+
+export function MonthPicker({ items, selected }: MonthPickerProps) {
+	const router = useRouter();
+	const [isPending, startTransition] = useTransition();
+
+	function handleChange(next: string | null) {
+		if (!next || next === selected) return;
+		startTransition(() => {
+			const params = new URLSearchParams({ month: next });
+			router.push(`/dashboard/leaderboard?${params.toString()}`);
+		});
+	}
+
+	return (
+		<Select value={selected} onValueChange={handleChange} disabled={isPending}>
+			<SelectTrigger className="w-64">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				{items.map((item) => (
+					<SelectItem key={item.key} value={item.key}>
+						{item.label}
+						{item.isCurrent ? " (live)" : ""}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}

--- a/app/(dashboard)/dashboard/leaderboard/page.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/page.tsx
@@ -62,7 +62,13 @@ export default async function LeaderboardHistoryPage({ searchParams }: PageProps
 	const archived = archivedKeys.filter((k) => k !== currentMonthKey);
 	const selectableKeys = visibility.visible ? [currentMonthKey, ...archived] : archived;
 
-	if (selectableKeys.length === 0) {
+	const requested = monthParam && isValidMonthKey(monthParam) ? monthParam : null;
+
+	// Generic empty state only when there's truly nothing to show AND the user
+	// didn't deep-link a specific month. A valid ?month= flows through below so
+	// locked/missing states surface for shared or bookmarked links even before
+	// the first archive exists.
+	if (selectableKeys.length === 0 && !requested) {
 		return (
 			<div className="max-w-7xl mx-auto mt-2 space-y-8">
 				<PageHeader />
@@ -77,7 +83,6 @@ export default async function LeaderboardHistoryPage({ searchParams }: PageProps
 		);
 	}
 
-	const requested = monthParam && isValidMonthKey(monthParam) ? monthParam : null;
 	// Honor a valid requested month even if it isn't in the selectable list
 	// (e.g. pre-archive months, the just-finished month before its snapshot
 	// lands, or the current month while hidden). This lets locked/missing

--- a/app/(dashboard)/dashboard/leaderboard/page.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/page.tsx
@@ -78,13 +78,22 @@ export default async function LeaderboardHistoryPage({ searchParams }: PageProps
 	}
 
 	const requested = monthParam && isValidMonthKey(monthParam) ? monthParam : null;
-	const selectedKey =
-		requested && selectableKeys.includes(requested) ? requested : selectableKeys[0];
-	const items = selectableKeys.map((key) => ({
+	// Honor a valid requested month even if it isn't in the selectable list
+	// (e.g. pre-archive months, the just-finished month before its snapshot
+	// lands, or the current month while hidden). This lets locked/missing
+	// states surface for shared/bookmarked links instead of silently falling
+	// back to selectableKeys[0].
+	const selectedKey = requested ?? selectableKeys[0];
+	const baseItems = selectableKeys.map((key) => ({
 		key,
-		label: formatMonthLabel(key),
-		isCurrent: key === currentMonthKey,
+		label:
+			key === currentMonthKey && visibility.visible
+				? `${formatMonthLabel(key)} (live)`
+				: formatMonthLabel(key),
 	}));
+	const items = selectableKeys.includes(selectedKey)
+		? baseItems
+		: [{ key: selectedKey, label: formatMonthLabel(selectedKey) }, ...baseItems];
 	const data = await getMonthLeaderboard(selectedKey, now, topLimit);
 
 	return (

--- a/app/(dashboard)/dashboard/leaderboard/page.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/page.tsx
@@ -11,6 +11,7 @@ import {
 	isValidMonthKey,
 } from "@/lib/leaderboard/history";
 import { getCurrentMonthBoundaries } from "@/lib/leaderboard/month";
+import { maybeSnapshotPreviousMonth } from "@/lib/leaderboard/snapshot";
 import { computeLeaderboardVisibility } from "@/lib/leaderboard/visibility";
 import { LeaderboardList } from "./_components/leaderboard-list";
 import { MonthPicker } from "./_components/month-picker";
@@ -41,6 +42,11 @@ export default async function LeaderboardHistoryPage({ searchParams }: PageProps
 
 	const { month: monthParam } = await searchParams;
 	const now = new Date();
+
+	// Self-heal the archive when a user lands here before anyone hits
+	// /dashboard post-rollover. Swallow errors so snapshot failures don't
+	// break the page render.
+	await maybeSnapshotPreviousMonth(now).catch(() => {});
 
 	const [archivedKeys, settings, topLimit] = await Promise.all([
 		getArchivedMonthKeys(),

--- a/app/(dashboard)/dashboard/leaderboard/page.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/page.tsx
@@ -1,0 +1,94 @@
+import { redirect } from "next/navigation";
+import {
+	getLeaderboardVisibilitySettings,
+	getTopRecognizedLimit,
+} from "@/lib/actions/settings-actions";
+import { requireSession } from "@/lib/auth-utils";
+import {
+	formatMonthLabel,
+	getArchivedMonthKeys,
+	getMonthLeaderboard,
+	isValidMonthKey,
+} from "@/lib/leaderboard/history";
+import { getCurrentMonthBoundaries } from "@/lib/leaderboard/month";
+import { computeLeaderboardVisibility } from "@/lib/leaderboard/visibility";
+import { LeaderboardList } from "./_components/leaderboard-list";
+import { MonthPicker } from "./_components/month-picker";
+
+interface PageProps {
+	searchParams: Promise<{ month?: string }>;
+}
+
+function PageHeader() {
+	return (
+		<div>
+			<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+				Leaderboard
+			</h1>
+			<p className="mt-2 text-base text-muted-foreground">
+				Most Recognized rankings, preserved month by month.
+			</p>
+		</div>
+	);
+}
+
+export default async function LeaderboardHistoryPage({ searchParams }: PageProps) {
+	try {
+		await requireSession();
+	} catch {
+		redirect("/login");
+	}
+
+	const { month: monthParam } = await searchParams;
+	const now = new Date();
+
+	const [archivedKeys, settings, topLimit] = await Promise.all([
+		getArchivedMonthKeys(),
+		getLeaderboardVisibilitySettings(),
+		getTopRecognizedLimit(),
+	]);
+
+	const currentMonthKey = getCurrentMonthBoundaries(now).monthKey;
+	const visibility = computeLeaderboardVisibility(settings, now);
+
+	// Archived list may include the current month if this process already wrote
+	// it (it shouldn't — we only snapshot the previous month — but filter defensively).
+	const archived = archivedKeys.filter((k) => k !== currentMonthKey);
+	const selectableKeys = visibility.visible ? [currentMonthKey, ...archived] : archived;
+
+	if (selectableKeys.length === 0) {
+		return (
+			<div className="max-w-7xl mx-auto mt-2 space-y-8">
+				<PageHeader />
+				<div className="rounded-[2rem] border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-8 py-16 text-center">
+					<p className="text-base font-medium text-foreground">No leaderboards to show yet</p>
+					<p className="mt-1 text-sm text-muted-foreground">
+						Archives appear here after each month ends. The current month becomes available when its
+						reveal window opens.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	const requested = monthParam && isValidMonthKey(monthParam) ? monthParam : null;
+	const selectedKey =
+		requested && selectableKeys.includes(requested) ? requested : selectableKeys[0];
+	const items = selectableKeys.map((key) => ({
+		key,
+		label: formatMonthLabel(key),
+		isCurrent: key === currentMonthKey,
+	}));
+	const data = await getMonthLeaderboard(selectedKey, now, topLimit);
+
+	return (
+		<div className="max-w-7xl mx-auto mt-2 space-y-8">
+			<PageHeader />
+			<div className="flex flex-wrap items-center gap-3">
+				<span className="text-sm text-muted-foreground">Showing:</span>
+				<MonthPicker items={items} selected={selectedKey} />
+			</div>
+			<LeaderboardList data={data} />
+		</div>
+	);
+}

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -1,25 +1,26 @@
 "use client";
 
+import {
+	Building2,
+	Heart,
+	LayoutDashboard,
+	LogOut,
+	Menu,
+	Settings,
+	ShieldCheck,
+	Trophy,
+	UserCircle,
+	Users,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
-import {
-	LayoutDashboard,
-	Users,
-	Building2,
-	Heart,
-	UserCircle,
-	Settings,
-	ShieldCheck,
-	LogOut,
-	Menu,
-} from "lucide-react";
 import { toast } from "sonner";
-import { signOut, useSession } from "@/lib/auth-client";
-import { cn } from "@/lib/utils";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { AccessGroupLogo } from "@/components/shared/access-logos";
 import { NotificationBadge } from "@/components/shared/notification-badge";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { signOut, useSession } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
 
 type MinRole = "STAFF" | "ADMIN" | "SUPERADMIN";
 
@@ -39,6 +40,12 @@ const NAV_ITEMS: {
 		label: "Recognition Card",
 		href: "/dashboard/recognition",
 		icon: Heart,
+		minRole: "STAFF",
+	},
+	{
+		label: "Leaderboard",
+		href: "/dashboard/leaderboard",
+		icon: Trophy,
 		minRole: "STAFF",
 	},
 	{
@@ -85,9 +92,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
 		SUPERADMIN: 2,
 	};
 
-	const filteredItems = NAV_ITEMS.filter(
-		(item) => roleLevel[userRole] >= roleLevel[item.minRole],
-	);
+	const filteredItems = NAV_ITEMS.filter((item) => roleLevel[userRole] >= roleLevel[item.minRole]);
 
 	async function handleSignOut() {
 		try {

--- a/lib/leaderboard/history.ts
+++ b/lib/leaderboard/history.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import { getLeaderboardVisibilitySettings } from "@/lib/actions/settings-actions";
+import { prisma } from "@/lib/db";
+import { getCurrentMonthBoundaries, parseMonthKey } from "./month";
+import { computeMonthRecipients, type SnapshotRecipient } from "./snapshot";
+import { computeLeaderboardVisibility, type LeaderboardVisibilityState } from "./visibility";
+
+const MONTH_KEY_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+export function isValidMonthKey(value: string): boolean {
+	if (!MONTH_KEY_REGEX.test(value)) return false;
+	try {
+		parseMonthKey(value);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+const SnapshotRecipientSchema = z.object({
+	userId: z.string(),
+	firstName: z.string(),
+	lastName: z.string(),
+	avatar: z.string().nullable(),
+	count: z.number().int().nonnegative(),
+	rank: z.number().int().positive(),
+});
+const SnapshotPayloadSchema = z.array(SnapshotRecipientSchema);
+
+export type MonthLeaderboard =
+	| {
+			kind: "live";
+			monthKey: string;
+			recipients: SnapshotRecipient[];
+			visibility: LeaderboardVisibilityState;
+	  }
+	| {
+			kind: "locked";
+			monthKey: string;
+			visibility: LeaderboardVisibilityState;
+	  }
+	| {
+			kind: "archived";
+			monthKey: string;
+			recipients: SnapshotRecipient[];
+			snapshotAt: Date;
+	  }
+	| { kind: "missing"; monthKey: string };
+
+export async function getArchivedMonthKeys(): Promise<string[]> {
+	const rows = await prisma.monthlyLeaderboardSnapshot.findMany({
+		select: { month: true },
+		orderBy: { month: "desc" },
+	});
+	return rows.map((r) => r.month);
+}
+
+export async function getMonthLeaderboard(
+	monthKey: string,
+	now: Date = new Date(),
+	liveLimit = 50,
+): Promise<MonthLeaderboard> {
+	const currentKey = getCurrentMonthBoundaries(now).monthKey;
+
+	if (monthKey === currentKey) {
+		const settings = await getLeaderboardVisibilitySettings();
+		const visibility = computeLeaderboardVisibility(settings, now);
+		if (!visibility.visible) {
+			return { kind: "locked", monthKey, visibility };
+		}
+		const recipients = await computeMonthRecipients(monthKey, liveLimit);
+		return { kind: "live", monthKey, recipients, visibility };
+	}
+
+	const snapshot = await prisma.monthlyLeaderboardSnapshot.findUnique({
+		where: { month: monthKey },
+	});
+	if (!snapshot) {
+		return { kind: "missing", monthKey };
+	}
+
+	const parsed = SnapshotPayloadSchema.safeParse(snapshot.recipients);
+	if (!parsed.success) {
+		return { kind: "missing", monthKey };
+	}
+
+	return {
+		kind: "archived",
+		monthKey,
+		recipients: parsed.data,
+		snapshotAt: snapshot.snapshotAt,
+	};
+}
+
+export function formatMonthLabel(monthKey: string): string {
+	const { year, month } = parseMonthKey(monthKey);
+	// Mid-month UTC avoids tz-shift flipping the rendered month name.
+	const date = new Date(Date.UTC(year, month, 15));
+	return new Intl.DateTimeFormat("en-AU", {
+		month: "long",
+		year: "numeric",
+	}).format(date);
+}

--- a/lib/leaderboard/history.ts
+++ b/lib/leaderboard/history.ts
@@ -58,7 +58,7 @@ export async function getArchivedMonthKeys(): Promise<string[]> {
 export async function getMonthLeaderboard(
 	monthKey: string,
 	now: Date = new Date(),
-	liveLimit = 50,
+	limit = 50,
 ): Promise<MonthLeaderboard> {
 	const currentKey = getCurrentMonthBoundaries(now).monthKey;
 
@@ -68,7 +68,7 @@ export async function getMonthLeaderboard(
 		if (!visibility.visible) {
 			return { kind: "locked", monthKey, visibility };
 		}
-		const recipients = await computeMonthRecipients(monthKey, liveLimit);
+		const recipients = await computeMonthRecipients(monthKey, limit);
 		return { kind: "live", monthKey, recipients, visibility };
 	}
 
@@ -84,10 +84,12 @@ export async function getMonthLeaderboard(
 		return { kind: "missing", monthKey };
 	}
 
+	// Snapshots are written at TOP_RECOGNIZED_MAX; trim to the active limit so
+	// archive display matches the current admin setting.
 	return {
 		kind: "archived",
 		monthKey,
-		recipients: parsed.data,
+		recipients: parsed.data.slice(0, limit),
 		snapshotAt: snapshot.snapshotAt,
 	};
 }


### PR DESCRIPTION
## Summary

Part 2 of 2 for #33. Adds `/dashboard/leaderboard` — a dedicated page for browsing the Most Recognized rankings month by month, reading from the archived snapshots written by PR #34 and falling back to a live query when the current month's reveal window is open.

- **Month picker** — shadcn `<Select>` listing every archived month (desc) plus the current month (tagged `(live)`) when visible. Updates `?month=YYYY-MM` via `router.push` so deep-links work.
- **Live / archived semantics** — current month pulls `computeMonthRecipients` respecting the dashboard's reveal gating (no admin bypass). Past months read `MonthlyLeaderboardSnapshot` and render the preserved top-50.
- **Discriminated render** — `live | archived | locked | missing` paths each get a dedicated UI (leaderboard list, locked card with reveal range, empty state). Snapshot JSON is zod-parsed on read; malformed rows fall back to `missing` rather than crashing the page.
- **Sidebar** — new "Leaderboard" entry (STAFF min-role, Trophy icon) right after Recognition Card.

## Files touched

- `lib/leaderboard/history.ts` — `getArchivedMonthKeys`, `getMonthLeaderboard`, `isValidMonthKey`, `formatMonthLabel`
- `app/(dashboard)/dashboard/leaderboard/page.tsx` — RSC page, URL-driven selection, empty state
- `app/(dashboard)/dashboard/leaderboard/_components/month-picker.tsx` — client Select
- `app/(dashboard)/dashboard/leaderboard/_components/leaderboard-list.tsx` — pure renderer
- `components/shared/dashboard-sidebar.tsx` — nav entry

## Decisions (confirmed with @chrisgen19 before implementation)

1. Current-month gating on this page **mirrors** the dashboard widget's reveal window — no admin bypass.
2. Archived months display the **full stored top-50**, independent of the admin's current `top_recognized_limit`. Archives are authoritative.
3. Month picker is a `<Select>` dropdown (simplest, scales to many months).
4. Archive preserves **snapshot-time names/avatars** — renamed or deleted users still render as they were at rollover.
5. Sidebar nav entry ships with this PR so the page is reachable.

## Test plan

- [ ] Visit `/dashboard/leaderboard` with no archived snapshots and visibility mode `always` — should show current-month live list
- [ ] With no archives and visibility mode `last_n_days_of_month` mid-month (hidden) — should show the "No leaderboards to show yet" empty state
- [ ] With one or more archived months present — picker lists them desc; selecting an archived month renders the preserved top-50
- [ ] When current month is in-window — picker includes "Month YYYY (live)" and renders the live list; switching off and back reflects latest counts
- [ ] Deep-link `?month=2026-03` loads that month directly; invalid month (`?month=foo`) falls back to most-recent selectable
- [ ] Staff + Admin + Superadmin all see the page and the sidebar entry
- [ ] `UserAvatar` falls back to initials if a snapshot-stored avatar URL is now 404
- [ ] `bunx @biomejs/biome check` + `bunx tsc --noEmit` clean

## Out of scope

- No unit tests — vitest infra still not scaffolded (tracked in #33 follow-up notes).
- No deep-link from the dashboard widget's locked card to this page — intentional; can add in a later polish PR.

Closes #33.