### PR TITLE
ci(test): run vitest on every pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run unit tests
+        run: bun run test:run


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` — installs deps via `bun install --frozen-lockfile` and runs `bun run test:run` on every PR plus pushes to `main`.
- Closes the gap raised in the review of #53: the `test:run` script existed but nothing automatically invoked it, so regressions in `safe-callback` (or any future spec) only surfaced if someone remembered to run tests locally.

## Stacking
Branched off `chore/setup-vitest` and **targets** that branch (the workflow needs the `test:run` script that #53 adds). Merge order: **#52 → #53 → #54**. GitHub will auto-retarget this PR to `main` once #53 lands.

## Test plan
- [ ] After merging the stack, CI runs on the next PR and reports a `Test` check
- [ ] Intentionally failing test → PR check turns red