### PR TITLE
fix(auth): preserve callbackUrl on bounce + sanitize at point of use

### DIFF
--- a/app/(auth)/login/_components/login-form.tsx
+++ b/app/(auth)/login/_components/login-form.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import Link from "next/link";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { signIn } from "@/lib/auth-client";
+import { safeCallbackOrDefault } from "@/lib/auth/safe-callback";
 import { loginSchema, type LoginInput } from "@/lib/validations/auth";
 import { AccessGroupLogo } from "@/components/shared/access-logos";
 import { GoogleIcon, MicrosoftIcon } from "@/components/shared/oauth-icons";
@@ -22,7 +23,7 @@ const OAUTH_ERROR_MESSAGES: Record<string, string> = {
 export function LoginForm() {
 	const router = useRouter();
 	const searchParams = useSearchParams();
-	const callbackUrl = searchParams.get("callbackUrl") ?? "/dashboard";
+	const callbackUrl = safeCallbackOrDefault(searchParams.get("callbackUrl"));
 	const [isLoading, setIsLoading] = useState(false);
 	const [isGoogleLoading, setIsGoogleLoading] = useState(false);
 	const [isMicrosoftLoading, setIsMicrosoftLoading] = useState(false);

--- a/lib/auth/safe-callback.ts
+++ b/lib/auth/safe-callback.ts
@@ -1,0 +1,12 @@
+export function sanitizeCallback(callbackUrl: string | null | undefined): string | null {
+	if (!callbackUrl) return null;
+	if (!callbackUrl.startsWith("/") || callbackUrl.startsWith("//")) return null;
+	return callbackUrl;
+}
+
+export function safeCallbackOrDefault(
+	callbackUrl: string | null | undefined,
+	fallback = "/dashboard",
+): string {
+	return sanitizeCallback(callbackUrl) ?? fallback;
+}

--- a/lib/auth/safe-callback.ts
+++ b/lib/auth/safe-callback.ts
@@ -1,6 +1,7 @@
 export function sanitizeCallback(callbackUrl: string | null | undefined): string | null {
 	if (!callbackUrl) return null;
-	if (!callbackUrl.startsWith("/") || callbackUrl.startsWith("//")) return null;
+	if (!callbackUrl.startsWith("/")) return null;
+	if (callbackUrl.startsWith("//") || callbackUrl.startsWith("/\\")) return null;
 	return callbackUrl;
 }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,15 +2,10 @@ import { getCookies } from "better-auth/cookies";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { sanitizeCallback } from "@/lib/auth/safe-callback";
 import { prisma } from "@/lib/db";
 
 const { sessionToken } = getCookies(auth.options);
-
-function sanitizeCallback(callbackUrl: string | null): string | null {
-	if (!callbackUrl) return null;
-	if (!callbackUrl.startsWith("/") || callbackUrl.startsWith("//")) return null;
-	return callbackUrl;
-}
 
 async function resolveSession(request: NextRequest) {
 	try {
@@ -28,7 +23,7 @@ export async function proxy(request: NextRequest) {
 
 	if (isProtected && !sessionCookie) {
 		const loginUrl = new URL("/login", request.url);
-		if (!pathname.startsWith("/dashboard")) {
+		if (pathname !== "/dashboard") {
 			loginUrl.searchParams.set("callbackUrl", pathname);
 		}
 		return NextResponse.redirect(loginUrl);


### PR DESCRIPTION
## Summary
- Closes #50 by inverting the dead inner guard in `proxy.ts` so `callbackUrl` is set whenever the bounced path is not `/dashboard` itself.
- Closes #49 by sanitizing `callbackUrl` at point of use in the login form so `router.push` and both OAuth `signIn.social` calls reject `//evil` and absolute URLs.
- Extracts the rule into `lib/auth/safe-callback.ts` so `proxy.ts` and the form share one definition (must start with `/`, must not start with `//`, fall back to `/dashboard`).
- Bundled because #50 widens the values reaching the form, which would widen the open-redirect surface without #49.

## Test plan
- [ ] Logged-out visit to `/dashboard/users/<id>` → redirected to `/login?callbackUrl=%2Fdashboard%2Fusers%2F<id>` → after sign-in lands on that page
- [ ] `/login?callbackUrl=//evil.example` → post-login lands on `/dashboard`, never external
- [ ] `/login?callbackUrl=https://evil.example` → post-login lands on `/dashboard`
- [ ] `/login?callbackUrl=/dashboard/users` → post-login lands on `/dashboard/users`
- [ ] Same coverage for Google and Microsoft OAuth flows