### PR TITLE
fix(notifications): sender auto-mark + delete notify + drop dead revalidations

### DIFF
--- a/app/(dashboard)/dashboard/recognition/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/page.tsx
@@ -213,7 +213,7 @@ export default async function RecognitionDetailPage({
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-6 mt-2">
-			{isRecipient && <MarkNotificationsRead cardId={id} />}
+			{canInteract && <MarkNotificationsRead cardId={id} />}
 			<div className="flex items-center gap-4">
 				<Link
 					href="/dashboard/recognition"

--- a/app/(dashboard)/dashboard/recognition/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/page.tsx
@@ -213,7 +213,7 @@ export default async function RecognitionDetailPage({
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-6 mt-2">
-			{canInteract && <MarkNotificationsRead cardId={id} />}
+			{(isSender || isRecipient) && <MarkNotificationsRead cardId={id} />}
 			<div className="flex items-center gap-4">
 				<Link
 					href="/dashboard/recognition"

--- a/lib/actions/interaction-actions.ts
+++ b/lib/actions/interaction-actions.ts
@@ -20,37 +20,8 @@ const commentBodySchema = z
 	.max(500, "Comment cannot exceed 500 characters")
 	.trim();
 
-async function notifyCardInteraction({
-	card,
-	actorId,
-	actorName,
-	type,
-	emoji,
-}: {
-	card: { id: string; senderId: string; recipientId: string };
-	actorId: string;
-	actorName: string;
-	type: "CARD_REACTION" | "CARD_COMMENT";
-	emoji?: string;
-}) {
-	const recipients = Array.from(
-		new Set([card.senderId, card.recipientId].filter((id) => id !== actorId)),
-	);
-	if (recipients.length === 0) return;
-
-	const message =
-		type === "CARD_REACTION"
-			? `${actorName} reacted ${emoji ?? ""} to a recognition card`.trim()
-			: `${actorName} commented on a recognition card`;
-
-	await prisma.notification.createMany({
-		data: recipients.map((userId) => ({
-			userId,
-			type,
-			message,
-			cardId: card.id,
-		})),
-	});
+function interactionRecipients(card: { senderId: string; recipientId: string }, actorId: string) {
+	return Array.from(new Set([card.senderId, card.recipientId].filter((id) => id !== actorId)));
 }
 
 export async function toggleReactionAction(cardId: string, emoji: string) {
@@ -75,8 +46,6 @@ export async function toggleReactionAction(cardId: string, emoji: string) {
 			return { success: false as const, error: "Forbidden" };
 		}
 
-		// Atomic toggle: attempt delete first, then create if nothing was removed.
-		// Catches unique constraint (P2002) from concurrent double-taps.
 		const deleted = await prisma.cardReaction.deleteMany({
 			where: { cardId, userId: session.user.id, emoji },
 		});
@@ -86,33 +55,29 @@ export async function toggleReactionAction(cardId: string, emoji: string) {
 		}
 
 		try {
-			await prisma.cardReaction.create({
-				data: { cardId, userId: session.user.id, emoji },
-			});
-			// Best-effort race mitigation: re-read after the create so we skip the
-			// notification when a racing sibling already hit P2002 and deleted the row.
-			// This narrows the window but is not atomic with the create — a sibling
-			// delete that commits between the create and this read can still slip
-			// through. Full atomicity would require a queue or a retract step,
-			// which is out of scope for this PR.
-			const stillExists = await prisma.cardReaction.findUnique({
-				where: {
-					cardId_userId_emoji: { cardId, userId: session.user.id, emoji },
-				},
-				select: { id: true },
-			});
-			if (stillExists) {
-				await notifyCardInteraction({
-					card,
-					actorId: session.user.id,
-					actorName: session.user.name ?? "Someone",
-					type: "CARD_REACTION",
-					emoji,
+			// Create + notify in one txn so the reaction and its notification are
+			// committed atomically. No window where we notify for a reaction that
+			// doesn't exist, and P2002 from a concurrent add rolls back cleanly.
+			await prisma.$transaction(async (tx) => {
+				await tx.cardReaction.create({
+					data: { cardId, userId: session.user.id, emoji },
 				});
-			}
+				const recipients = interactionRecipients(card, session.user.id);
+				if (recipients.length > 0) {
+					await tx.notification.createMany({
+						data: recipients.map((userId) => ({
+							userId,
+							type: "CARD_REACTION" as const,
+							message:
+								`${session.user.name ?? "Someone"} reacted ${emoji} to a recognition card`.trim(),
+							cardId: card.id,
+						})),
+					});
+				}
+			});
 			return { success: true as const, action: "added" as const };
 		} catch (err) {
-			// Concurrent toggle already created it — treat as remove
+			// A concurrent add already created the row — our click flips to remove.
 			if (err instanceof Error && "code" in err && (err as { code: string }).code === "P2002") {
 				await prisma.cardReaction.deleteMany({
 					where: { cardId, userId: session.user.id, emoji },
@@ -170,9 +135,7 @@ export async function addCommentAction(cardId: string, body: string) {
 				},
 			});
 
-			const recipients = Array.from(
-				new Set([card.senderId, card.recipientId].filter((id) => id !== session.user.id)),
-			);
+			const recipients = interactionRecipients(card, session.user.id);
 			if (recipients.length > 0) {
 				await tx.notification.createMany({
 					data: recipients.map((userId) => ({

--- a/lib/actions/notification-actions.ts
+++ b/lib/actions/notification-actions.ts
@@ -2,7 +2,6 @@
 
 import { prisma } from "@/lib/db";
 import { requireSession } from "@/lib/auth-utils";
-import { revalidatePath } from "next/cache";
 
 export async function markNotificationReadAction(notificationId: string) {
 	try {
@@ -16,7 +15,6 @@ export async function markNotificationReadAction(notificationId: string) {
 			data: { isRead: true },
 		});
 
-		revalidatePath("/dashboard");
 		return { success: true as const };
 	} catch (error) {
 		const message =
@@ -37,7 +35,6 @@ export async function markAllNotificationsReadAction() {
 			data: { isRead: true },
 		});
 
-		revalidatePath("/dashboard");
 		return { success: true as const };
 	} catch (error) {
 		const message =
@@ -59,7 +56,6 @@ export async function markNotificationsReadByCardAction(cardId: string) {
 			data: { isRead: true },
 		});
 
-		revalidatePath("/dashboard");
 		return { success: true as const };
 	} catch (error) {
 		const message =

--- a/lib/actions/recognition-actions.ts
+++ b/lib/actions/recognition-actions.ts
@@ -173,24 +173,33 @@ export async function deleteRecognitionCardAction(cardId: string) {
 
 		const card = await prisma.recognitionCard.findUnique({
 			where: { id: cardId },
-			select: { id: true, recipientId: true },
+			select: { id: true, senderId: true, recipientId: true },
 		});
 
 		if (!card) {
 			return { success: false as const, error: "Card not found" };
 		}
 
+		const notifyUserIds = Array.from(
+			new Set([card.senderId, card.recipientId].filter((id) => id !== session.user.id)),
+		);
+
 		await prisma.$transaction(async (tx) => {
 			await tx.notification.deleteMany({ where: { cardId } });
 			await tx.recognitionCard.delete({ where: { id: cardId } });
-			await tx.notification.create({
-				data: {
-					userId: card.recipientId,
-					type: "CARD_DELETED",
-					message: "An admin deleted a recognition card you received",
-					cardId: null,
-				},
-			});
+			if (notifyUserIds.length > 0) {
+				await tx.notification.createMany({
+					data: notifyUserIds.map((userId) => ({
+						userId,
+						type: "CARD_DELETED" as const,
+						message:
+							userId === card.senderId
+								? "An admin deleted a recognition card you sent"
+								: "An admin deleted a recognition card you received",
+						cardId: null,
+					})),
+				});
+			}
 		});
 
 		revalidatePath("/dashboard/recognition");


### PR DESCRIPTION
Closes #45

## Summary
- **Fix regression (#45):** `MarkNotificationsRead` on the card detail page was gated on `isRecipient`, which predated #44. Since `CARD_REACTION` / `CARD_COMMENT` notifications go to **both** sender and recipient, senders viewing their own card weren't getting those auto-marked read. Gate on `canInteract` so sender + recipient both get mark-on-view (admin is a safe no-op — the action is scoped by `session.user.id`).
- **Notify sender on card delete:** `deleteRecognitionCardAction` previously only notified the recipient. It now notifies both sender and recipient (excluding the acting admin) with role-specific messages.
- **Drop dead revalidations:** removed `revalidatePath("/dashboard")` from the three mark-read actions. The bell and badge read via React Query and the client invalidates its own query keys; the server-side revalidation wasn't driving any SSR refresh.

## Test plan
- [ ] As user A, send a card to user B. As B, react to it. As A, open the card detail page directly (not via the notification) → reaction notification for that card is marked read (previously stayed unread).
- [ ] As B, comment on A's card. As A, open the card detail page → comment notification marked read.
- [ ] As recipient, opening a card still auto-marks `CARD_RECEIVED` / `CARD_EDITED` as before (no regression).
- [ ] As admin, delete a card A sent to B → both A and B receive a `CARD_DELETED` notification with the correct "you sent" / "you received" wording.
- [ ] As admin who is also the sender of the deleted card → only the other party is notified (actor excluded).
- [ ] `mark all as read` and per-notification mark-read still update the bell badge and inbox "new" pill without a full refresh (React Query invalidation path).