### PR TITLE
fix(auth): resolve redirect loop from stale session cookie (#47)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -24,20 +24,31 @@ export async function proxy(request: NextRequest) {
 		const session = await auth.api.getSession({
 			headers: request.headers,
 		});
-		if (session) {
-			const user = await prisma.user.findUnique({
-				where: { id: session.user.id },
-				select: { isActive: true },
-			});
-			if (!user?.isActive) {
-				const response = NextResponse.redirect(new URL("/login", request.url));
-				response.cookies.delete(sessionToken.name);
-				return response;
-			}
+		if (!session) {
+			const response = NextResponse.redirect(new URL("/login", request.url));
+			response.cookies.delete(sessionToken.name);
+			return response;
+		}
+		const user = await prisma.user.findUnique({
+			where: { id: session.user.id },
+			select: { isActive: true },
+		});
+		if (!user?.isActive) {
+			const response = NextResponse.redirect(new URL("/login", request.url));
+			response.cookies.delete(sessionToken.name);
+			return response;
 		}
 	}
 
 	if ((pathname === "/login" || pathname === "/register") && sessionCookie) {
+		const session = await auth.api.getSession({
+			headers: request.headers,
+		});
+		if (!session) {
+			const response = NextResponse.next();
+			response.cookies.delete(sessionToken.name);
+			return response;
+		}
 		const callbackUrl = request.nextUrl.searchParams.get("callbackUrl");
 		const safeCallback = callbackUrl?.startsWith("/") && !callbackUrl.startsWith("//") ? callbackUrl : "/dashboard";
 		return NextResponse.redirect(new URL(safeCallback, request.url));

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,10 +1,24 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
 import { getCookies } from "better-auth/cookies";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 
 const { sessionToken } = getCookies(auth.options);
+
+function sanitizeCallback(callbackUrl: string | null): string | null {
+	if (!callbackUrl) return null;
+	if (!callbackUrl.startsWith("/") || callbackUrl.startsWith("//")) return null;
+	return callbackUrl;
+}
+
+async function resolveSession(request: NextRequest) {
+	try {
+		return await auth.api.getSession({ headers: request.headers });
+	} catch {
+		return null;
+	}
+}
 
 export async function proxy(request: NextRequest) {
 	const sessionCookie = request.cookies.get(sessionToken.name)?.value ?? null;
@@ -21,9 +35,7 @@ export async function proxy(request: NextRequest) {
 	}
 
 	if (isProtected && sessionCookie) {
-		const session = await auth.api.getSession({
-			headers: request.headers,
-		});
+		const session = await resolveSession(request);
 		if (!session) {
 			const response = NextResponse.redirect(new URL("/login", request.url));
 			response.cookies.delete(sessionToken.name);
@@ -41,16 +53,19 @@ export async function proxy(request: NextRequest) {
 	}
 
 	if ((pathname === "/login" || pathname === "/register") && sessionCookie) {
-		const session = await auth.api.getSession({
-			headers: request.headers,
-		});
+		const session = await resolveSession(request);
 		if (!session) {
-			const response = NextResponse.next();
+			const authUrl = new URL(pathname, request.url);
+			const safeCallback = sanitizeCallback(request.nextUrl.searchParams.get("callbackUrl"));
+			if (safeCallback) {
+				authUrl.searchParams.set("callbackUrl", safeCallback);
+			}
+			const response = NextResponse.redirect(authUrl);
 			response.cookies.delete(sessionToken.name);
 			return response;
 		}
-		const callbackUrl = request.nextUrl.searchParams.get("callbackUrl");
-		const safeCallback = callbackUrl?.startsWith("/") && !callbackUrl.startsWith("//") ? callbackUrl : "/dashboard";
+		const safeCallback =
+			sanitizeCallback(request.nextUrl.searchParams.get("callbackUrl")) ?? "/dashboard";
 		return NextResponse.redirect(new URL(safeCallback, request.url));
 	}
 


### PR DESCRIPTION
## Summary
- Fixes `ERR_TOO_MANY_REDIRECTS` loop between `/login` and `/dashboard` when a stale `better-auth.session_token` cookie is present (e.g. after DB reset or session expiry).
- On protected routes, if `getSession()` returns `null` despite a cookie being present, clear the cookie and redirect to `/login` instead of silently falling through.
- On `/login` and `/register`, verify the session is actually valid before redirecting to `/dashboard`; clear the cookie if stale.

Closes #47

## Test plan
- [ ] With a stale cookie, hit `/dashboard` → lands on `/login` cleanly, no loop
- [ ] With a stale cookie, hit `/login` → page renders, cookie cleared
- [ ] Valid session → `/login` still redirects to `/dashboard`
- [ ] Inactive user → still kicked to `/login` with cookie cleared
- [ ] Logged-out user hitting `/dashboard` → redirected to `/login`