### PR TITLE
fix(auth): sanitize callbackUrl in login form before redirect

### DIFF
--- a/app/(auth)/login/_components/login-form.tsx
+++ b/app/(auth)/login/_components/login-form.tsx
@@ -1,17 +1,18 @@
 "use client";
 
-import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import Link from "next/link";
-import { Eye, EyeOff, Loader2 } from "lucide-react";
-import { signIn } from "@/lib/auth-client";
-import { loginSchema, type LoginInput } from "@/lib/validations/auth";
 import { AccessGroupLogo } from "@/components/shared/access-logos";
 import { GoogleIcon, MicrosoftIcon } from "@/components/shared/oauth-icons";
 import type { OAuthSettings } from "@/lib/actions/settings-actions";
+import { safeCallbackUrl } from "@/lib/auth/safe-callback";
+import { signIn } from "@/lib/auth-client";
+import { type LoginInput, loginSchema } from "@/lib/validations/auth";
 
 const OAUTH_ERROR_MESSAGES: Record<string, string> = {
 	invalid_code: "OAuth sign-in failed. Please try again.",
@@ -22,13 +23,16 @@ const OAUTH_ERROR_MESSAGES: Record<string, string> = {
 export function LoginForm() {
 	const router = useRouter();
 	const searchParams = useSearchParams();
-	const callbackUrl = searchParams.get("callbackUrl") ?? "/dashboard";
+	const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
 	const [isLoading, setIsLoading] = useState(false);
 	const [isGoogleLoading, setIsGoogleLoading] = useState(false);
 	const [isMicrosoftLoading, setIsMicrosoftLoading] = useState(false);
 	const [showPassword, setShowPassword] = useState(false);
 	const [oauthSettings, setOauthSettings] = useState<OAuthSettings | null>(null);
-	const [oauthAvailability, setOauthAvailability] = useState<{ google: boolean; microsoft: boolean } | null>(null);
+	const [oauthAvailability, setOauthAvailability] = useState<{
+		google: boolean;
+		microsoft: boolean;
+	} | null>(null);
 
 	useEffect(() => {
 		fetch("/api/settings/oauth")
@@ -116,7 +120,8 @@ export function LoginForm() {
 	const oauthLoaded = oauthSettings !== null;
 	const anyOAuthDisabled = isLoading || isGoogleLoading || isMicrosoftLoading;
 	const showGoogle = oauthSettings?.oauth_google_enabled && oauthAvailability?.google !== false;
-	const showMicrosoft = oauthSettings?.oauth_microsoft_enabled && oauthAvailability?.microsoft === true;
+	const showMicrosoft =
+		oauthSettings?.oauth_microsoft_enabled && oauthAvailability?.microsoft === true;
 	const hasOAuth = showGoogle || showMicrosoft;
 
 	return (
@@ -188,9 +193,7 @@ export function LoginForm() {
 									<div className="w-full border-t border-gray-200 dark:border-white/10" />
 								</div>
 								<div className="relative flex justify-center text-xs uppercase">
-									<span className="bg-card px-2 text-muted-foreground">
-										Or continue with
-									</span>
+									<span className="bg-card px-2 text-muted-foreground">Or continue with</span>
 								</div>
 							</div>
 						</>

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.9",
         "@tailwindcss/postcss": "^4",
+        "@types/bun": "^1.3.12",
         "@types/node": "^20",
         "@types/pg": "^8.20.0",
         "@types/react": "^19",
@@ -565,6 +566,8 @@
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
     "@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
@@ -614,6 +617,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/lib/auth/safe-callback.test.ts
+++ b/lib/auth/safe-callback.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { safeCallbackUrl, sanitizeCallbackUrl } from "./safe-callback";
+
+describe("sanitizeCallbackUrl", () => {
+	test.each([
+		["//evil.example"],
+		["///evil.example"],
+		["https://evil.example"],
+		["http://evil.example"],
+		["javascript:alert(1)"],
+		["mailto:a@b.c"],
+		["dashboard"],
+		[""],
+		[null],
+		[undefined],
+	])("rejects %p", (input) => {
+		expect(sanitizeCallbackUrl(input)).toBeNull();
+	});
+
+	test.each([
+		["/", "/"],
+		["/dashboard", "/dashboard"],
+		["/dashboard/users", "/dashboard/users"],
+		["/dashboard?tab=1&q=foo", "/dashboard?tab=1&q=foo"],
+		["/dashboard#section", "/dashboard#section"],
+	])("accepts %p", (input, expected) => {
+		expect(sanitizeCallbackUrl(input)).toBe(expected);
+	});
+});
+
+describe("safeCallbackUrl", () => {
+	test("returns sanitized value when valid", () => {
+		expect(safeCallbackUrl("/dashboard/users")).toBe("/dashboard/users");
+	});
+
+	test("falls back to /dashboard when invalid", () => {
+		expect(safeCallbackUrl("//evil.example")).toBe("/dashboard");
+		expect(safeCallbackUrl("https://evil.example")).toBe("/dashboard");
+		expect(safeCallbackUrl(null)).toBe("/dashboard");
+		expect(safeCallbackUrl(undefined)).toBe("/dashboard");
+		expect(safeCallbackUrl("")).toBe("/dashboard");
+	});
+});

--- a/lib/auth/safe-callback.ts
+++ b/lib/auth/safe-callback.ts
@@ -1,0 +1,11 @@
+const DEFAULT_CALLBACK = "/dashboard";
+
+export function sanitizeCallbackUrl(callbackUrl: string | null | undefined): string | null {
+	if (!callbackUrl) return null;
+	if (!callbackUrl.startsWith("/") || callbackUrl.startsWith("//")) return null;
+	return callbackUrl;
+}
+
+export function safeCallbackUrl(callbackUrl: string | null | undefined): string {
+	return sanitizeCallbackUrl(callbackUrl) ?? DEFAULT_CALLBACK;
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
     "@tailwindcss/postcss": "^4",
+    "@types/bun": "^1.3.12",
     "@types/node": "^20",
     "@types/pg": "^8.20.0",
     "@types/react": "^19",

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,15 +2,10 @@ import { getCookies } from "better-auth/cookies";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { sanitizeCallbackUrl } from "@/lib/auth/safe-callback";
 import { prisma } from "@/lib/db";
 
 const { sessionToken } = getCookies(auth.options);
-
-function sanitizeCallback(callbackUrl: string | null): string | null {
-	if (!callbackUrl) return null;
-	if (!callbackUrl.startsWith("/") || callbackUrl.startsWith("//")) return null;
-	return callbackUrl;
-}
 
 async function resolveSession(request: NextRequest) {
 	try {
@@ -56,7 +51,7 @@ export async function proxy(request: NextRequest) {
 		const session = await resolveSession(request);
 		if (!session) {
 			const authUrl = new URL(pathname, request.url);
-			const safeCallback = sanitizeCallback(request.nextUrl.searchParams.get("callbackUrl"));
+			const safeCallback = sanitizeCallbackUrl(request.nextUrl.searchParams.get("callbackUrl"));
 			if (safeCallback) {
 				authUrl.searchParams.set("callbackUrl", safeCallback);
 			}
@@ -65,7 +60,7 @@ export async function proxy(request: NextRequest) {
 			return response;
 		}
 		const safeCallback =
-			sanitizeCallback(request.nextUrl.searchParams.get("callbackUrl")) ?? "/dashboard";
+			sanitizeCallbackUrl(request.nextUrl.searchParams.get("callbackUrl")) ?? "/dashboard";
 		return NextResponse.redirect(new URL(safeCallback, request.url));
 	}
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,7 +2,7 @@ import { getCookies } from "better-auth/cookies";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { sanitizeCallbackUrl } from "@/lib/auth/safe-callback";
+import { safeCallbackUrl, sanitizeCallbackUrl } from "@/lib/auth/safe-callback";
 import { prisma } from "@/lib/db";
 
 const { sessionToken } = getCookies(auth.options);
@@ -59,8 +59,7 @@ export async function proxy(request: NextRequest) {
 			response.cookies.delete(sessionToken.name);
 			return response;
 		}
-		const safeCallback =
-			sanitizeCallbackUrl(request.nextUrl.searchParams.get("callbackUrl")) ?? "/dashboard";
+		const safeCallback = safeCallbackUrl(request.nextUrl.searchParams.get("callbackUrl"));
 		return NextResponse.redirect(new URL(safeCallback, request.url));
 	}
 


### PR DESCRIPTION
## Summary
- Extracts the `proxy.ts` callback sanitizer into a shared `lib/auth/safe-callback.ts` util (`sanitizeCallbackUrl`, `safeCallbackUrl`).
- Applies the sanitizer at the read site in `app/(auth)/login/_components/login-form.tsx` so the email/password `router.push` and both `signIn.social` OAuth calls can no longer redirect to an external host.
- Closes the gap left by #48: the prior fix only covered the stale-cookie path in `proxy.ts`; fresh (cookie-less) visits to `/login?callbackUrl=//evil.example` fell through to the form without sanitization.

Register form already hardcodes `/dashboard` for OAuth callbacks, so no change needed there.

Closes #49

## Test plan
- [ ] `/login?callbackUrl=//evil.example` → post email/password login lands on `/dashboard`
- [ ] `/login?callbackUrl=https://evil.example` → post email/password login lands on `/dashboard`
- [ ] `/login?callbackUrl=/dashboard/users` → post email/password login lands on `/dashboard/users`
- [ ] Same three cases via Google OAuth
- [ ] Same three cases via Microsoft OAuth
- [ ] Stale-cookie path (existing #48 coverage) still sanitizes correctly