### PR TITLE
feat(users): port recognition table + filter pattern to Staff Directory

### DIFF
--- a/app/(dashboard)/dashboard/users/_components/user-filter-bar.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-filter-bar.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { Download, Loader2, Search, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface DepartmentOption {
+	id: string;
+	name: string;
+}
+
+export const ROLE_OPTIONS = [
+	{ value: "STAFF", label: "Staff" },
+	{ value: "ADMIN", label: "Admin" },
+	{ value: "SUPERADMIN", label: "Super Admin" },
+] as const;
+
+export const STATUS_OPTIONS = [
+	{ value: "active", label: "Active" },
+	{ value: "inactive", label: "Inactive" },
+] as const;
+
+export const BRANCH_OPTIONS = [
+	{ value: "ISO", label: "ISO" },
+	{ value: "PERTH", label: "Perth" },
+] as const;
+
+interface UserFilterBarProps {
+	search: string;
+	onSearchChange: (value: string) => void;
+	selectedRoles: string[];
+	onSelectedRolesChange: (values: string[]) => void;
+	selectedStatuses: string[];
+	onSelectedStatusesChange: (values: string[]) => void;
+	selectedDepartmentId: string;
+	onDepartmentChange: (value: string) => void;
+	selectedBranch: string;
+	onBranchChange: (value: string) => void;
+	departments: DepartmentOption[];
+	showRoleFilter: boolean;
+	hasActiveFilters: boolean;
+	onClear: () => void;
+	onExport: () => void;
+	isExporting: boolean;
+}
+
+export function UserFilterBar({
+	search,
+	onSearchChange,
+	selectedRoles,
+	onSelectedRolesChange,
+	selectedStatuses,
+	onSelectedStatusesChange,
+	selectedDepartmentId,
+	onDepartmentChange,
+	selectedBranch,
+	onBranchChange,
+	departments,
+	showRoleFilter,
+	hasActiveFilters,
+	onClear,
+	onExport,
+	isExporting,
+}: UserFilterBarProps) {
+	function toggle(list: string[], setter: (values: string[]) => void, value: string) {
+		if (list.includes(value)) {
+			setter(list.filter((v) => v !== value));
+		} else {
+			setter([...list, value]);
+		}
+	}
+
+	return (
+		<div className="rounded-xl border border-gray-200/60 dark:border-white/10 bg-card p-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+			<div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-center">
+				<div className="relative min-w-0 lg:w-64">
+					<Search
+						size={16}
+						className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+					/>
+					<input
+						type="text"
+						placeholder="Search name, email, position..."
+						value={search}
+						onChange={(e) => onSearchChange(e.target.value)}
+						className="h-9 w-full rounded-full border border-input bg-transparent pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
+					/>
+				</div>
+
+				{showRoleFilter && (
+					<div className="flex flex-wrap items-center gap-1.5">
+						{ROLE_OPTIONS.map((role) => {
+							const isActive = selectedRoles.includes(role.value);
+							return (
+								<button
+									key={role.value}
+									type="button"
+									onClick={() => toggle(selectedRoles, onSelectedRolesChange, role.value)}
+									className={cn(
+										"inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
+										isActive
+											? "border-primary/20 bg-primary/5 text-primary dark:bg-primary/10"
+											: "border-gray-200 dark:border-white/10 bg-transparent text-muted-foreground hover:border-gray-300 dark:hover:border-white/20",
+									)}
+								>
+									{role.label}
+								</button>
+							);
+						})}
+					</div>
+				)}
+
+				<div className="flex flex-wrap items-center gap-1.5">
+					{STATUS_OPTIONS.map((status) => {
+						const isActive = selectedStatuses.includes(status.value);
+						return (
+							<button
+								key={status.value}
+								type="button"
+								onClick={() => toggle(selectedStatuses, onSelectedStatusesChange, status.value)}
+								className={cn(
+									"inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
+									isActive
+										? "border-primary/20 bg-primary/5 text-primary dark:bg-primary/10"
+										: "border-gray-200 dark:border-white/10 bg-transparent text-muted-foreground hover:border-gray-300 dark:hover:border-white/20",
+								)}
+							>
+								{status.label}
+							</button>
+						);
+					})}
+				</div>
+
+				<div className="flex items-center gap-2 lg:ml-auto">
+					<select
+						value={selectedDepartmentId}
+						onChange={(e) => onDepartmentChange(e.target.value)}
+						className={cn(
+							"h-9 rounded-lg border border-input bg-transparent px-2.5 pr-8 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30",
+							!selectedDepartmentId && "text-muted-foreground",
+						)}
+					>
+						<option value="">Department</option>
+						{departments.map((dept) => (
+							<option key={dept.id} value={dept.id}>
+								{dept.name}
+							</option>
+						))}
+					</select>
+					<select
+						value={selectedBranch}
+						onChange={(e) => onBranchChange(e.target.value)}
+						className={cn(
+							"h-9 rounded-lg border border-input bg-transparent px-2.5 pr-8 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30",
+							!selectedBranch && "text-muted-foreground",
+						)}
+					>
+						<option value="">Branch</option>
+						{BRANCH_OPTIONS.map((b) => (
+							<option key={b.value} value={b.value}>
+								{b.label}
+							</option>
+						))}
+					</select>
+				</div>
+
+				<div className="flex items-center gap-1 shrink-0">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={onClear}
+						className={cn("gap-1 text-muted-foreground", !hasActiveFilters && "invisible")}
+					>
+						<X size={14} />
+						Clear
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={onExport}
+						disabled={isExporting}
+						className="gap-1"
+					>
+						{isExporting ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+						{isExporting ? "Exporting..." : "Export"}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -134,8 +134,9 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 		setSelectedBranch("");
 	}
 
-	function buildParams(base: URLSearchParams) {
-		if (debouncedSearch) base.set("search", debouncedSearch);
+	function buildParams(base: URLSearchParams, searchOverride?: string) {
+		const effectiveSearch = searchOverride ?? debouncedSearch;
+		if (effectiveSearch) base.set("search", effectiveSearch);
 		if (selectedRoles.length > 0) base.set("roles", selectedRoles.join(","));
 		if (selectedStatuses.length > 0) base.set("statuses", selectedStatuses.join(","));
 		if (selectedDepartmentId) base.set("departmentId", selectedDepartmentId);
@@ -181,7 +182,7 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 	async function exportUsers() {
 		setIsExporting(true);
 		try {
-			const params = buildParams(new URLSearchParams({ export: "true" }));
+			const params = buildParams(new URLSearchParams({ export: "true" }), search.trim());
 			const res = await fetch(`/api/users?${params}`);
 			if (!res.ok) throw new Error("Failed to fetch users");
 

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -210,6 +210,12 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 	const users = data?.data ?? [];
 	const pagination = data?.pagination;
 
+	useEffect(() => {
+		if (pagination && pagination.total > 0 && page > pagination.totalPages) {
+			setPage(pagination.totalPages);
+		}
+	}, [pagination, page]);
+
 	return (
 		<div className="max-w-7xl mx-auto space-y-6 mt-2">
 			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	ChevronLeft,
 	ChevronRight,
@@ -97,6 +97,7 @@ interface UserListClientProps {
 
 export function UserListClient({ currentUserRole, departments }: UserListClientProps) {
 	const router = useRouter();
+	const queryClient = useQueryClient();
 	const showRoleFilter = currentUserRole === "SUPERADMIN";
 
 	const [page, setPage] = useState(1);
@@ -142,7 +143,7 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 		return base;
 	}
 
-	const { data, isPending, isError, refetch } = useQuery<PaginatedResponse>({
+	const { data, isPending, isError } = useQuery<PaginatedResponse>({
 		queryKey: [
 			"users",
 			page,
@@ -171,7 +172,7 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 		const result = await toggleUserActiveAction(userId);
 		if (result.success) {
 			toast.success("User status updated");
-			refetch();
+			queryClient.invalidateQueries({ queryKey: ["users"] });
 		} else {
 			toast.error(typeof result.error === "string" ? result.error : "Failed to update status");
 		}

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -1,14 +1,35 @@
 "use client";
 
-import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import {
+	ChevronLeft,
+	ChevronRight,
+	Eye,
+	Pencil,
+	Plus,
+	Search,
+	UserCheck,
+	Users,
+	UserX,
+} from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Plus, Search, Eye, Pencil, UserX, UserCheck, Users } from "lucide-react";
-import { toggleUserActiveAction } from "@/lib/actions/user-actions";
-import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
 import { UserAvatar } from "@/components/shared/user-avatar";
+import { Badge } from "@/components/ui/badge";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { toggleUserActiveAction } from "@/lib/actions/user-actions";
+import { type ExportUser, generateUserCsv } from "@/lib/users";
+import { type DepartmentOption, UserFilterBar } from "./user-filter-bar";
+
+const PAGE_SIZE = 20;
 
 interface User {
 	id: string;
@@ -25,6 +46,17 @@ interface User {
 	department: { id: string; name: string; code: string } | null;
 }
 
+interface PaginatedResponse {
+	success: boolean;
+	data: User[];
+	pagination: {
+		page: number;
+		pageSize: number;
+		total: number;
+		totalPages: number;
+	};
+}
+
 function roleBadgeVariant(role: string) {
 	switch (role) {
 		case "SUPERADMIN":
@@ -36,17 +68,103 @@ function roleBadgeVariant(role: string) {
 	}
 }
 
-export function UserListClient({ currentUserRole }: { currentUserRole: string }) {
-	const router = useRouter();
-	const [searchQuery, setSearchQuery] = useState("");
+function TableSkeleton() {
+	return (
+		<div className="rounded-xl border border-gray-200/60 dark:border-white/10 bg-card overflow-hidden">
+			<div className="animate-pulse">
+				<div className="h-10 bg-muted/30 border-b" />
+				{Array.from({ length: 5 }).map((_, i) => (
+					<div
+						key={`skeleton-row-${i}`}
+						className="flex items-center gap-4 px-4 py-3 border-b last:border-0"
+					>
+						<div className="h-10 w-10 rounded-full bg-gray-200 dark:bg-white/10" />
+						<div className="h-4 w-48 bg-gray-200 dark:bg-white/10 rounded" />
+						<div className="h-4 w-32 bg-gray-200 dark:bg-white/10 rounded" />
+						<div className="h-4 w-20 bg-gray-200 dark:bg-white/10 rounded" />
+						<div className="h-4 w-20 bg-gray-200 dark:bg-white/10 rounded ml-auto" />
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
 
-	const { data, isPending, error, refetch } = useQuery<{ success: boolean; data: User[] }>({
-		queryKey: ["users"],
+interface UserListClientProps {
+	currentUserRole: string;
+	departments: DepartmentOption[];
+}
+
+export function UserListClient({ currentUserRole, departments }: UserListClientProps) {
+	const router = useRouter();
+	const showRoleFilter = currentUserRole === "SUPERADMIN";
+
+	const [page, setPage] = useState(1);
+	const [search, setSearch] = useState("");
+	const [debouncedSearch, setDebouncedSearch] = useState("");
+	const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
+	const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
+	const [selectedDepartmentId, setSelectedDepartmentId] = useState("");
+	const [selectedBranch, setSelectedBranch] = useState("");
+	const [isExporting, setIsExporting] = useState(false);
+
+	useEffect(() => {
+		const timer = setTimeout(() => setDebouncedSearch(search), 300);
+		return () => clearTimeout(timer);
+	}, [search]);
+
+	useEffect(() => {
+		setPage(1);
+	}, [debouncedSearch, selectedRoles, selectedStatuses, selectedDepartmentId, selectedBranch]);
+
+	const hasActiveFilters =
+		search.length > 0 ||
+		selectedRoles.length > 0 ||
+		selectedStatuses.length > 0 ||
+		selectedDepartmentId.length > 0 ||
+		selectedBranch.length > 0;
+
+	function clearFilters() {
+		setSearch("");
+		setDebouncedSearch("");
+		setSelectedRoles([]);
+		setSelectedStatuses([]);
+		setSelectedDepartmentId("");
+		setSelectedBranch("");
+	}
+
+	function buildParams(base: URLSearchParams) {
+		if (debouncedSearch) base.set("search", debouncedSearch);
+		if (selectedRoles.length > 0) base.set("roles", selectedRoles.join(","));
+		if (selectedStatuses.length > 0) base.set("statuses", selectedStatuses.join(","));
+		if (selectedDepartmentId) base.set("departmentId", selectedDepartmentId);
+		if (selectedBranch) base.set("branch", selectedBranch);
+		return base;
+	}
+
+	const { data, isPending, isError, refetch } = useQuery<PaginatedResponse>({
+		queryKey: [
+			"users",
+			page,
+			debouncedSearch,
+			selectedRoles,
+			selectedStatuses,
+			selectedDepartmentId,
+			selectedBranch,
+		],
 		queryFn: async () => {
-			const res = await fetch("/api/users");
+			const params = buildParams(
+				new URLSearchParams({
+					paginated: "true",
+					page: String(page),
+					pageSize: String(PAGE_SIZE),
+				}),
+			);
+			const res = await fetch(`/api/users?${params}`);
 			if (!res.ok) throw new Error("Failed to fetch users");
 			return res.json();
 		},
+		staleTime: 30_000,
 	});
 
 	async function handleToggleActive(userId: string) {
@@ -59,30 +177,40 @@ export function UserListClient({ currentUserRole }: { currentUserRole: string })
 		}
 	}
 
-	if (isPending) {
-		return (
-			<div className="space-y-4">
-				<Skeleton className="h-10 w-full" />
-				<Skeleton className="h-10 w-full" />
-				<Skeleton className="h-10 w-full" />
-			</div>
-		);
-	}
+	async function exportUsers() {
+		setIsExporting(true);
+		try {
+			const params = buildParams(new URLSearchParams({ export: "true" }));
+			const res = await fetch(`/api/users?${params}`);
+			if (!res.ok) throw new Error("Failed to fetch users");
 
-	if (error) {
-		return <p className="text-destructive">Failed to load users.</p>;
+			const json = (await res.json()) as {
+				success: boolean;
+				data: ExportUser[];
+			};
+			if (!json.success) throw new Error("Export failed");
+
+			const csv = generateUserCsv(json.data);
+			const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = `users-export-${new Date().toISOString().split("T")[0]}.csv`;
+			link.click();
+			URL.revokeObjectURL(url);
+			toast.success(`Exported ${json.data.length} users`);
+		} catch {
+			toast.error("Failed to export users");
+		} finally {
+			setIsExporting(false);
+		}
 	}
 
 	const users = data?.data ?? [];
-	const filteredUsers = users.filter(
-		(user) =>
-			`${user.firstName} ${user.lastName}`.toLowerCase().includes(searchQuery.toLowerCase()) ||
-			(user.department?.name ?? "").toLowerCase().includes(searchQuery.toLowerCase()) ||
-			(user.position ?? "").toLowerCase().includes(searchQuery.toLowerCase()),
-	);
+	const pagination = data?.pagination;
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
+		<div className="max-w-7xl mx-auto space-y-6 mt-2">
 			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
 				<div>
 					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
@@ -102,52 +230,79 @@ export function UserListClient({ currentUserRole }: { currentUserRole: string })
 				</button>
 			</div>
 
-			<div className="overflow-hidden rounded-[2rem] border border-gray-200 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
-				<div className="border-b border-gray-200/60 dark:border-white/10 p-6">
-					<div className="relative max-w-md w-full">
-						<div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4">
-							<Search className="h-5 w-5 text-muted-foreground" />
-						</div>
-						<input
-							type="text"
-							className="block w-full rounded-full border-transparent bg-background py-3.5 pl-12 pr-4 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:bg-card focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-							placeholder="Search staff members..."
-							value={searchQuery}
-							onChange={(e) => setSearchQuery(e.target.value)}
-						/>
-					</div>
-				</div>
+			<UserFilterBar
+				search={search}
+				onSearchChange={setSearch}
+				selectedRoles={selectedRoles}
+				onSelectedRolesChange={setSelectedRoles}
+				selectedStatuses={selectedStatuses}
+				onSelectedStatusesChange={setSelectedStatuses}
+				selectedDepartmentId={selectedDepartmentId}
+				onDepartmentChange={setSelectedDepartmentId}
+				selectedBranch={selectedBranch}
+				onBranchChange={setSelectedBranch}
+				departments={departments}
+				showRoleFilter={showRoleFilter}
+				hasActiveFilters={hasActiveFilters}
+				onClear={clearFilters}
+				onExport={exportUsers}
+				isExporting={isExporting}
+			/>
 
-				<div className="overflow-x-auto">
-					<table className="min-w-full divide-y divide-gray-200 dark:divide-white/10">
-						<thead>
-							<tr>
-								<th className="px-8 py-4 text-left text-[0.75rem] font-semibold uppercase tracking-widest text-muted-foreground">
-									Employee
-								</th>
-								<th className="px-8 py-4 text-left text-[0.75rem] font-semibold uppercase tracking-widest text-muted-foreground">
-									Position / Dept
-								</th>
-								<th className="px-8 py-4 text-left text-[0.75rem] font-semibold uppercase tracking-widest text-muted-foreground">
-									Branch
-								</th>
-								<th className="px-8 py-4 text-left text-[0.75rem] font-semibold uppercase tracking-widest text-muted-foreground">
-									Status
-								</th>
-								<th className="relative px-8 py-4">
-									<span className="sr-only">Actions</span>
-								</th>
-							</tr>
-						</thead>
-						<tbody className="divide-y divide-gray-200/60 dark:divide-white/10">
-							{filteredUsers.length > 0 ? (
-								filteredUsers.map((user) => (
-									<tr
-										key={user.id}
-										className="group transition-colors hover:bg-background"
-									>
-										<td className="whitespace-nowrap px-8 py-5">
-											<div className="flex items-center">
+			{isPending ? (
+				<TableSkeleton />
+			) : isError ? (
+				<div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 dark:border-white/10 bg-card p-16">
+					<p className="text-[1.5rem] font-medium text-foreground">Something went wrong</p>
+					<p className="mt-2 text-base text-muted-foreground">
+						Failed to load staff. Please try again later.
+					</p>
+				</div>
+			) : users.length === 0 ? (
+				<div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 dark:border-white/10 bg-card p-16">
+					<div className="mb-6 rounded-full bg-background p-6">
+						{hasActiveFilters ? (
+							<Search size={48} className="text-muted-foreground opacity-40" />
+						) : (
+							<Users size={48} className="text-muted-foreground opacity-40" />
+						)}
+					</div>
+					<p className="text-[1.5rem] font-medium text-foreground">
+						{hasActiveFilters ? "No matching staff" : "No staff yet"}
+					</p>
+					<p className="mt-2 text-base text-muted-foreground">
+						{hasActiveFilters
+							? "No staff match your current filters."
+							: "Add your first staff member to get started."}
+					</p>
+					{hasActiveFilters && (
+						<button
+							type="button"
+							onClick={clearFilters}
+							className="mt-4 text-sm font-medium text-primary hover:text-primary/80 transition-colors"
+						>
+							Clear all filters
+						</button>
+					)}
+				</div>
+			) : (
+				<>
+					<div className="rounded-xl border border-gray-200/60 dark:border-white/10 bg-card overflow-hidden shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+						<Table>
+							<TableHeader>
+								<TableRow className="bg-muted/30 hover:bg-muted/30">
+									<TableHead>Employee</TableHead>
+									<TableHead>Position / Dept</TableHead>
+									<TableHead>Branch</TableHead>
+									<TableHead>Status</TableHead>
+									<TableHead className="text-right">Actions</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{users.map((user) => (
+									<TableRow key={user.id} className="group">
+										<TableCell>
+											<div className="flex items-center gap-3">
 												<UserAvatar
 													firstName={user.firstName}
 													lastName={user.lastName}
@@ -156,108 +311,101 @@ export function UserListClient({ currentUserRole }: { currentUserRole: string })
 													size="lg"
 													className="border border-gray-100 dark:border-white/10 bg-background text-primary"
 												/>
-												<div className="ml-4">
-													<div className="text-sm font-medium text-foreground">
+												<div className="min-w-0">
+													<p className="text-sm font-medium text-foreground truncate">
 														{user.firstName} {user.lastName}
-													</div>
-													<div className="mt-0.5 text-sm text-muted-foreground">
-														{user.email}
-													</div>
+													</p>
+													<p className="text-xs text-muted-foreground truncate">{user.email}</p>
 												</div>
 											</div>
-										</td>
-										<td className="whitespace-nowrap px-8 py-5">
-											<div className="text-sm font-medium text-foreground">
-												{user.position ?? "—"}
-											</div>
-											<div className="mt-0.5 text-sm text-muted-foreground">
+										</TableCell>
+										<TableCell>
+											<p className="text-sm font-medium text-foreground">{user.position ?? "—"}</p>
+											<p className="text-xs text-muted-foreground">
 												{user.department?.name ?? "—"}
-											</div>
-										</td>
-										<td className="whitespace-nowrap px-8 py-5">
-											<span className="text-sm text-foreground">
-												{user.branch ?? "—"}
-											</span>
-										</td>
-										<td className="whitespace-nowrap px-8 py-5">
+											</p>
+										</TableCell>
+										<TableCell>
+											<span className="text-sm text-foreground">{user.branch ?? "—"}</span>
+										</TableCell>
+										<TableCell>
 											<div className="flex flex-col gap-1.5">
 												{currentUserRole === "SUPERADMIN" && (
-													<Badge variant={roleBadgeVariant(user.role)}>
-														{user.role}
-													</Badge>
+													<Badge variant={roleBadgeVariant(user.role)}>{user.role}</Badge>
 												)}
-												<Badge
-													variant={user.isActive ? "outline" : "destructive"}
-												>
+												<Badge variant={user.isActive ? "outline" : "destructive"}>
 													{user.isActive ? "Active" : "Inactive"}
 												</Badge>
 											</div>
-										</td>
-										<td className="whitespace-nowrap px-8 py-5 text-right text-sm font-medium">
+										</TableCell>
+										<TableCell className="text-right">
 											<div className="flex justify-end gap-1 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity [@media(hover:hover)]:group-hover:opacity-100 focus-within:opacity-100">
 												<button
 													type="button"
 													onClick={() => router.push(`/dashboard/users/${user.id}`)}
 													className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
-													title="View"
+													aria-label="View user"
 												>
-													<Eye size={18} />
+													<Eye size={16} />
 												</button>
 												<button
 													type="button"
 													onClick={() => router.push(`/dashboard/users/${user.id}/edit`)}
 													className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
-													title="Edit"
+													aria-label="Edit user"
 												>
-													<Pencil size={18} />
+													<Pencil size={16} />
 												</button>
 												<button
 													type="button"
 													onClick={() => handleToggleActive(user.id)}
 													className="rounded-full p-2 text-muted-foreground hover:bg-[oklch(0.96_0.03_18)] hover:text-primary dark:hover:bg-primary/10 transition-colors"
-													title={user.isActive ? "Deactivate" : "Activate"}
+													aria-label={user.isActive ? "Deactivate user" : "Activate user"}
 												>
-													{user.isActive ? (
-														<UserX size={18} />
-													) : (
-														<UserCheck size={18} />
-													)}
+													{user.isActive ? <UserX size={16} /> : <UserCheck size={16} />}
 												</button>
 											</div>
-										</td>
-									</tr>
-								))
-							) : (
-								<tr>
-									<td colSpan={5} className="px-8 py-16 text-center">
-										<div className="flex flex-col items-center justify-center text-muted-foreground">
-											<Users size={40} className="mb-3 opacity-20" />
-											<p className="text-base font-medium text-foreground">
-												No staff found
-											</p>
-											<p className="mt-1 text-sm">
-												We couldn&apos;t find anyone matching your search.
-											</p>
-										</div>
-									</td>
-								</tr>
-							)}
-						</tbody>
-					</table>
-				</div>
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</div>
 
-				<div className="border-t border-gray-200/60 dark:border-white/10 bg-card px-8 py-4">
-					<p className="text-sm text-muted-foreground">
-						Showing{" "}
-						<span className="font-medium text-foreground">
-							{filteredUsers.length}
-						</span>{" "}
-						of{" "}
-						<span className="font-medium text-foreground">{users.length}</span>{" "}
-						results
-					</p>
-				</div>
-			</div>
+					{pagination && pagination.totalPages > 1 && (
+						<div className="flex items-center justify-between pt-2">
+							<p className="text-sm text-muted-foreground">
+								Showing {(pagination.page - 1) * pagination.pageSize + 1}–
+								{Math.min(pagination.page * pagination.pageSize, pagination.total)} of{" "}
+								{pagination.total} staff
+							</p>
+							<div className="flex items-center gap-2">
+								<button
+									type="button"
+									disabled={page === 1}
+									onClick={() => setPage((p) => p - 1)}
+									className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-gray-100 dark:hover:bg-white/5 transition-colors disabled:opacity-30 disabled:pointer-events-none"
+								>
+									<ChevronLeft size={16} />
+									Previous
+								</button>
+								<span className="text-sm font-medium text-foreground">
+									{pagination.page} / {pagination.totalPages}
+								</span>
+								<button
+									type="button"
+									disabled={page >= pagination.totalPages}
+									onClick={() => setPage((p) => p + 1)}
+									className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-gray-100 dark:hover:bg-white/5 transition-colors disabled:opacity-30 disabled:pointer-events-none"
+								>
+									Next
+									<ChevronRight size={16} />
+								</button>
+							</div>
+						</div>
+					)}
+				</>
+			)}
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -189,6 +189,9 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 			const json = (await res.json()) as {
 				success: boolean;
 				data: ExportUser[];
+				total?: number;
+				truncated?: boolean;
+				limit?: number;
 			};
 			if (!json.success) throw new Error("Export failed");
 
@@ -200,7 +203,13 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 			link.download = `users-export-${new Date().toISOString().split("T")[0]}.csv`;
 			link.click();
 			URL.revokeObjectURL(url);
-			toast.success(`Exported ${json.data.length} users`);
+			if (json.truncated && json.total && json.limit) {
+				toast.warning(
+					`Exported first ${json.data.length} of ${json.total} users. Apply filters to narrow the result set.`,
+				);
+			} else {
+				toast.success(`Exported ${json.data.length} users`);
+			}
 		} catch {
 			toast.error("Failed to export users");
 		} finally {

--- a/app/(dashboard)/dashboard/users/page.tsx
+++ b/app/(dashboard)/dashboard/users/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from "next/navigation";
+import type { Role } from "@/app/generated/prisma/client";
+import { getAllDepartmentsAction } from "@/lib/actions/department-actions";
 import { getServerSession } from "@/lib/auth-utils";
 import { canViewUsers } from "@/lib/permissions";
-import type { Role } from "@/app/generated/prisma/client";
 import { UserListClient } from "./_components/user-list-client";
 
 export default async function UsersPage() {
@@ -10,5 +11,12 @@ export default async function UsersPage() {
 		redirect("/dashboard");
 	}
 
-	return <UserListClient currentUserRole={session.user.role as Role} />;
+	const departments = await getAllDepartmentsAction();
+
+	return (
+		<UserListClient
+			currentUserRole={session.user.role as Role}
+			departments={departments.map((d) => ({ id: d.id, name: d.name }))}
+		/>
+	);
 }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -9,6 +9,7 @@ const VALID_ROLES: Role[] = ["STAFF", "ADMIN", "SUPERADMIN"];
 const VALID_BRANCHES: Branch[] = ["ISO", "PERTH"];
 const VALID_STATUSES = ["active", "inactive"] as const;
 const EXPORT_LIMIT = 10_000;
+const SEARCH_MAX_LENGTH = 200;
 
 function parseRoles(param: string | null): Role[] {
 	if (!param) return [];
@@ -53,8 +54,9 @@ export async function GET(request: NextRequest) {
 		return Response.json({ success: true, data: users });
 	}
 
-	const search = searchParams.get("search")?.trim();
-	const roles = parseRoles(searchParams.get("roles"));
+	const search = searchParams.get("search")?.trim().slice(0, SEARCH_MAX_LENGTH);
+	const userRole = session.user.role as Role;
+	const roles = userRole === "SUPERADMIN" ? parseRoles(searchParams.get("roles")) : [];
 	const statuses = parseStatuses(searchParams.get("statuses"));
 	const departmentId = searchParams.get("departmentId")?.trim();
 	const branch = parseBranch(searchParams.get("branch"));

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -95,13 +95,22 @@ export async function GET(request: NextRequest) {
 	const where: Prisma.UserWhereInput = conditions.length > 0 ? { AND: conditions } : {};
 
 	if (isExport) {
-		const users = await prisma.user.findMany({
-			where,
-			include: { department: { select: { name: true } } },
-			orderBy: [{ firstName: "asc" }, { lastName: "asc" }, { id: "asc" }],
-			take: EXPORT_LIMIT,
+		const [users, total] = await Promise.all([
+			prisma.user.findMany({
+				where,
+				include: { department: { select: { name: true } } },
+				orderBy: [{ firstName: "asc" }, { lastName: "asc" }, { id: "asc" }],
+				take: EXPORT_LIMIT,
+			}),
+			prisma.user.count({ where }),
+		]);
+		return Response.json({
+			success: true,
+			data: users,
+			total,
+			truncated: total > users.length,
+			limit: EXPORT_LIMIT,
 		});
-		return Response.json({ success: true, data: users });
 	}
 
 	const page = Math.max(1, Number(searchParams.get("page")) || 1);

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,20 +1,128 @@
+import { headers } from "next/headers";
+import type { NextRequest } from "next/server";
+import type { Branch, Prisma, Role } from "@/app/generated/prisma/client";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { canViewUsers } from "@/lib/permissions";
-import type { Role } from "@/app/generated/prisma/client";
-import { headers } from "next/headers";
 
-export async function GET() {
+const VALID_ROLES: Role[] = ["STAFF", "ADMIN", "SUPERADMIN"];
+const VALID_BRANCHES: Branch[] = ["ISO", "PERTH"];
+const VALID_STATUSES = ["active", "inactive"] as const;
+const EXPORT_LIMIT = 10_000;
+
+function parseRoles(param: string | null): Role[] {
+	if (!param) return [];
+	return param
+		.split(",")
+		.map((r) => r.trim().toUpperCase())
+		.filter((r): r is Role => VALID_ROLES.includes(r as Role));
+}
+
+function parseStatuses(param: string | null): (typeof VALID_STATUSES)[number][] {
+	if (!param) return [];
+	return param
+		.split(",")
+		.map((s) => s.trim().toLowerCase())
+		.filter((s): s is (typeof VALID_STATUSES)[number] =>
+			VALID_STATUSES.includes(s as (typeof VALID_STATUSES)[number]),
+		);
+}
+
+function parseBranch(param: string | null): Branch | null {
+	if (!param) return null;
+	const upper = param.toUpperCase();
+	return VALID_BRANCHES.includes(upper as Branch) ? (upper as Branch) : null;
+}
+
+export async function GET(request: NextRequest) {
 	const session = await auth.api.getSession({ headers: await headers() });
 
 	if (!session || !canViewUsers(session.user.role as Role)) {
 		return Response.json({ success: false, error: "Forbidden" }, { status: 403 });
 	}
 
-	const users = await prisma.user.findMany({
-		include: { department: true },
-		orderBy: { createdAt: "desc" },
-	});
+	const { searchParams } = request.nextUrl;
+	const paginated = searchParams.get("paginated") === "true";
+	const isExport = searchParams.get("export") === "true";
 
-	return Response.json({ success: true, data: users });
+	if (!paginated && !isExport) {
+		const users = await prisma.user.findMany({
+			include: { department: true },
+			orderBy: { createdAt: "desc" },
+		});
+		return Response.json({ success: true, data: users });
+	}
+
+	const search = searchParams.get("search")?.trim();
+	const roles = parseRoles(searchParams.get("roles"));
+	const statuses = parseStatuses(searchParams.get("statuses"));
+	const departmentId = searchParams.get("departmentId")?.trim();
+	const branch = parseBranch(searchParams.get("branch"));
+
+	const conditions: Prisma.UserWhereInput[] = [];
+
+	if (search) {
+		conditions.push({
+			OR: [
+				{ firstName: { contains: search, mode: "insensitive" } },
+				{ lastName: { contains: search, mode: "insensitive" } },
+				{ email: { contains: search, mode: "insensitive" } },
+				{ position: { contains: search, mode: "insensitive" } },
+				{ department: { name: { contains: search, mode: "insensitive" } } },
+			],
+		});
+	}
+
+	if (roles.length > 0) {
+		conditions.push({ role: { in: roles } });
+	}
+
+	if (statuses.length === 1) {
+		conditions.push({ isActive: statuses[0] === "active" });
+	}
+
+	if (departmentId) {
+		conditions.push({ departmentId });
+	}
+
+	if (branch) {
+		conditions.push({ branch });
+	}
+
+	const where: Prisma.UserWhereInput = conditions.length > 0 ? { AND: conditions } : {};
+
+	if (isExport) {
+		const users = await prisma.user.findMany({
+			where,
+			include: { department: { select: { name: true } } },
+			orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+			take: EXPORT_LIMIT,
+		});
+		return Response.json({ success: true, data: users });
+	}
+
+	const page = Math.max(1, Number(searchParams.get("page")) || 1);
+	const pageSize = Math.min(100, Math.max(1, Number(searchParams.get("pageSize")) || 20));
+
+	const [users, total] = await Promise.all([
+		prisma.user.findMany({
+			where,
+			include: { department: true },
+			orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+			skip: (page - 1) * pageSize,
+			take: pageSize,
+		}),
+		prisma.user.count({ where }),
+	]);
+
+	return Response.json({
+		success: true,
+		data: users,
+		pagination: {
+			page,
+			pageSize,
+			total,
+			totalPages: Math.ceil(total / pageSize),
+		},
+	});
 }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -62,15 +62,18 @@ export async function GET(request: NextRequest) {
 	const conditions: Prisma.UserWhereInput[] = [];
 
 	if (search) {
-		conditions.push({
-			OR: [
-				{ firstName: { contains: search, mode: "insensitive" } },
-				{ lastName: { contains: search, mode: "insensitive" } },
-				{ email: { contains: search, mode: "insensitive" } },
-				{ position: { contains: search, mode: "insensitive" } },
-				{ department: { name: { contains: search, mode: "insensitive" } } },
-			],
-		});
+		const tokens = search.split(/\s+/).filter(Boolean);
+		for (const token of tokens) {
+			conditions.push({
+				OR: [
+					{ firstName: { contains: token, mode: "insensitive" } },
+					{ lastName: { contains: token, mode: "insensitive" } },
+					{ email: { contains: token, mode: "insensitive" } },
+					{ position: { contains: token, mode: "insensitive" } },
+					{ department: { name: { contains: token, mode: "insensitive" } } },
+				],
+			});
+		}
 	}
 
 	if (roles.length > 0) {
@@ -95,7 +98,7 @@ export async function GET(request: NextRequest) {
 		const users = await prisma.user.findMany({
 			where,
 			include: { department: { select: { name: true } } },
-			orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+			orderBy: [{ firstName: "asc" }, { lastName: "asc" }, { id: "asc" }],
 			take: EXPORT_LIMIT,
 		});
 		return Response.json({ success: true, data: users });
@@ -108,7 +111,7 @@ export async function GET(request: NextRequest) {
 		prisma.user.findMany({
 			where,
 			include: { department: true },
-			orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+			orderBy: [{ firstName: "asc" }, { lastName: "asc" }, { id: "asc" }],
 			skip: (page - 1) * pageSize,
 			take: pageSize,
 		}),

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,0 +1,47 @@
+export interface ExportUser {
+	firstName: string;
+	lastName: string;
+	email: string;
+	role: string;
+	position: string | null;
+	branch: string | null;
+	isActive: boolean;
+	department: { name: string } | null;
+}
+
+function escapeCsvField(value: string): string {
+	const needsQuoting = value.includes(",") || value.includes('"') || value.includes("\n");
+	const escaped = needsQuoting ? `"${value.replace(/"/g, '""')}"` : value;
+	if (/^[=+\-@\t\r]/.test(escaped)) {
+		return `\t${escaped}`;
+	}
+	return escaped;
+}
+
+const CSV_HEADERS = [
+	"First Name",
+	"Last Name",
+	"Email",
+	"Role",
+	"Department",
+	"Branch",
+	"Position",
+	"Status",
+];
+
+export function generateUserCsv(users: ExportUser[]): string {
+	const rows = users.map((user) => [
+		user.firstName,
+		user.lastName,
+		user.email,
+		user.role,
+		user.department?.name ?? "",
+		user.branch ?? "",
+		user.position ?? "",
+		user.isActive ? "Active" : "Inactive",
+	]);
+
+	const lines = [CSV_HEADERS.join(","), ...rows.map((row) => row.map(escapeCsvField).join(","))];
+
+	return lines.join("\n");
+}

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -10,12 +10,10 @@ export interface ExportUser {
 }
 
 function escapeCsvField(value: string): string {
-	const needsQuoting = value.includes(",") || value.includes('"') || value.includes("\n");
-	const escaped = needsQuoting ? `"${value.replace(/"/g, '""')}"` : value;
-	if (/^[=+\-@\t\r]/.test(escaped)) {
-		return `\t${escaped}`;
-	}
-	return escaped;
+	const safeValue = /^[=+\-@\t\r]/.test(value) ? `\t${value}` : value;
+	const needsQuoting =
+		safeValue.includes(",") || safeValue.includes('"') || safeValue.includes("\n");
+	return needsQuoting ? `"${safeValue.replace(/"/g, '""')}"` : safeValue;
 }
 
 const CSV_HEADERS = [


### PR DESCRIPTION
Closes #38

## Summary
- Staff Directory (`/dashboard/users`) now uses the same shadcn `Table` shell, debounced search, filter chips, dropdowns, and CSV export as `/dashboard/recognition/all`.
- `GET /api/users` gained `paginated`, `page`, `pageSize`, `search`, `roles`, `statuses`, `departmentId`, `branch`, and `export` query params. Paginated responses match the recognition shape (`pagination: { page, pageSize, total, totalPages }`).
- New client component `UserFilterBar` holds the search input, role/status chips, department/branch dropdowns, Clear, and Export actions. Role filter is only shown to SUPERADMIN (same gating as the existing role badge).
- New helper `generateUserCsv` (columns: First Name, Last Name, Email, Role, Department, Branch, Position, Status).
- Preserved existing row actions (View, Edit, Activate/Deactivate).

## Test plan
- [ ] `/dashboard/users` loads with the new filter bar + paginated table (20/page)
- [ ] Search matches across first name, last name, email, position, department
- [ ] Role chips appear only for SUPERADMIN and narrow results server-side
- [ ] Status chips (Active/Inactive) narrow results; selecting both clears the filter
- [ ] Department dropdown filters to the selected department
- [ ] Branch dropdown (ISO / Perth) filters correctly
- [ ] Clear button resets all filters
- [ ] Export CSV reflects active filters and opens correctly in a spreadsheet app
- [ ] Pagination prev/next works; page resets to 1 when any filter changes
- [ ] View / Edit / Activate-Deactivate still function
- [ ] Non-admin users are still redirected away from the page