### PR TITLE
feat(recognition): notify on reactions/comments + show reactors

### DIFF
--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -41,12 +41,15 @@ export function CardInteractionBar({
 	const pendingToggles = useRef(new Set<string>());
 	const rootRef = useRef<HTMLDivElement>(null);
 
+	// Read from searchParams inside so the effect re-runs on every navigation,
+	// not just when the raw focus value changes — repeated notification clicks
+	// to the same URL must still re-open the thread.
 	useEffect(() => {
-		if (focusTarget !== "comments") return;
+		if (searchParams?.get("focus") !== "comments") return;
 		setShowComments(true);
 		setFetchEnabled(true);
 		rootRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-	}, [focusTarget]);
+	}, [searchParams]);
 
 	const { data } = useQuery<{ success: boolean; data: CardInteractions }>({
 		queryKey: ["card-interactions", cardId, currentUserId],

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -42,9 +42,10 @@ export function CardInteractionBar({
 	const rootRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
-		if (focusTarget === "comments") {
-			rootRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-		}
+		if (focusTarget !== "comments") return;
+		setShowComments(true);
+		setFetchEnabled(true);
+		rootRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
 	}, [focusTarget]);
 
 	const { data } = useQuery<{ success: boolean; data: CardInteractions }>({
@@ -174,17 +175,16 @@ export function CardInteractionBar({
 			<div className="flex flex-wrap items-center gap-1.5">
 				{/* Active reactions with counts */}
 				{activeReactions.map((r) => (
-					<ReactorPopover key={r.emoji} emoji={r.emoji} users={r.users ?? []}>
-						{(handlers) => (
+					<ReactorPopover
+						key={r.emoji}
+						emoji={r.emoji}
+						users={r.users ?? []}
+						onActivate={() => handleReaction(r.emoji)}
+					>
+						{(trigger) => (
 							<button
 								type="button"
-								onClick={() => handleReaction(r.emoji)}
-								onMouseEnter={handlers.onMouseEnter}
-								onMouseLeave={handlers.onMouseLeave}
-								onPointerDown={handlers.onPointerDown}
-								onPointerUp={handlers.onPointerUp}
-								onPointerCancel={handlers.onPointerCancel}
-								onClickCapture={handlers.onClickCapture}
+								{...trigger}
 								className={cn(
 									"inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-sm transition-all select-none",
 									r.hasReacted

--- a/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx
@@ -1,24 +1,27 @@
 "use client";
 
-import { useState, useRef } from "react";
-import { MessageCircle, ChevronDown, ChevronUp } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronUp, MessageCircle } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { cn } from "@/lib/utils";
-import {
-	REACTION_EMOJIS,
-	type CardInteractions,
-	type CardComment,
-} from "@/lib/recognition";
 import { toggleReactionAction } from "@/lib/actions/interaction-actions";
+import { type CardComment, type CardInteractions, REACTION_EMOJIS } from "@/lib/recognition";
+import { cn } from "@/lib/utils";
 import { CommentThread } from "./comment-thread";
+import { ReactorPopover } from "./reactor-popover";
 
 interface CardInteractionBarProps {
 	cardId: string;
 	currentUserId: string;
 	isAdmin: boolean;
 	initialCommentCount?: number;
-	initialReactions?: { emoji: string; count: number; hasReacted: boolean }[];
+	initialReactions?: {
+		emoji: string;
+		count: number;
+		hasReacted: boolean;
+		users?: { id: string; firstName: string; lastName: string; avatar: string | null }[];
+	}[];
 }
 
 export function CardInteractionBar({
@@ -29,11 +32,20 @@ export function CardInteractionBar({
 	initialReactions,
 }: CardInteractionBarProps) {
 	const queryClient = useQueryClient();
-	const [showComments, setShowComments] = useState(false);
+	const searchParams = useSearchParams();
+	const focusTarget = searchParams?.get("focus");
+	const [showComments, setShowComments] = useState(focusTarget === "comments");
 	// Lazy: only fetch when user first hovers (desktop) or interacts (mobile)
-	const [fetchEnabled, setFetchEnabled] = useState(false);
+	const [fetchEnabled, setFetchEnabled] = useState(focusTarget === "comments");
 	// Track in-flight emoji toggles to prevent double-tap race
 	const pendingToggles = useRef(new Set<string>());
+	const rootRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (focusTarget === "comments") {
+			rootRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+		}
+	}, [focusTarget]);
 
 	const { data } = useQuery<{ success: boolean; data: CardInteractions }>({
 		queryKey: ["card-interactions", cardId, currentUserId],
@@ -140,19 +152,21 @@ export function CardInteractionBar({
 	const totalComments = interactions?.totalComments ?? initialCommentCount;
 
 	// Use initialReactions from the feed before the lazy fetch fires
-	const displayReactions = interactions
-		? reactions
-		: initialReactions ?? [];
+	const displayReactions = interactions ? reactions : (initialReactions ?? []);
 
 	const activeReactions = displayReactions.filter((r) => r.count > 0);
 	// Build ghost buttons for emojis not already shown as active
 	const activeEmojis = new Set(activeReactions.map((r) => r.emoji));
-	const ghostReactions = REACTION_EMOJIS.filter((e) => !activeEmojis.has(e)).map(
-		(emoji) => ({ emoji, count: 0, hasReacted: false }),
-	);
+	const ghostReactions = REACTION_EMOJIS.filter((e) => !activeEmojis.has(e)).map((emoji) => ({
+		emoji,
+		count: 0,
+		hasReacted: false,
+	}));
 
 	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: mouseenter only used for lazy-fetch hint
 		<div
+			ref={rootRef}
 			className="pt-3 mt-3 border-t border-border/50"
 			onMouseEnter={() => setFetchEnabled(true)}
 		>
@@ -160,21 +174,30 @@ export function CardInteractionBar({
 			<div className="flex flex-wrap items-center gap-1.5">
 				{/* Active reactions with counts */}
 				{activeReactions.map((r) => (
-					<button
-						key={r.emoji}
-						type="button"
-						onClick={() => handleReaction(r.emoji)}
-						className={cn(
-							"inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-sm transition-all",
-							r.hasReacted
-								? "bg-primary/15 ring-1 ring-primary/40 text-foreground font-medium"
-								: "bg-muted/60 dark:bg-white/5 text-foreground/80 hover:bg-muted dark:hover:bg-white/10",
+					<ReactorPopover key={r.emoji} emoji={r.emoji} users={r.users ?? []}>
+						{(handlers) => (
+							<button
+								type="button"
+								onClick={() => handleReaction(r.emoji)}
+								onMouseEnter={handlers.onMouseEnter}
+								onMouseLeave={handlers.onMouseLeave}
+								onPointerDown={handlers.onPointerDown}
+								onPointerUp={handlers.onPointerUp}
+								onPointerCancel={handlers.onPointerCancel}
+								onClickCapture={handlers.onClickCapture}
+								className={cn(
+									"inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-sm transition-all select-none",
+									r.hasReacted
+										? "bg-primary/15 ring-1 ring-primary/40 text-foreground font-medium"
+										: "bg-muted/60 dark:bg-white/5 text-foreground/80 hover:bg-muted dark:hover:bg-white/10",
+								)}
+								aria-label={`React with ${r.emoji} (${r.count})`}
+							>
+								<span>{r.emoji}</span>
+								<span className="text-xs tabular-nums">{r.count}</span>
+							</button>
 						)}
-						aria-label={`React with ${r.emoji} (${r.count})`}
-					>
-						<span>{r.emoji}</span>
-						<span className="text-xs tabular-nums">{r.count}</span>
-					</button>
+					</ReactorPopover>
 				))}
 
 				{/* Ghost buttons for zero-count emojis */}

--- a/app/(dashboard)/dashboard/recognition/_components/reactor-popover.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/reactor-popover.tsx
@@ -6,22 +6,28 @@ import { UserAvatar } from "@/components/shared/user-avatar";
 import type { CardReactionUser } from "@/lib/recognition";
 import { cn } from "@/lib/utils";
 
+interface TriggerProps {
+	onClick: (e: React.MouseEvent) => void;
+	onMouseEnter: () => void;
+	onMouseLeave: () => void;
+	onPointerDown: (e: React.PointerEvent) => void;
+	onPointerUp: () => void;
+	onPointerCancel: () => void;
+}
+
 interface ReactorPopoverProps {
 	emoji: string;
 	users: CardReactionUser[];
-	children: (handlers: {
-		onMouseEnter: () => void;
-		onMouseLeave: () => void;
-		onPointerDown: (e: React.PointerEvent) => void;
-		onPointerUp: () => void;
-		onPointerCancel: () => void;
-		onClickCapture: (e: React.MouseEvent) => void;
-	}) => ReactNode;
+	onActivate: () => void;
+	children: (trigger: TriggerProps) => ReactNode;
 }
 
-export function ReactorPopover({ emoji, users, children }: ReactorPopoverProps) {
+const HOVER_CLOSE_DELAY = 150;
+
+export function ReactorPopover({ emoji, users, onActivate, children }: ReactorPopoverProps) {
 	const [open, setOpen] = useState(false);
 	const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const hoverCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const suppressNextClick = useRef(false);
 	const containerRef = useRef<HTMLSpanElement>(null);
 
@@ -36,17 +42,38 @@ export function ReactorPopover({ emoji, users, children }: ReactorPopoverProps) 
 		return () => document.removeEventListener("pointerdown", handleDocClick);
 	}, [open]);
 
-	function onMouseEnter() {
-		// Desktop hover only — touch devices don't fire meaningful mouseenter before click
-		if (window.matchMedia("(hover: hover)").matches) {
-			setOpen(true);
+	useEffect(() => {
+		return () => {
+			if (longPressTimer.current) clearTimeout(longPressTimer.current);
+			if (hoverCloseTimer.current) clearTimeout(hoverCloseTimer.current);
+		};
+	}, []);
+
+	function isHoverCapable() {
+		return typeof window !== "undefined" && window.matchMedia("(hover: hover)").matches;
+	}
+
+	function cancelHoverClose() {
+		if (hoverCloseTimer.current) {
+			clearTimeout(hoverCloseTimer.current);
+			hoverCloseTimer.current = null;
 		}
 	}
 
+	function scheduleHoverClose() {
+		cancelHoverClose();
+		hoverCloseTimer.current = setTimeout(() => setOpen(false), HOVER_CLOSE_DELAY);
+	}
+
+	function onMouseEnter() {
+		if (!isHoverCapable()) return;
+		cancelHoverClose();
+		setOpen(true);
+	}
+
 	function onMouseLeave() {
-		if (window.matchMedia("(hover: hover)").matches) {
-			setOpen(false);
-		}
+		if (!isHoverCapable()) return;
+		scheduleHoverClose();
 	}
 
 	function onPointerDown(e: React.PointerEvent) {
@@ -64,12 +91,14 @@ export function ReactorPopover({ emoji, users, children }: ReactorPopoverProps) 
 		}
 	}
 
-	function onClickCapture(e: React.MouseEvent) {
+	function onClick(e: React.MouseEvent) {
 		if (suppressNextClick.current) {
 			e.preventDefault();
 			e.stopPropagation();
 			suppressNextClick.current = false;
+			return;
 		}
+		onActivate();
 	}
 
 	const hasUsers = users.length > 0;
@@ -77,46 +106,54 @@ export function ReactorPopover({ emoji, users, children }: ReactorPopoverProps) 
 	return (
 		<span ref={containerRef} className="relative inline-flex">
 			{children({
+				onClick,
 				onMouseEnter,
 				onMouseLeave,
 				onPointerDown,
 				onPointerUp: clearLongPress,
 				onPointerCancel: clearLongPress,
-				onClickCapture,
 			})}
 			{open && hasUsers && (
+				// biome-ignore lint/a11y/noStaticElementInteractions: mouse handlers only extend hover area
 				<div
 					role="dialog"
 					aria-label={`People who reacted with ${emoji}`}
+					onMouseEnter={cancelHoverClose}
+					onMouseLeave={scheduleHoverClose}
 					className={cn(
-						"absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50",
-						"min-w-[180px] max-w-[240px] rounded-xl border border-border/60",
-						"bg-popover text-popover-foreground shadow-lg p-2",
+						"absolute bottom-full left-1/2 -translate-x-1/2 z-50 pt-1 pb-2",
+						"min-w-[180px] max-w-[240px]",
 						"animate-in fade-in-0 zoom-in-95 duration-100",
 					)}
 				>
-					<div className="flex items-center gap-1.5 px-1.5 py-1 border-b border-border/40 mb-1">
-						<span className="text-base leading-none">{emoji}</span>
-						<span className="text-[11px] font-medium text-muted-foreground">
-							{users.length} {users.length === 1 ? "person" : "people"}
-						</span>
+					<div
+						className={cn(
+							"rounded-xl border border-border/60 bg-popover text-popover-foreground shadow-lg p-2",
+						)}
+					>
+						<div className="flex items-center gap-1.5 px-1.5 py-1 border-b border-border/40 mb-1">
+							<span className="text-base leading-none">{emoji}</span>
+							<span className="text-[11px] font-medium text-muted-foreground">
+								{users.length} {users.length === 1 ? "person" : "people"}
+							</span>
+						</div>
+						<ul className="max-h-48 overflow-y-auto space-y-1">
+							{users.map((u) => (
+								<li key={u.id} className="flex items-center gap-2 rounded-md px-1.5 py-1">
+									<UserAvatar
+										firstName={u.firstName}
+										lastName={u.lastName}
+										avatar={u.avatar}
+										size="xs"
+										className="bg-primary/10 text-primary"
+									/>
+									<span className="text-xs text-foreground truncate">
+										{u.firstName} {u.lastName}
+									</span>
+								</li>
+							))}
+						</ul>
 					</div>
-					<ul className="max-h-48 overflow-y-auto space-y-1">
-						{users.map((u) => (
-							<li key={u.id} className="flex items-center gap-2 rounded-md px-1.5 py-1">
-								<UserAvatar
-									firstName={u.firstName}
-									lastName={u.lastName}
-									avatar={u.avatar}
-									size="xs"
-									className="bg-primary/10 text-primary"
-								/>
-								<span className="text-xs text-foreground truncate">
-									{u.firstName} {u.lastName}
-								</span>
-							</li>
-						))}
-					</ul>
 				</div>
 			)}
 		</span>

--- a/app/(dashboard)/dashboard/recognition/_components/reactor-popover.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/reactor-popover.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
+import { UserAvatar } from "@/components/shared/user-avatar";
+import type { CardReactionUser } from "@/lib/recognition";
+import { cn } from "@/lib/utils";
+
+interface ReactorPopoverProps {
+	emoji: string;
+	users: CardReactionUser[];
+	children: (handlers: {
+		onMouseEnter: () => void;
+		onMouseLeave: () => void;
+		onPointerDown: (e: React.PointerEvent) => void;
+		onPointerUp: () => void;
+		onPointerCancel: () => void;
+		onClickCapture: (e: React.MouseEvent) => void;
+	}) => ReactNode;
+}
+
+export function ReactorPopover({ emoji, users, children }: ReactorPopoverProps) {
+	const [open, setOpen] = useState(false);
+	const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const suppressNextClick = useRef(false);
+	const containerRef = useRef<HTMLSpanElement>(null);
+
+	useEffect(() => {
+		if (!open) return;
+		function handleDocClick(e: MouseEvent) {
+			if (!containerRef.current?.contains(e.target as Node)) {
+				setOpen(false);
+			}
+		}
+		document.addEventListener("pointerdown", handleDocClick);
+		return () => document.removeEventListener("pointerdown", handleDocClick);
+	}, [open]);
+
+	function onMouseEnter() {
+		// Desktop hover only — touch devices don't fire meaningful mouseenter before click
+		if (window.matchMedia("(hover: hover)").matches) {
+			setOpen(true);
+		}
+	}
+
+	function onMouseLeave() {
+		if (window.matchMedia("(hover: hover)").matches) {
+			setOpen(false);
+		}
+	}
+
+	function onPointerDown(e: React.PointerEvent) {
+		if (e.pointerType === "mouse") return;
+		longPressTimer.current = setTimeout(() => {
+			setOpen(true);
+			suppressNextClick.current = true;
+		}, 450);
+	}
+
+	function clearLongPress() {
+		if (longPressTimer.current) {
+			clearTimeout(longPressTimer.current);
+			longPressTimer.current = null;
+		}
+	}
+
+	function onClickCapture(e: React.MouseEvent) {
+		if (suppressNextClick.current) {
+			e.preventDefault();
+			e.stopPropagation();
+			suppressNextClick.current = false;
+		}
+	}
+
+	const hasUsers = users.length > 0;
+
+	return (
+		<span ref={containerRef} className="relative inline-flex">
+			{children({
+				onMouseEnter,
+				onMouseLeave,
+				onPointerDown,
+				onPointerUp: clearLongPress,
+				onPointerCancel: clearLongPress,
+				onClickCapture,
+			})}
+			{open && hasUsers && (
+				<div
+					role="dialog"
+					aria-label={`People who reacted with ${emoji}`}
+					className={cn(
+						"absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50",
+						"min-w-[180px] max-w-[240px] rounded-xl border border-border/60",
+						"bg-popover text-popover-foreground shadow-lg p-2",
+						"animate-in fade-in-0 zoom-in-95 duration-100",
+					)}
+				>
+					<div className="flex items-center gap-1.5 px-1.5 py-1 border-b border-border/40 mb-1">
+						<span className="text-base leading-none">{emoji}</span>
+						<span className="text-[11px] font-medium text-muted-foreground">
+							{users.length} {users.length === 1 ? "person" : "people"}
+						</span>
+					</div>
+					<ul className="max-h-48 overflow-y-auto space-y-1">
+						{users.map((u) => (
+							<li key={u.id} className="flex items-center gap-2 rounded-md px-1.5 py-1">
+								<UserAvatar
+									firstName={u.firstName}
+									lastName={u.lastName}
+									avatar={u.avatar}
+									size="xs"
+									className="bg-primary/10 text-primary"
+								/>
+								<span className="text-xs text-foreground truncate">
+									{u.firstName} {u.lastName}
+								</span>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+		</span>
+	);
+}

--- a/app/api/recognition/[cardId]/interactions/route.ts
+++ b/app/api/recognition/[cardId]/interactions/route.ts
@@ -1,22 +1,16 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
+import type { Role } from "@/app/generated/prisma/client";
 import { requireSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
 import { hasMinRole } from "@/lib/permissions";
 import { REACTION_EMOJIS } from "@/lib/recognition";
-import type { Role } from "@/app/generated/prisma/client";
 
-export async function GET(
-	_req: Request,
-	{ params }: { params: Promise<{ cardId: string }> },
-) {
+export async function GET(_req: Request, { params }: { params: Promise<{ cardId: string }> }) {
 	let session: Awaited<ReturnType<typeof requireSession>>;
 	try {
 		session = await requireSession();
 	} catch {
-		return NextResponse.json(
-			{ success: false, error: "Unauthorized" },
-			{ status: 401 },
-		);
+		return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
 	}
 
 	try {
@@ -28,26 +22,32 @@ export async function GET(
 		});
 
 		if (!card) {
-			return NextResponse.json(
-				{ success: false, error: "Card not found" },
-				{ status: 404 },
-			);
+			return NextResponse.json({ success: false, error: "Card not found" }, { status: 404 });
 		}
 
 		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-		const isParticipant =
-			card.senderId === session.user.id || card.recipientId === session.user.id;
+		const isParticipant = card.senderId === session.user.id || card.recipientId === session.user.id;
 		if (!isParticipant && !isAdmin) {
-			return NextResponse.json(
-				{ success: false, error: "Forbidden" },
-				{ status: 403 },
-			);
+			return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
 		}
 
 		const [allReactions, comments] = await Promise.all([
 			prisma.cardReaction.findMany({
 				where: { cardId },
-				select: { emoji: true, userId: true },
+				select: {
+					emoji: true,
+					userId: true,
+					createdAt: true,
+					user: {
+						select: {
+							id: true,
+							firstName: true,
+							lastName: true,
+							avatar: true,
+						},
+					},
+				},
+				orderBy: { createdAt: "asc" },
 			}),
 			prisma.cardComment.findMany({
 				where: { cardId },
@@ -71,20 +71,36 @@ export async function GET(
 			}),
 		]);
 
-		const reactionMap = new Map<string, { count: number; hasReacted: boolean }>();
+		type ReactorEntry = {
+			count: number;
+			hasReacted: boolean;
+			users: {
+				id: string;
+				firstName: string;
+				lastName: string;
+				avatar: string | null;
+			}[];
+		};
+		const reactionMap = new Map<string, ReactorEntry>();
 		for (const emoji of REACTION_EMOJIS) {
-			reactionMap.set(emoji, { count: 0, hasReacted: false });
+			reactionMap.set(emoji, { count: 0, hasReacted: false, users: [] });
 		}
 		for (const r of allReactions) {
 			const entry = reactionMap.get(r.emoji);
 			if (entry) {
 				entry.count += 1;
+				entry.users.push(r.user);
 				if (r.userId === session.user.id) entry.hasReacted = true;
 			}
 		}
 
 		const reactions = Array.from(reactionMap.entries()).map(
-			([emoji, { count, hasReacted }]) => ({ emoji, count, hasReacted }),
+			([emoji, { count, hasReacted, users }]) => ({
+				emoji,
+				count,
+				hasReacted,
+				users,
+			}),
 		);
 
 		return NextResponse.json({

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -191,36 +191,48 @@ export async function GET(request: NextRequest) {
 
 		const cardIds = cards.map((c) => c.id);
 
-		// Batch fetch per-emoji reaction counts + current user's reactions (2 queries, not N+1)
-		const [reactionCounts, userReactions] = await Promise.all([
-			prisma.cardReaction.groupBy({
-				by: ["cardId", "emoji"],
-				where: { cardId: { in: cardIds } },
-				_count: true,
-			}),
-			prisma.cardReaction.findMany({
-				where: { cardId: { in: cardIds }, userId: session.user.id },
-				select: { cardId: true, emoji: true },
-			}),
-		]);
+		// Single pass — fetch every reaction row with the reactor's public fields.
+		// Bounded per card (≤ 6 emojis × N participants), so joining the user is cheap
+		// and lets the ReactorPopover render on first paint without waiting for the lazy fetch.
+		const allReactions = await prisma.cardReaction.findMany({
+			where: { cardId: { in: cardIds } },
+			select: {
+				cardId: true,
+				emoji: true,
+				userId: true,
+				user: {
+					select: {
+						id: true,
+						firstName: true,
+						lastName: true,
+						avatar: true,
+					},
+				},
+			},
+			orderBy: { createdAt: "asc" },
+		});
 
-		const userReactionSet = new Set(
-			userReactions.map((r) => `${r.cardId}:${r.emoji}`),
-		);
-
-		const reactionsByCard = new Map<
-			string,
-			{ emoji: string; count: number; hasReacted: boolean }[]
-		>();
-		for (const rc of reactionCounts) {
-			if (!reactionsByCard.has(rc.cardId)) {
-				reactionsByCard.set(rc.cardId, []);
+		type ReactorEntry = {
+			emoji: string;
+			count: number;
+			hasReacted: boolean;
+			users: { id: string; firstName: string; lastName: string; avatar: string | null }[];
+		};
+		const reactionsByCard = new Map<string, Map<string, ReactorEntry>>();
+		for (const r of allReactions) {
+			let perCard = reactionsByCard.get(r.cardId);
+			if (!perCard) {
+				perCard = new Map();
+				reactionsByCard.set(r.cardId, perCard);
 			}
-			reactionsByCard.get(rc.cardId)!.push({
-				emoji: rc.emoji,
-				count: rc._count,
-				hasReacted: userReactionSet.has(`${rc.cardId}:${rc.emoji}`),
-			});
+			let entry = perCard.get(r.emoji);
+			if (!entry) {
+				entry = { emoji: r.emoji, count: 0, hasReacted: false, users: [] };
+				perCard.set(r.emoji, entry);
+			}
+			entry.count += 1;
+			entry.users.push(r.user);
+			if (r.userId === session.user.id) entry.hasReacted = true;
 		}
 
 		return Response.json({
@@ -234,7 +246,7 @@ export async function GET(request: NextRequest) {
 				return {
 					...mapped,
 					reactionSummary: isCardParticipant
-						? reactionsByCard.get(card.id) ?? []
+						? Array.from(reactionsByCard.get(card.id)?.values() ?? [])
 						: undefined,
 				};
 			}),

--- a/components/shared/notification-bell.tsx
+++ b/components/shared/notification-bell.tsx
@@ -1,20 +1,20 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
-import { Bell, CheckCheck, Heart, Pencil, Trash2 } from "lucide-react";
-import { cn } from "@/lib/utils";
-import {
-	markNotificationReadAction,
-	markAllNotificationsReadAction,
-} from "@/lib/actions/notification-actions";
+import { Bell, CheckCheck, Heart, MessageCircle, Pencil, Smile, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import {
 	DropdownMenu,
-	DropdownMenuTrigger,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useNotifications, type Notification } from "@/hooks/use-notifications";
+import { type Notification, useNotifications } from "@/hooks/use-notifications";
+import {
+	markAllNotificationsReadAction,
+	markNotificationReadAction,
+} from "@/lib/actions/notification-actions";
+import { cn } from "@/lib/utils";
 
 function formatRelativeTime(dateString: string) {
 	const now = Date.now();
@@ -39,6 +39,10 @@ function notificationIcon(type: Notification["type"]) {
 			return <Pencil size={14} className="text-blue-500" />;
 		case "CARD_DELETED":
 			return <Trash2 size={14} className="text-destructive" />;
+		case "CARD_REACTION":
+			return <Smile size={14} className="text-amber-500" />;
+		case "CARD_COMMENT":
+			return <MessageCircle size={14} className="text-blue-500" />;
 	}
 }
 
@@ -62,7 +66,8 @@ export function NotificationBell() {
 			});
 		}
 		if (notification.cardId) {
-			router.push(`/dashboard/recognition/${notification.cardId}`);
+			const focus = notification.type === "CARD_COMMENT" ? "?focus=comments" : "";
+			router.push(`/dashboard/recognition/${notification.cardId}${focus}`);
 		}
 	}
 
@@ -76,15 +81,9 @@ export function NotificationBell() {
 					</span>
 				)}
 			</DropdownMenuTrigger>
-			<DropdownMenuContent
-				align="end"
-				sideOffset={8}
-				className="w-80 p-0 overflow-hidden"
-			>
+			<DropdownMenuContent align="end" sideOffset={8} className="w-80 p-0 overflow-hidden">
 				<div className="flex items-center justify-between border-b border-gray-200 dark:border-white/10 px-4 py-3">
-					<span className="text-sm font-semibold text-foreground">
-						Notifications
-					</span>
+					<span className="text-sm font-semibold text-foreground">Notifications</span>
 					{unreadCount > 0 && (
 						<button
 							type="button"
@@ -120,9 +119,7 @@ export function NotificationBell() {
 									<p
 										className={cn(
 											"text-sm leading-snug",
-											notification.isRead
-												? "text-muted-foreground"
-												: "text-foreground font-medium",
+											notification.isRead ? "text-muted-foreground" : "text-foreground font-medium",
 										)}
 									>
 										{notification.message}

--- a/components/shared/notification-bell.tsx
+++ b/components/shared/notification-bell.tsx
@@ -34,15 +34,15 @@ function formatRelativeTime(dateString: string) {
 function notificationIcon(type: Notification["type"]) {
 	switch (type) {
 		case "CARD_RECEIVED":
-			return <Heart size={14} className="text-primary" />;
+			return <Heart size={14} className="text-primary group-focus:text-white" />;
 		case "CARD_EDITED":
-			return <Pencil size={14} className="text-blue-500" />;
+			return <Pencil size={14} className="text-blue-500 group-focus:text-white" />;
 		case "CARD_DELETED":
-			return <Trash2 size={14} className="text-destructive" />;
+			return <Trash2 size={14} className="text-destructive group-focus:text-white" />;
 		case "CARD_REACTION":
-			return <Smile size={14} className="text-amber-500" />;
+			return <Smile size={14} className="text-amber-500 group-focus:text-white" />;
 		case "CARD_COMMENT":
-			return <MessageCircle size={14} className="text-blue-500" />;
+			return <MessageCircle size={14} className="text-blue-500 group-focus:text-white" />;
 	}
 }
 
@@ -112,11 +112,11 @@ export function NotificationBell() {
 								key={notification.id}
 								onClick={() => handleNotificationClick(notification)}
 								className={cn(
-									"flex w-full items-start gap-3 px-4 py-3 text-left transition-colors rounded-none cursor-pointer",
+									"group flex w-full items-start gap-3 px-4 py-3 text-left transition-colors rounded-none cursor-pointer",
 									!notification.isRead && "bg-primary/5",
 								)}
 							>
-								<div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-white/10">
+								<div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-white/10 group-focus:bg-white/20">
 									{notificationIcon(notification.type)}
 								</div>
 								<div className="flex-1 min-w-0">

--- a/components/shared/notification-bell.tsx
+++ b/components/shared/notification-bell.tsx
@@ -66,8 +66,12 @@ export function NotificationBell() {
 			});
 		}
 		if (notification.cardId) {
-			const focus = notification.type === "CARD_COMMENT" ? "?focus=comments" : "";
-			router.push(`/dashboard/recognition/${notification.cardId}${focus}`);
+			const params = new URLSearchParams();
+			if (notification.type === "CARD_COMMENT") params.set("focus", "comments");
+			// Nonce: guarantees the URL changes per click so repeated notifications
+			// for the same card still trigger navigation and re-open the thread.
+			params.set("n", notification.id);
+			router.push(`/dashboard/recognition/${notification.cardId}?${params.toString()}`);
 		}
 	}
 

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 
 interface Notification {
 	id: string;
-	type: "CARD_RECEIVED" | "CARD_EDITED" | "CARD_DELETED";
+	type: "CARD_RECEIVED" | "CARD_EDITED" | "CARD_DELETED" | "CARD_REACTION" | "CARD_COMMENT";
 	message: string;
 	isRead: boolean;
 	createdAt: string;

--- a/lib/actions/interaction-actions.ts
+++ b/lib/actions/interaction-actions.ts
@@ -1,11 +1,11 @@
 "use server";
 
-import { prisma } from "@/lib/db";
+import { z } from "zod";
+import type { Role } from "@/app/generated/prisma/client";
 import { requireSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
 import { hasMinRole } from "@/lib/permissions";
 import { REACTION_EMOJIS } from "@/lib/recognition";
-import type { Role } from "@/app/generated/prisma/client";
-import { z } from "zod";
 
 const reactionSchema = z.object({
 	cardId: z.string().min(1),
@@ -19,6 +19,39 @@ const commentBodySchema = z
 	.min(1, "Comment cannot be empty")
 	.max(500, "Comment cannot exceed 500 characters")
 	.trim();
+
+async function notifyCardInteraction({
+	card,
+	actorId,
+	actorName,
+	type,
+	emoji,
+}: {
+	card: { id: string; senderId: string; recipientId: string };
+	actorId: string;
+	actorName: string;
+	type: "CARD_REACTION" | "CARD_COMMENT";
+	emoji?: string;
+}) {
+	const recipients = Array.from(
+		new Set([card.senderId, card.recipientId].filter((id) => id !== actorId)),
+	);
+	if (recipients.length === 0) return;
+
+	const message =
+		type === "CARD_REACTION"
+			? `${actorName} reacted ${emoji ?? ""} to a recognition card`.trim()
+			: `${actorName} commented on a recognition card`;
+
+	await prisma.notification.createMany({
+		data: recipients.map((userId) => ({
+			userId,
+			type,
+			message,
+			cardId: card.id,
+		})),
+	});
+}
 
 export async function toggleReactionAction(cardId: string, emoji: string) {
 	try {
@@ -37,8 +70,7 @@ export async function toggleReactionAction(cardId: string, emoji: string) {
 		}
 
 		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-		const isParticipant =
-			card.senderId === session.user.id || card.recipientId === session.user.id;
+		const isParticipant = card.senderId === session.user.id || card.recipientId === session.user.id;
 		if (!isParticipant && !isAdmin) {
 			return { success: false as const, error: "Forbidden" };
 		}
@@ -57,14 +89,17 @@ export async function toggleReactionAction(cardId: string, emoji: string) {
 			await prisma.cardReaction.create({
 				data: { cardId, userId: session.user.id, emoji },
 			});
+			await notifyCardInteraction({
+				card,
+				actorId: session.user.id,
+				actorName: session.user.name ?? "Someone",
+				type: "CARD_REACTION",
+				emoji,
+			});
 			return { success: true as const, action: "added" as const };
 		} catch (err) {
 			// Concurrent toggle already created it — treat as remove
-			if (
-				err instanceof Error &&
-				"code" in err &&
-				(err as { code: string }).code === "P2002"
-			) {
+			if (err instanceof Error && "code" in err && (err as { code: string }).code === "P2002") {
 				await prisma.cardReaction.deleteMany({
 					where: { cardId, userId: session.user.id, emoji },
 				});
@@ -95,8 +130,7 @@ export async function addCommentAction(cardId: string, body: string) {
 		}
 
 		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-		const isParticipant =
-			card.senderId === session.user.id || card.recipientId === session.user.id;
+		const isParticipant = card.senderId === session.user.id || card.recipientId === session.user.id;
 		if (!isParticipant && !isAdmin) {
 			return { success: false as const, error: "Forbidden" };
 		}
@@ -119,6 +153,13 @@ export async function addCommentAction(cardId: string, body: string) {
 					},
 				},
 			},
+		});
+
+		await notifyCardInteraction({
+			card,
+			actorId: session.user.id,
+			actorName: session.user.name ?? "Someone",
+			type: "CARD_COMMENT",
 		});
 
 		return { success: true as const, data: comment };
@@ -150,8 +191,7 @@ export async function editCommentAction(commentId: string, body: string) {
 
 		const isEditAdmin = hasMinRole(session.user.role as Role, "ADMIN");
 		const isEditParticipant =
-			comment.card.senderId === session.user.id ||
-			comment.card.recipientId === session.user.id;
+			comment.card.senderId === session.user.id || comment.card.recipientId === session.user.id;
 		if (!isEditParticipant && !isEditAdmin) {
 			return { success: false as const, error: "Forbidden" };
 		}
@@ -206,8 +246,7 @@ export async function deleteCommentAction(commentId: string) {
 
 		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
 		const isDeleteParticipant =
-			comment.card.senderId === session.user.id ||
-			comment.card.recipientId === session.user.id;
+			comment.card.senderId === session.user.id || comment.card.recipientId === session.user.id;
 		if (!isDeleteParticipant && !isAdmin) {
 			return { success: false as const, error: "Forbidden" };
 		}

--- a/lib/actions/interaction-actions.ts
+++ b/lib/actions/interaction-actions.ts
@@ -89,9 +89,12 @@ export async function toggleReactionAction(cardId: string, emoji: string) {
 			await prisma.cardReaction.create({
 				data: { cardId, userId: session.user.id, emoji },
 			});
-			// Only notify if the reaction survives a concurrent double-tap.
-			// A racing sibling request that hits P2002 will delete the row —
-			// in that case the final state is "removed" and we must not notify.
+			// Best-effort race mitigation: re-read after the create so we skip the
+			// notification when a racing sibling already hit P2002 and deleted the row.
+			// This narrows the window but is not atomic with the create — a sibling
+			// delete that commits between the create and this read can still slip
+			// through. Full atomicity would require a queue or a retract step,
+			// which is out of scope for this PR.
 			const stillExists = await prisma.cardReaction.findUnique({
 				where: {
 					cardId_userId_emoji: { cardId, userId: session.user.id, emoji },
@@ -146,31 +149,42 @@ export async function addCommentAction(cardId: string, body: string) {
 			return { success: false as const, error: "Forbidden" };
 		}
 
-		const comment = await prisma.cardComment.create({
-			data: { cardId, userId: session.user.id, body: parsedBody.data },
-			select: {
-				id: true,
-				body: true,
-				createdAt: true,
-				updatedAt: true,
-				userId: true,
-				user: {
-					select: {
-						id: true,
-						firstName: true,
-						lastName: true,
-						avatar: true,
-						position: true,
+		const comment = await prisma.$transaction(async (tx) => {
+			const created = await tx.cardComment.create({
+				data: { cardId, userId: session.user.id, body: parsedBody.data },
+				select: {
+					id: true,
+					body: true,
+					createdAt: true,
+					updatedAt: true,
+					userId: true,
+					user: {
+						select: {
+							id: true,
+							firstName: true,
+							lastName: true,
+							avatar: true,
+							position: true,
+						},
 					},
 				},
-			},
-		});
+			});
 
-		await notifyCardInteraction({
-			card,
-			actorId: session.user.id,
-			actorName: session.user.name ?? "Someone",
-			type: "CARD_COMMENT",
+			const recipients = Array.from(
+				new Set([card.senderId, card.recipientId].filter((id) => id !== session.user.id)),
+			);
+			if (recipients.length > 0) {
+				await tx.notification.createMany({
+					data: recipients.map((userId) => ({
+						userId,
+						type: "CARD_COMMENT" as const,
+						message: `${session.user.name ?? "Someone"} commented on a recognition card`,
+						cardId: card.id,
+					})),
+				});
+			}
+
+			return created;
 		});
 
 		return { success: true as const, data: comment };

--- a/lib/actions/interaction-actions.ts
+++ b/lib/actions/interaction-actions.ts
@@ -89,13 +89,24 @@ export async function toggleReactionAction(cardId: string, emoji: string) {
 			await prisma.cardReaction.create({
 				data: { cardId, userId: session.user.id, emoji },
 			});
-			await notifyCardInteraction({
-				card,
-				actorId: session.user.id,
-				actorName: session.user.name ?? "Someone",
-				type: "CARD_REACTION",
-				emoji,
+			// Only notify if the reaction survives a concurrent double-tap.
+			// A racing sibling request that hits P2002 will delete the row —
+			// in that case the final state is "removed" and we must not notify.
+			const stillExists = await prisma.cardReaction.findUnique({
+				where: {
+					cardId_userId_emoji: { cardId, userId: session.user.id, emoji },
+				},
+				select: { id: true },
 			});
+			if (stillExists) {
+				await notifyCardInteraction({
+					card,
+					actorId: session.user.id,
+					actorName: session.user.name ?? "Someone",
+					type: "CARD_REACTION",
+					emoji,
+				});
+			}
 			return { success: true as const, action: "added" as const };
 		} catch (err) {
 			// Concurrent toggle already created it — treat as remove

--- a/lib/interactions.ts
+++ b/lib/interactions.ts
@@ -1,39 +1,53 @@
 import { prisma } from "@/lib/db";
-import { REACTION_EMOJIS } from "@/lib/recognition";
+import { type CardReactionUser, REACTION_EMOJIS } from "@/lib/recognition";
 
-export async function getCardReactionSummary(
-	cardId: string,
-	userId?: string,
-) {
-	const [reactionCounts, userReactions, commentCount] = await Promise.all([
-		prisma.cardReaction.groupBy({
-			by: ["emoji"],
+export async function getCardReactionSummary(cardId: string, userId?: string) {
+	const [reactions, commentCount] = await Promise.all([
+		prisma.cardReaction.findMany({
 			where: { cardId },
-			_count: true,
+			select: {
+				emoji: true,
+				userId: true,
+				user: {
+					select: {
+						id: true,
+						firstName: true,
+						lastName: true,
+						avatar: true,
+					},
+				},
+			},
+			orderBy: { createdAt: "asc" },
 		}),
-		userId
-			? prisma.cardReaction.findMany({
-					where: { cardId, userId },
-					select: { emoji: true },
-				})
-			: Promise.resolve([]),
 		prisma.cardComment.count({ where: { cardId } }),
 	]);
 
-	const userReactionSet = new Set(userReactions.map((r) => r.emoji));
-	const reactionMap = new Map(
-		reactionCounts.map((r) => [r.emoji, r._count]),
-	);
+	type Entry = { count: number; users: CardReactionUser[]; hasReacted: boolean };
+	const byEmoji = new Map<string, Entry>();
+	for (const r of reactions) {
+		let entry = byEmoji.get(r.emoji);
+		if (!entry) {
+			entry = { count: 0, users: [], hasReacted: false };
+			byEmoji.set(r.emoji, entry);
+		}
+		entry.count += 1;
+		entry.users.push(r.user);
+		if (userId && r.userId === userId) entry.hasReacted = true;
+	}
 
-	const publicReactions = REACTION_EMOJIS.map((emoji) => ({
-		emoji,
-		count: reactionMap.get(emoji) ?? 0,
-	})).filter((r) => r.count > 0);
+	const publicReactions = REACTION_EMOJIS.map((emoji) => {
+		const entry = byEmoji.get(emoji);
+		return { emoji, count: entry?.count ?? 0 };
+	}).filter((r) => r.count > 0);
 
-	const initialReactions = publicReactions.map((r) => ({
-		...r,
-		hasReacted: userReactionSet.has(r.emoji),
-	}));
+	const initialReactions = publicReactions.map((r) => {
+		const entry = byEmoji.get(r.emoji);
+		return {
+			...r,
+			hasReacted: entry?.hasReacted ?? false,
+			users: entry?.users ?? [],
+		};
+	});
 
 	return { publicReactions, initialReactions, commentCount };
 }

--- a/lib/recognition.ts
+++ b/lib/recognition.ts
@@ -59,7 +59,7 @@ export interface RecognitionCard {
 	valuesCommunication: boolean;
 	valuesContinuousImprovement: boolean;
 	interactionCounts: { reactions: number; comments: number } | null;
-	reactionSummary?: { emoji: string; count: number; hasReacted: boolean }[];
+	reactionSummary?: CardReactionSummary[];
 }
 
 export const COMPANY_VALUES = [

--- a/lib/recognition.ts
+++ b/lib/recognition.ts
@@ -1,10 +1,18 @@
 export const REACTION_EMOJIS = ["👏", "❤️", "🔥", "🎉", "💪", "😊"] as const;
 export type ReactionEmoji = (typeof REACTION_EMOJIS)[number];
 
+export interface CardReactionUser {
+	id: string;
+	firstName: string;
+	lastName: string;
+	avatar: string | null;
+}
+
 export interface CardReactionSummary {
 	emoji: string;
 	count: number;
 	hasReacted: boolean;
+	users?: CardReactionUser[];
 }
 
 export interface CardCommentUser {
@@ -84,11 +92,7 @@ export const VALUE_KEY_MAP: Record<string, string> = {
 
 export function formatRecognitionDate(dateString: string) {
 	const [year, month, day] = dateString.split("T")[0].split("-");
-	return new Date(
-		Number(year),
-		Number(month) - 1,
-		Number(day),
-	).toLocaleDateString("en-US", {
+	return new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString("en-US", {
 		month: "short",
 		day: "numeric",
 		year: "numeric",
@@ -141,8 +145,7 @@ function getQuarter(dateString: string): string {
 }
 
 function escapeCsvField(value: string): string {
-	const needsQuoting =
-		value.includes(",") || value.includes('"') || value.includes("\n");
+	const needsQuoting = value.includes(",") || value.includes('"') || value.includes("\n");
 	const escaped = needsQuoting ? `"${value.replace(/"/g, '""')}"` : value;
 	if (/^[=+\-@\t\r]/.test(escaped)) {
 		return `\t${escaped}`;
@@ -185,10 +188,7 @@ export function generateRecognitionCsv(cards: ExportRecognitionCard[]): string {
 		getQuarter(card.date),
 	]);
 
-	const lines = [
-		CSV_HEADERS.join(","),
-		...rows.map((row) => row.map(escapeCsvField).join(",")),
-	];
+	const lines = [CSV_HEADERS.join(","), ...rows.map((row) => row.map(escapeCsvField).join(","))];
 
 	return lines.join("\n");
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,8 @@ enum NotificationType {
   CARD_RECEIVED
   CARD_EDITED
   CARD_DELETED
+  CARD_REACTION
+  CARD_COMMENT
 }
 
 model User {


### PR DESCRIPTION
Closes #42

## Summary
- Notify both sender and recipient (excluding the actor) when someone adds a reaction or comment on a recognition card. Reaction removals do not create notifications.
- Adds two `NotificationType` enum values: `CARD_REACTION`, `CARD_COMMENT`, each with an icon in the bell dropdown.
- Clicking a comment notification deep-links to `/dashboard/recognition/[cardId]?focus=comments`, which auto-expands the comment thread and scrolls it into view.
- New `ReactorPopover` shows the list of people who reacted per emoji — hover on desktop, long-press on mobile — without breaking the existing click-to-toggle reaction behaviour.

## Changes
- `prisma/schema.prisma`: extend `NotificationType` enum (`bunx prisma db push` used, no migration file since project uses db push).
- `lib/actions/interaction-actions.ts`: add `notifyCardInteraction` helper; fire notifications on reaction add and comment add.
- `app/api/recognition/[cardId]/interactions/route.ts`: include reactor `id/firstName/lastName/avatar` per emoji.
- `lib/recognition.ts`: add `CardReactionUser` type; add optional `users` to `CardReactionSummary`.
- `app/(dashboard)/dashboard/recognition/_components/reactor-popover.tsx`: new component.
- `app/(dashboard)/dashboard/recognition/_components/card-interaction-bar.tsx`: wrap active reactions in popover; read `?focus=comments` to auto-open + scroll.
- `components/shared/notification-bell.tsx` + `hooks/use-notifications.ts`: icons and types for the two new notification kinds; append `?focus=comments` on comment notification click.

## Test plan
- [ ] Send a card; as the recipient, add a reaction → sender sees a `CARD_REACTION` bell notification (actor does not)
- [ ] As sender, add a comment → recipient sees a `CARD_COMMENT` notification
- [ ] Remove a reaction → no notification fires
- [ ] Clicking a `CARD_COMMENT` notification lands on the detail page with the comment section expanded and scrolled into view
- [ ] Hover an emoji with reactors on desktop → popover lists their names + avatars
- [ ] Long-press an emoji on mobile → popover opens and the reaction is not toggled
- [ ] Tap an emoji on mobile → reaction toggles as before

## Follow-up
- Coalescing bursty notifications tracked in #43