### PR TITLE
fix(auth): preserve callbackUrl when proxy bounces deep dashboard URLs

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -23,7 +23,7 @@ export async function proxy(request: NextRequest) {
 
 	if (isProtected && !sessionCookie) {
 		const loginUrl = new URL("/login", request.url);
-		if (!pathname.startsWith("/dashboard")) {
+		if (pathname !== "/dashboard") {
 			loginUrl.searchParams.set("callbackUrl", pathname);
 		}
 		return NextResponse.redirect(loginUrl);


### PR DESCRIPTION
## Summary
- Inverts the dead inner guard in `proxy.ts` so unauthenticated visits to deep dashboard URLs (e.g. `/dashboard/users/42`) round-trip through `/login` with the original path preserved as `callbackUrl`.
- One-line change. The original `!pathname.startsWith("/dashboard")` could never be true under the outer `isProtected = pathname.startsWith("/dashboard")` guard.
- `/dashboard` itself still bounces without a callback — the login form's `safeCallbackUrl` falls back to `/dashboard` anyway, so it's a no-op.

Closes #50.

## Context
Originally bundled in #52 with the #49 sanitization fix, but #51 landed the #49 work independently with different export names. Closing #52/#53/#54 in favour of this minimal patch — the proxy fix is the only piece not yet on `main`.

## Test plan
- [ ] Logged-out visit to `/dashboard/users/<id>` → redirected to `/login?callbackUrl=%2Fdashboard%2Fusers%2F<id>`
- [ ] After sign-in, lands on `/dashboard/users/<id>`
- [ ] Logged-out visit to `/dashboard` → redirected to `/login` (no callback) → after sign-in lands on `/dashboard`