### PR TITLE
feat(users): add date hired and structured shift schedule

### DIFF
--- a/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
@@ -16,11 +16,30 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 
 	const { id } = await params;
 	const [user, departments] = await Promise.all([
-		prisma.user.findUnique({ where: { id } }),
+		prisma.user.findUnique({
+			where: { id },
+			include: { shiftSchedule: { include: { days: { orderBy: { dayOfWeek: "asc" } } } } },
+		}),
 		prisma.department.findMany({ orderBy: { name: "asc" } }),
 	]);
 
 	if (!user) notFound();
+
+	const scheduleDefault = user.shiftSchedule
+		? {
+				timezone: user.shiftSchedule.timezone,
+				days: Array.from({ length: 7 }, (_, dayOfWeek) => {
+					const existing = user.shiftSchedule?.days.find((d) => d.dayOfWeek === dayOfWeek);
+					return {
+						dayOfWeek,
+						isWorking: existing?.isWorking ?? false,
+						startTime: existing?.startTime ?? null,
+						endTime: existing?.endTime ?? null,
+						breakMins: existing?.breakMins ?? 0,
+					};
+				}),
+			}
+		: null;
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-8 mt-2">
@@ -55,6 +74,8 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 					role: user.role,
 					departmentId: user.departmentId,
 					isActive: user.isActive,
+					hireDate: user.hireDate,
+					shiftSchedule: scheduleDefault,
 				}}
 			/>
 			<ResetPasswordForm userId={user.id} userName={`${user.firstName} ${user.lastName}`} />

--- a/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
@@ -75,6 +75,7 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 					departmentId: user.departmentId,
 					isActive: user.isActive,
 					hireDate: user.hireDate,
+					birthday: user.birthday,
 					shiftSchedule: scheduleDefault,
 				}}
 			/>

--- a/app/(dashboard)/dashboard/users/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Pencil } from "lucide-react";
+import { ArrowLeft, Clock, Pencil } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import type { Role } from "@/app/generated/prisma/client";
@@ -6,6 +6,17 @@ import { Badge } from "@/components/ui/badge";
 import { getServerSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { canViewUsers } from "@/lib/permissions";
+import { DISPLAY_DAY_ORDER, SHIFT_DAY_LABELS_SHORT } from "@/lib/validations/user";
+
+function hhmmToMinutes(value: string): number {
+	const [h, m] = value.split(":").map((n) => Number.parseInt(n, 10));
+	return h * 60 + m;
+}
+
+function formatWeeklyHours(minutes: number): string {
+	const hours = minutes / 60;
+	return `${hours.toFixed(hours % 1 === 0 ? 0 : 1)}h / week`;
+}
 
 const BRANCH_LABELS: Record<string, string> = {
 	ISO: "ISO",
@@ -17,6 +28,16 @@ function formatBranch(branch: string | null): string | null {
 	return BRANCH_LABELS[branch] ?? branch;
 }
 
+function formatHireDate(value: Date | null): string | null {
+	if (!value) return null;
+	return new Intl.DateTimeFormat("en-AU", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+		timeZone: "UTC",
+	}).format(value);
+}
+
 export default async function UserDetailPage({ params }: { params: Promise<{ id: string }> }) {
 	const session = await getServerSession();
 	if (!session || !canViewUsers(session.user.role as Role)) {
@@ -26,10 +47,19 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 	const { id } = await params;
 	const user = await prisma.user.findUnique({
 		where: { id },
-		include: { department: true },
+		include: {
+			department: true,
+			shiftSchedule: { include: { days: { orderBy: { dayOfWeek: "asc" } } } },
+		},
 	});
 
 	if (!user) notFound();
+
+	const orderedDays = user.shiftSchedule
+		? Array.from({ length: 7 }, (_, dayOfWeek) =>
+				user.shiftSchedule?.days.find((d) => d.dayOfWeek === dayOfWeek),
+			)
+		: null;
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-8 mt-2">
@@ -98,8 +128,101 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 								{user.isActive ? "Active" : "Inactive"}
 							</Badge>
 						</div>
+						<InfoRow label="Date Hired" value={formatHireDate(user.hireDate)} />
 						<InfoRow label="Joined" value={user.createdAt.toLocaleDateString()} />
 					</div>
+				</div>
+			</div>
+
+			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] overflow-hidden">
+				<div className="px-8 pt-8 pb-4 flex items-center justify-between gap-4">
+					<div className="flex items-center gap-3">
+						<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+							<Clock className="h-5 w-5" />
+						</div>
+						<div>
+							<h2 className="text-[1.25rem] font-medium text-foreground leading-tight">
+								Shift Schedule
+							</h2>
+							{user.shiftSchedule && (
+								<p className="text-xs text-muted-foreground mt-0.5">
+									{user.shiftSchedule.timezone}
+								</p>
+							)}
+						</div>
+					</div>
+					{orderedDays &&
+						(() => {
+							const totalMins = orderedDays.reduce((sum, day) => {
+								if (!day?.isWorking || !day.startTime || !day.endTime) return sum;
+								return (
+									sum + (hhmmToMinutes(day.endTime) - hhmmToMinutes(day.startTime)) - day.breakMins
+								);
+							}, 0);
+							const workingCount = orderedDays.filter((d) => d?.isWorking).length;
+							return (
+								<div className="text-right">
+									<div className="text-lg font-semibold text-foreground">
+										{formatWeeklyHours(totalMins)}
+									</div>
+									<div className="text-xs text-muted-foreground">
+										{workingCount} working {workingCount === 1 ? "day" : "days"}
+									</div>
+								</div>
+							);
+						})()}
+				</div>
+				<div className="px-8 pb-8">
+					{!orderedDays && (
+						<div className="rounded-2xl border border-dashed border-gray-200 dark:border-white/10 px-6 py-8 text-center">
+							<p className="text-sm text-muted-foreground">No shift schedule configured.</p>
+						</div>
+					)}
+					{orderedDays && (
+						<div className="grid grid-cols-7 gap-2">
+							{DISPLAY_DAY_ORDER.map((dayOfWeek) => {
+								const day = orderedDays[dayOfWeek];
+								const isWorking = !!(day?.isWorking && day.startTime && day.endTime);
+								return (
+									<div
+										key={dayOfWeek}
+										className={`rounded-2xl border px-3 py-3 text-center transition-colors ${
+											isWorking
+												? "border-primary/20 bg-primary/5"
+												: "border-gray-200/60 dark:border-white/10 bg-gray-50/40 dark:bg-white/[0.02]"
+										}`}
+									>
+										<div
+											className={`text-[11px] font-semibold uppercase tracking-wider ${
+												isWorking ? "text-primary" : "text-muted-foreground"
+											}`}
+										>
+											{SHIFT_DAY_LABELS_SHORT[dayOfWeek]}
+										</div>
+										<div
+											className={`mt-2 text-sm font-medium ${
+												isWorking ? "text-foreground" : "text-muted-foreground/70"
+											}`}
+										>
+											{isWorking ? day?.startTime : "—"}
+										</div>
+										<div
+											className={`text-sm ${
+												isWorking ? "text-foreground" : "text-muted-foreground/70"
+											}`}
+										>
+											{isWorking ? day?.endTime : "Off"}
+										</div>
+										{isWorking && day?.breakMins ? (
+											<div className="mt-1 text-[10px] text-muted-foreground">
+												{day.breakMins}m break
+											</div>
+										) : null}
+									</div>
+								);
+							})}
+						</div>
+					)}
 				</div>
 			</div>
 		</div>

--- a/app/(dashboard)/dashboard/users/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/page.tsx
@@ -28,7 +28,7 @@ function formatBranch(branch: string | null): string | null {
 	return BRANCH_LABELS[branch] ?? branch;
 }
 
-function formatHireDate(value: Date | null): string | null {
+function formatDate(value: Date | null): string | null {
 	if (!value) return null;
 	return new Intl.DateTimeFormat("en-AU", {
 		year: "numeric",
@@ -97,6 +97,7 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 						<InfoRow label="Display Name" value={user.displayName} />
 						<InfoRow label="Email" value={user.email} />
 						<InfoRow label="Phone" value={user.phone} />
+						<InfoRow label="Birthday" value={formatDate(user.birthday)} />
 					</div>
 				</div>
 
@@ -128,7 +129,7 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 								{user.isActive ? "Active" : "Inactive"}
 							</Badge>
 						</div>
-						<InfoRow label="Date Hired" value={formatHireDate(user.hireDate)} />
+						<InfoRow label="Date Hired" value={formatDate(user.hireDate)} />
 						<InfoRow label="Joined" value={user.createdAt.toLocaleDateString()} />
 					</div>
 				</div>

--- a/app/(dashboard)/dashboard/users/_components/shift-schedule-editor.tsx
+++ b/app/(dashboard)/dashboard/users/_components/shift-schedule-editor.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import {
+	DISPLAY_DAY_ORDER,
+	SHIFT_DAY_LABELS,
+	type ShiftScheduleInput,
+} from "@/lib/validations/user";
+
+const timeInputClass =
+	"w-full rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 px-2.5 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-all disabled:opacity-40 disabled:cursor-not-allowed";
+
+const breakInputClass =
+	"w-16 rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 px-2 py-1.5 text-sm text-foreground text-center focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-all disabled:opacity-40 disabled:cursor-not-allowed";
+
+export const DEFAULT_SHIFT_SCHEDULE: ShiftScheduleInput = {
+	timezone: "Asia/Manila",
+	days: [
+		{ dayOfWeek: 0, isWorking: false, startTime: null, endTime: null, breakMins: 0 },
+		{ dayOfWeek: 1, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
+		{ dayOfWeek: 2, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
+		{ dayOfWeek: 3, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
+		{ dayOfWeek: 4, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
+		{ dayOfWeek: 5, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
+		{ dayOfWeek: 6, isWorking: false, startTime: null, endTime: null, breakMins: 0 },
+	],
+};
+
+interface DayError {
+	startTime?: { message?: string };
+	endTime?: { message?: string };
+	breakMins?: { message?: string };
+}
+
+interface ShiftScheduleEditorProps {
+	value: ShiftScheduleInput;
+	onChange: (next: ShiftScheduleInput) => void;
+	errors?: { days?: DayError[] };
+}
+
+function hhmmToMinutes(value: string): number {
+	const [h, m] = value.split(":").map((n) => Number.parseInt(n, 10));
+	return h * 60 + m;
+}
+
+function formatHours(minutes: number): string {
+	const hours = minutes / 60;
+	return `${hours.toFixed(hours % 1 === 0 ? 0 : 1)}h`;
+}
+
+export function ShiftScheduleEditor({ value, onChange, errors }: ShiftScheduleEditorProps) {
+	function updateDay(dayOfWeek: number, patch: Partial<ShiftScheduleInput["days"][number]>) {
+		onChange({
+			...value,
+			days: value.days.map((day) => (day.dayOfWeek === dayOfWeek ? { ...day, ...patch } : day)),
+		});
+	}
+
+	function applyPreset(preset: "weekdays-9-5" | "weekdays-8-4" | "everyday-9-5" | "clear") {
+		const makeDay = (
+			dayOfWeek: number,
+			isWorking: boolean,
+			startTime: string | null,
+			endTime: string | null,
+			breakMins: number,
+		) => ({ dayOfWeek, isWorking, startTime, endTime, breakMins });
+
+		const patterns: Record<typeof preset, (d: number) => ReturnType<typeof makeDay>> = {
+			"weekdays-9-5": (d) =>
+				d >= 1 && d <= 5
+					? makeDay(d, true, "09:00", "17:00", 60)
+					: makeDay(d, false, null, null, 0),
+			"weekdays-8-4": (d) =>
+				d >= 1 && d <= 5
+					? makeDay(d, true, "08:00", "16:00", 60)
+					: makeDay(d, false, null, null, 0),
+			"everyday-9-5": (d) => makeDay(d, true, "09:00", "17:00", 60),
+			clear: (d) => makeDay(d, false, null, null, 0),
+		};
+
+		const build = patterns[preset];
+		onChange({ ...value, days: [0, 1, 2, 3, 4, 5, 6].map(build) });
+	}
+
+	const totalMins = value.days.reduce((sum, day) => {
+		if (!day.isWorking || !day.startTime || !day.endTime) return sum;
+		return sum + (hhmmToMinutes(day.endTime) - hhmmToMinutes(day.startTime)) - day.breakMins;
+	}, 0);
+	const workingDays = value.days.filter((d) => d.isWorking).length;
+
+	return (
+		<div className="space-y-4">
+			<div className="flex flex-wrap items-center justify-between gap-3 rounded-xl bg-gray-50/60 dark:bg-white/[0.02] border border-gray-200/60 dark:border-white/10 px-4 py-3">
+				<div className="text-sm">
+					<span className="font-semibold text-foreground">{formatHours(totalMins)}</span>
+					<span className="text-muted-foreground"> / week · </span>
+					<span className="text-muted-foreground">
+						{workingDays} working {workingDays === 1 ? "day" : "days"}
+					</span>
+				</div>
+				<div className="flex flex-wrap gap-1.5">
+					<PresetButton onClick={() => applyPreset("weekdays-9-5")}>Mon–Fri 9–5</PresetButton>
+					<PresetButton onClick={() => applyPreset("weekdays-8-4")}>Mon–Fri 8–4</PresetButton>
+					<PresetButton onClick={() => applyPreset("everyday-9-5")}>Every day 9–5</PresetButton>
+					<PresetButton onClick={() => applyPreset("clear")} variant="ghost">
+						Clear all
+					</PresetButton>
+				</div>
+			</div>
+
+			<div className="space-y-1.5">
+				{DISPLAY_DAY_ORDER.map((dayOfWeek) => {
+					const day = value.days.find((d) => d.dayOfWeek === dayOfWeek);
+					if (!day) return null;
+					const dayError = errors?.days?.[value.days.indexOf(day)];
+					const dayMins =
+						day.isWorking && day.startTime && day.endTime
+							? hhmmToMinutes(day.endTime) - hhmmToMinutes(day.startTime) - day.breakMins
+							: 0;
+					return (
+						<div
+							key={dayOfWeek}
+							className={`flex flex-wrap items-center gap-3 rounded-xl border px-4 py-2.5 transition-colors ${
+								day.isWorking
+									? "border-primary/20 bg-primary/[0.03]"
+									: "border-gray-200/60 dark:border-white/10 bg-card"
+							}`}
+						>
+							<label className="flex items-center gap-3 min-w-[8rem] flex-1 cursor-pointer">
+								<input
+									type="checkbox"
+									checked={day.isWorking}
+									onChange={(e) =>
+										updateDay(dayOfWeek, {
+											isWorking: e.target.checked,
+											startTime: e.target.checked ? (day.startTime ?? "09:00") : null,
+											endTime: e.target.checked ? (day.endTime ?? "17:00") : null,
+											breakMins: e.target.checked ? day.breakMins : 0,
+										})
+									}
+									className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+								/>
+								<span
+									className={`text-sm font-medium ${
+										day.isWorking ? "text-foreground" : "text-muted-foreground"
+									}`}
+								>
+									{SHIFT_DAY_LABELS[dayOfWeek]}
+								</span>
+							</label>
+
+							{day.isWorking ? (
+								<div className="flex items-center gap-2 flex-wrap">
+									<div className="flex items-center gap-1.5">
+										<input
+											type="time"
+											aria-label={`${SHIFT_DAY_LABELS[dayOfWeek]} start time`}
+											value={day.startTime ?? ""}
+											onChange={(e) => updateDay(dayOfWeek, { startTime: e.target.value || null })}
+											className={timeInputClass}
+										/>
+										<span className="text-xs text-muted-foreground">to</span>
+										<input
+											type="time"
+											aria-label={`${SHIFT_DAY_LABELS[dayOfWeek]} end time`}
+											value={day.endTime ?? ""}
+											onChange={(e) => updateDay(dayOfWeek, { endTime: e.target.value || null })}
+											className={timeInputClass}
+										/>
+									</div>
+									<div className="flex items-center gap-1.5">
+										<input
+											type="number"
+											min={0}
+											max={720}
+											aria-label={`${SHIFT_DAY_LABELS[dayOfWeek]} break minutes`}
+											value={day.breakMins}
+											onChange={(e) =>
+												updateDay(dayOfWeek, {
+													breakMins: Number.parseInt(e.target.value, 10) || 0,
+												})
+											}
+											className={breakInputClass}
+										/>
+										<span className="text-xs text-muted-foreground">min break</span>
+									</div>
+									{dayMins > 0 && (
+										<span className="text-xs font-medium text-primary ml-auto">
+											{formatHours(dayMins)}
+										</span>
+									)}
+								</div>
+							) : (
+								<span className="text-sm text-muted-foreground italic ml-auto">Off</span>
+							)}
+
+							{(dayError?.startTime?.message || dayError?.endTime?.message) && (
+								<p className="w-full text-xs text-destructive pl-7">
+									{dayError?.endTime?.message ?? dayError?.startTime?.message}
+								</p>
+							)}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+function PresetButton({
+	children,
+	onClick,
+	variant = "default",
+}: {
+	children: React.ReactNode;
+	onClick: () => void;
+	variant?: "default" | "ghost";
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={
+				variant === "ghost"
+					? "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium text-muted-foreground hover:text-destructive transition-colors"
+					: "inline-flex items-center rounded-full border border-gray-200 dark:border-white/10 bg-card px-3 py-1 text-xs font-medium text-foreground hover:bg-primary/10 hover:border-primary/30 hover:text-primary transition-colors"
+			}
+		>
+			{children}
+		</button>
+	);
+}

--- a/app/(dashboard)/dashboard/users/_components/shift-schedule-editor.tsx
+++ b/app/(dashboard)/dashboard/users/_components/shift-schedule-editor.tsx
@@ -5,6 +5,7 @@ import {
 	SHIFT_DAY_LABELS,
 	type ShiftScheduleFieldErrors,
 	type ShiftScheduleInput,
+	TIMEZONE_OPTIONS,
 } from "@/lib/validations/user";
 
 const timeInputClass =
@@ -15,30 +16,6 @@ const breakInputClass =
 
 const timezoneSelectClass =
 	"rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-all";
-
-export const TIMEZONE_OPTIONS = [
-	"Asia/Manila",
-	"Australia/Perth",
-	"Australia/Sydney",
-	"Australia/Melbourne",
-	"Australia/Brisbane",
-	"Australia/Adelaide",
-	"Pacific/Auckland",
-	"UTC",
-] as const;
-
-export const DEFAULT_SHIFT_SCHEDULE: ShiftScheduleInput = {
-	timezone: "Asia/Manila",
-	days: [
-		{ dayOfWeek: 0, isWorking: false, startTime: null, endTime: null, breakMins: 0 },
-		{ dayOfWeek: 1, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
-		{ dayOfWeek: 2, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
-		{ dayOfWeek: 3, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
-		{ dayOfWeek: 4, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
-		{ dayOfWeek: 5, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
-		{ dayOfWeek: 6, isWorking: false, startTime: null, endTime: null, breakMins: 0 },
-	],
-};
 
 interface ShiftScheduleEditorProps {
 	value: ShiftScheduleInput;
@@ -140,9 +117,10 @@ export function ShiftScheduleEditor({ value, onChange, errors }: ShiftScheduleEd
 
 			<div className="space-y-1.5">
 				{DISPLAY_DAY_ORDER.map((dayOfWeek) => {
-					const day = value.days.find((d) => d.dayOfWeek === dayOfWeek);
+					const dayIndex = value.days.findIndex((d) => d.dayOfWeek === dayOfWeek);
+					const day = value.days[dayIndex];
 					if (!day) return null;
-					const dayError = errors?.days?.[value.days.indexOf(day)];
+					const dayError = errors?.days?.[dayIndex];
 					const dayMins =
 						day.isWorking && day.startTime && day.endTime
 							? hhmmToMinutes(day.endTime) - hhmmToMinutes(day.startTime) - day.breakMins

--- a/app/(dashboard)/dashboard/users/_components/shift-schedule-editor.tsx
+++ b/app/(dashboard)/dashboard/users/_components/shift-schedule-editor.tsx
@@ -3,6 +3,7 @@
 import {
 	DISPLAY_DAY_ORDER,
 	SHIFT_DAY_LABELS,
+	type ShiftScheduleFieldErrors,
 	type ShiftScheduleInput,
 } from "@/lib/validations/user";
 
@@ -39,16 +40,10 @@ export const DEFAULT_SHIFT_SCHEDULE: ShiftScheduleInput = {
 	],
 };
 
-interface DayError {
-	startTime?: { message?: string };
-	endTime?: { message?: string };
-	breakMins?: { message?: string };
-}
-
 interface ShiftScheduleEditorProps {
 	value: ShiftScheduleInput;
 	onChange: (next: ShiftScheduleInput) => void;
-	errors?: { days?: DayError[] };
+	errors?: ShiftScheduleFieldErrors;
 }
 
 function hhmmToMinutes(value: string): number {

--- a/app/(dashboard)/dashboard/users/_components/shift-schedule-editor.tsx
+++ b/app/(dashboard)/dashboard/users/_components/shift-schedule-editor.tsx
@@ -12,6 +12,20 @@ const timeInputClass =
 const breakInputClass =
 	"w-16 rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 px-2 py-1.5 text-sm text-foreground text-center focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-all disabled:opacity-40 disabled:cursor-not-allowed";
 
+const timezoneSelectClass =
+	"rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-all";
+
+export const TIMEZONE_OPTIONS = [
+	"Asia/Manila",
+	"Australia/Perth",
+	"Australia/Sydney",
+	"Australia/Melbourne",
+	"Australia/Brisbane",
+	"Australia/Adelaide",
+	"Pacific/Auckland",
+	"UTC",
+] as const;
+
 export const DEFAULT_SHIFT_SCHEDULE: ShiftScheduleInput = {
 	timezone: "Asia/Manila",
 	days: [
@@ -90,12 +104,34 @@ export function ShiftScheduleEditor({ value, onChange, errors }: ShiftScheduleEd
 	return (
 		<div className="space-y-4">
 			<div className="flex flex-wrap items-center justify-between gap-3 rounded-xl bg-gray-50/60 dark:bg-white/[0.02] border border-gray-200/60 dark:border-white/10 px-4 py-3">
-				<div className="text-sm">
-					<span className="font-semibold text-foreground">{formatHours(totalMins)}</span>
-					<span className="text-muted-foreground"> / week · </span>
-					<span className="text-muted-foreground">
-						{workingDays} working {workingDays === 1 ? "day" : "days"}
-					</span>
+				<div className="flex flex-wrap items-center gap-3 text-sm">
+					<div>
+						<span className="font-semibold text-foreground">{formatHours(totalMins)}</span>
+						<span className="text-muted-foreground"> / week · </span>
+						<span className="text-muted-foreground">
+							{workingDays} working {workingDays === 1 ? "day" : "days"}
+						</span>
+					</div>
+					<label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+						<span>Timezone</span>
+						<select
+							aria-label="Shift schedule timezone"
+							value={value.timezone}
+							onChange={(e) => onChange({ ...value, timezone: e.target.value })}
+							className={timezoneSelectClass}
+						>
+							{TIMEZONE_OPTIONS.includes(
+								value.timezone as (typeof TIMEZONE_OPTIONS)[number],
+							) ? null : (
+								<option value={value.timezone}>{value.timezone}</option>
+							)}
+							{TIMEZONE_OPTIONS.map((tz) => (
+								<option key={tz} value={tz}>
+									{tz}
+								</option>
+							))}
+						</select>
+					</label>
 				</div>
 				<div className="flex flex-wrap gap-1.5">
 					<PresetButton onClick={() => applyPreset("weekdays-9-5")}>Mon–Fri 9–5</PresetButton>

--- a/app/(dashboard)/dashboard/users/_components/shift-schedule-editor.tsx
+++ b/app/(dashboard)/dashboard/users/_components/shift-schedule-editor.tsx
@@ -193,9 +193,13 @@ export function ShiftScheduleEditor({ value, onChange, errors }: ShiftScheduleEd
 								<span className="text-sm text-muted-foreground italic ml-auto">Off</span>
 							)}
 
-							{(dayError?.startTime?.message || dayError?.endTime?.message) && (
+							{(dayError?.startTime?.message ||
+								dayError?.endTime?.message ||
+								dayError?.breakMins?.message) && (
 								<p className="w-full text-xs text-destructive pl-7">
-									{dayError?.endTime?.message ?? dayError?.startTime?.message}
+									{dayError?.breakMins?.message ??
+										dayError?.endTime?.message ??
+										dayError?.startTime?.message}
 								</p>
 							)}
 						</div>

--- a/app/(dashboard)/dashboard/users/_components/user-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-form.tsx
@@ -27,6 +27,24 @@ function toDateInputValue(value: Date | string | null | undefined): string {
 	return `${year}-${month}-${day}`;
 }
 
+function parseDateInputValue(value: string): Date | null {
+	if (!value) return null;
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+	if (!match) return null;
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const date = new Date(Date.UTC(year, month - 1, day));
+	if (
+		date.getUTCFullYear() !== year ||
+		date.getUTCMonth() !== month - 1 ||
+		date.getUTCDate() !== day
+	) {
+		return null;
+	}
+	return date;
+}
+
 const inputClass =
 	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
 
@@ -340,9 +358,7 @@ export function UserForm({
 									id="hireDate"
 									type="date"
 									value={toDateInputValue(hireDateValue)}
-									onChange={(e) =>
-										setValue("hireDate", e.target.value ? new Date(e.target.value) : null)
-									}
+									onChange={(e) => setValue("hireDate", parseDateInputValue(e.target.value))}
 									className={inputClass}
 								/>
 							</div>
@@ -357,9 +373,7 @@ export function UserForm({
 									id="birthday"
 									type="date"
 									value={toDateInputValue(birthdayValue)}
-									onChange={(e) =>
-										setValue("birthday", e.target.value ? new Date(e.target.value) : null)
-									}
+									onChange={(e) => setValue("birthday", parseDateInputValue(e.target.value))}
 									className={inputClass}
 								/>
 							</div>
@@ -384,7 +398,12 @@ export function UserForm({
 								) : (
 									<button
 										type="button"
-										onClick={() => setValue("shiftSchedule", DEFAULT_SHIFT_SCHEDULE)}
+										onClick={() => {
+											const branch = watch("branch");
+											const timezone =
+												branch === "PERTH" ? "Australia/Perth" : DEFAULT_SHIFT_SCHEDULE.timezone;
+											setValue("shiftSchedule", { ...DEFAULT_SHIFT_SCHEDULE, timezone });
+										}}
 										className="text-sm font-medium text-primary hover:text-primary/80 transition-colors"
 									>
 										Add schedule

--- a/app/(dashboard)/dashboard/users/_components/user-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-form.tsx
@@ -12,12 +12,13 @@ import { parseDateInputValue, toDateInputValue } from "@/lib/date-input";
 import {
 	type CreateUserInput,
 	createUserSchema,
+	DEFAULT_SHIFT_SCHEDULE,
 	type ShiftScheduleFieldErrors,
 	type ShiftScheduleInput,
 	type UpdateUserInput,
 	updateUserSchema,
 } from "@/lib/validations/user";
-import { DEFAULT_SHIFT_SCHEDULE, ShiftScheduleEditor } from "./shift-schedule-editor";
+import { ShiftScheduleEditor } from "./shift-schedule-editor";
 
 const inputClass =
 	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";

--- a/app/(dashboard)/dashboard/users/_components/user-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-form.tsx
@@ -79,6 +79,7 @@ export function UserForm({
 	const roleValue = watch("role");
 	const isActiveValue = watch("isActive");
 	const hireDateValue = watch("hireDate");
+	const birthdayValue = watch("birthday");
 	const shiftScheduleValue = watch("shiftSchedule");
 
 	const availableRoles =
@@ -327,22 +328,41 @@ export function UserForm({
 							</select>
 						</div>
 
-						<div>
-							<label
-								htmlFor="hireDate"
-								className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
-							>
-								Date Hired
-							</label>
-							<input
-								id="hireDate"
-								type="date"
-								value={toDateInputValue(hireDateValue)}
-								onChange={(e) =>
-									setValue("hireDate", e.target.value ? new Date(e.target.value) : null)
-								}
-								className={inputClass}
-							/>
+						<div className="grid grid-cols-2 gap-5">
+							<div>
+								<label
+									htmlFor="hireDate"
+									className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+								>
+									Date Hired
+								</label>
+								<input
+									id="hireDate"
+									type="date"
+									value={toDateInputValue(hireDateValue)}
+									onChange={(e) =>
+										setValue("hireDate", e.target.value ? new Date(e.target.value) : null)
+									}
+									className={inputClass}
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="birthday"
+									className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+								>
+									Birthday
+								</label>
+								<input
+									id="birthday"
+									type="date"
+									value={toDateInputValue(birthdayValue)}
+									onChange={(e) =>
+										setValue("birthday", e.target.value ? new Date(e.target.value) : null)
+									}
+									className={inputClass}
+								/>
+							</div>
 						</div>
 
 						<div className="space-y-3">

--- a/app/(dashboard)/dashboard/users/_components/user-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-form.tsx
@@ -8,42 +8,16 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { createUserAction, updateUserAction } from "@/lib/actions/user-actions";
+import { parseDateInputValue, toDateInputValue } from "@/lib/date-input";
 import {
 	type CreateUserInput,
 	createUserSchema,
+	type ShiftScheduleFieldErrors,
 	type ShiftScheduleInput,
 	type UpdateUserInput,
 	updateUserSchema,
 } from "@/lib/validations/user";
 import { DEFAULT_SHIFT_SCHEDULE, ShiftScheduleEditor } from "./shift-schedule-editor";
-
-function toDateInputValue(value: Date | string | null | undefined): string {
-	if (!value) return "";
-	const date = value instanceof Date ? value : new Date(value);
-	if (Number.isNaN(date.getTime())) return "";
-	const year = date.getUTCFullYear();
-	const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-	const day = String(date.getUTCDate()).padStart(2, "0");
-	return `${year}-${month}-${day}`;
-}
-
-function parseDateInputValue(value: string): Date | null {
-	if (!value) return null;
-	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-	if (!match) return null;
-	const year = Number(match[1]);
-	const month = Number(match[2]);
-	const day = Number(match[3]);
-	const date = new Date(Date.UTC(year, month - 1, day));
-	if (
-		date.getUTCFullYear() !== year ||
-		date.getUTCMonth() !== month - 1 ||
-		date.getUTCDate() !== day
-	) {
-		return null;
-	}
-	return date;
-}
 
 const inputClass =
 	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
@@ -83,6 +57,7 @@ export function UserForm({
 		handleSubmit,
 		setValue,
 		watch,
+		getValues,
 		formState: { errors },
 	} = useForm<CreateUserInput>({
 		// biome-ignore lint/suspicious/noExplicitAny: schemas diverge on optional fields; resolver union narrows at runtime
@@ -399,7 +374,7 @@ export function UserForm({
 									<button
 										type="button"
 										onClick={() => {
-											const branch = watch("branch");
+											const branch = getValues("branch");
 											const timezone =
 												branch === "PERTH" ? "Australia/Perth" : DEFAULT_SHIFT_SCHEDULE.timezone;
 											setValue("shiftSchedule", { ...DEFAULT_SHIFT_SCHEDULE, timezone });
@@ -414,16 +389,7 @@ export function UserForm({
 								<ShiftScheduleEditor
 									value={shiftScheduleValue}
 									onChange={(next: ShiftScheduleInput) => setValue("shiftSchedule", next)}
-									errors={
-										errors.shiftSchedule as
-											| {
-													days?: Array<{
-														startTime?: { message?: string };
-														endTime?: { message?: string };
-													}>;
-											  }
-											| undefined
-									}
+									errors={errors.shiftSchedule as ShiftScheduleFieldErrors | undefined}
 								/>
 							)}
 						</div>

--- a/app/(dashboard)/dashboard/users/_components/user-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-form.tsx
@@ -11,9 +11,21 @@ import { createUserAction, updateUserAction } from "@/lib/actions/user-actions";
 import {
 	type CreateUserInput,
 	createUserSchema,
+	type ShiftScheduleInput,
 	type UpdateUserInput,
 	updateUserSchema,
 } from "@/lib/validations/user";
+import { DEFAULT_SHIFT_SCHEDULE, ShiftScheduleEditor } from "./shift-schedule-editor";
+
+function toDateInputValue(value: Date | string | null | undefined): string {
+	if (!value) return "";
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) return "";
+	const year = date.getUTCFullYear();
+	const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+	const day = String(date.getUTCDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
 
 const inputClass =
 	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
@@ -66,6 +78,8 @@ export function UserForm({
 
 	const roleValue = watch("role");
 	const isActiveValue = watch("isActive");
+	const hireDateValue = watch("hireDate");
+	const shiftScheduleValue = watch("shiftSchedule");
 
 	const availableRoles =
 		currentUserRole === "SUPERADMIN" ? (["STAFF", "ADMIN"] as const) : (["STAFF"] as const);
@@ -311,6 +325,68 @@ export function UserForm({
 								<option value="ISO">ISO</option>
 								<option value="PERTH">Perth</option>
 							</select>
+						</div>
+
+						<div>
+							<label
+								htmlFor="hireDate"
+								className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+							>
+								Date Hired
+							</label>
+							<input
+								id="hireDate"
+								type="date"
+								value={toDateInputValue(hireDateValue)}
+								onChange={(e) =>
+									setValue("hireDate", e.target.value ? new Date(e.target.value) : null)
+								}
+								className={inputClass}
+							/>
+						</div>
+
+						<div className="space-y-3">
+							<div className="flex items-center justify-between gap-3 px-1">
+								<div>
+									<div className="text-sm font-medium text-foreground/70">Shift Schedule</div>
+									<p className="text-xs text-muted-foreground">
+										Weekly working hours. Leave empty to clear.
+									</p>
+								</div>
+								{shiftScheduleValue ? (
+									<button
+										type="button"
+										onClick={() => setValue("shiftSchedule", null)}
+										className="text-sm font-medium text-muted-foreground hover:text-destructive transition-colors"
+									>
+										Clear
+									</button>
+								) : (
+									<button
+										type="button"
+										onClick={() => setValue("shiftSchedule", DEFAULT_SHIFT_SCHEDULE)}
+										className="text-sm font-medium text-primary hover:text-primary/80 transition-colors"
+									>
+										Add schedule
+									</button>
+								)}
+							</div>
+							{shiftScheduleValue && (
+								<ShiftScheduleEditor
+									value={shiftScheduleValue}
+									onChange={(next: ShiftScheduleInput) => setValue("shiftSchedule", next)}
+									errors={
+										errors.shiftSchedule as
+											| {
+													days?: Array<{
+														startTime?: { message?: string };
+														endTime?: { message?: string };
+													}>;
+											  }
+											| undefined
+									}
+								/>
+							)}
 						</div>
 
 						<div className="flex items-center gap-2 px-1">

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -45,7 +45,7 @@ async function upsertShiftSchedule(
 			isWorking: day.isWorking,
 			startTime: day.isWorking ? (day.startTime ?? null) : null,
 			endTime: day.isWorking ? (day.endTime ?? null) : null,
-			breakMins: day.breakMins,
+			breakMins: day.isWorking ? day.breakMins : 0,
 		})),
 	});
 }

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -92,6 +92,7 @@ export async function createUserAction(formData: unknown) {
 					departmentId: rest.departmentId ?? null,
 					isActive: rest.isActive,
 					hireDate: rest.hireDate ?? null,
+					birthday: rest.birthday ?? null,
 				},
 			});
 			if (shiftSchedule !== undefined) {
@@ -135,7 +136,7 @@ export async function updateUserAction(userId: string, formData: unknown) {
 			return { success: false as const, error: "Insufficient permissions to assign this role" };
 		}
 
-		const { shiftSchedule, hireDate, ...userFields } = parsed.data;
+		const { shiftSchedule, hireDate, birthday, ...userFields } = parsed.data;
 		const updated = await prisma.$transaction(async (tx) => {
 			const user = await tx.user.update({
 				where: { id: userId },
@@ -143,6 +144,7 @@ export async function updateUserAction(userId: string, formData: unknown) {
 					...userFields,
 					role: roleIsChanging ? (parsed.data.role as Role) : undefined,
 					hireDate: hireDate === undefined ? undefined : (hireDate ?? null),
+					birthday: birthday === undefined ? undefined : (birthday ?? null),
 					name:
 						parsed.data.firstName && parsed.data.lastName
 							? `${parsed.data.firstName} ${parsed.data.lastName}`

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -2,13 +2,53 @@
 
 import { hashPassword } from "better-auth/crypto";
 import { revalidatePath } from "next/cache";
-import type { Role } from "@/app/generated/prisma/client";
+import type { Prisma, Role } from "@/app/generated/prisma/client";
 import { auth } from "@/lib/auth";
 import { requireRole, requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { canAssignRole } from "@/lib/permissions";
 import { adminResetPasswordSchema } from "@/lib/validations/auth";
-import { createUserSchema, updateUserSchema } from "@/lib/validations/user";
+import {
+	createUserSchema,
+	type ShiftScheduleInput,
+	updateUserSchema,
+} from "@/lib/validations/user";
+
+async function upsertShiftSchedule(
+	tx: Prisma.TransactionClient,
+	userId: string,
+	schedule: ShiftScheduleInput | null,
+) {
+	if (schedule === null) {
+		await tx.shiftSchedule.deleteMany({ where: { userId } });
+		return;
+	}
+	const existing = await tx.shiftSchedule.findUnique({ where: { userId } });
+	const scheduleId = existing
+		? (
+				await tx.shiftSchedule.update({
+					where: { userId },
+					data: { timezone: schedule.timezone },
+				})
+			).id
+		: (
+				await tx.shiftSchedule.create({
+					data: { userId, timezone: schedule.timezone },
+				})
+			).id;
+
+	await tx.shiftDay.deleteMany({ where: { scheduleId } });
+	await tx.shiftDay.createMany({
+		data: schedule.days.map((day) => ({
+			scheduleId,
+			dayOfWeek: day.dayOfWeek,
+			isWorking: day.isWorking,
+			startTime: day.isWorking ? (day.startTime ?? null) : null,
+			endTime: day.isWorking ? (day.endTime ?? null) : null,
+			breakMins: day.breakMins,
+		})),
+	});
+}
 
 export async function createUserAction(formData: unknown) {
 	try {
@@ -19,7 +59,7 @@ export async function createUserAction(formData: unknown) {
 			return { success: false as const, error: parsed.error.flatten().fieldErrors };
 		}
 
-		const { role, email, password, firstName, lastName, ...rest } = parsed.data;
+		const { role, email, password, firstName, lastName, shiftSchedule, ...rest } = parsed.data;
 
 		if (!canAssignRole(session.user.role as Role, role as Role)) {
 			return { success: false as const, error: "Insufficient permissions to assign this role" };
@@ -39,17 +79,25 @@ export async function createUserAction(formData: unknown) {
 			return { success: false as const, error: "Failed to create user" };
 		}
 
-		const updated = await prisma.user.update({
-			where: { id: result.user.id },
-			data: {
-				role: role as Role,
-				displayName: rest.displayName,
-				phone: rest.phone,
-				position: rest.position,
-				branch: rest.branch ?? null,
-				departmentId: rest.departmentId ?? null,
-				isActive: rest.isActive,
-			},
+		const userId = result.user.id;
+		const updated = await prisma.$transaction(async (tx) => {
+			const user = await tx.user.update({
+				where: { id: userId },
+				data: {
+					role: role as Role,
+					displayName: rest.displayName,
+					phone: rest.phone,
+					position: rest.position,
+					branch: rest.branch ?? null,
+					departmentId: rest.departmentId ?? null,
+					isActive: rest.isActive,
+					hireDate: rest.hireDate ?? null,
+				},
+			});
+			if (shiftSchedule !== undefined) {
+				await upsertShiftSchedule(tx, userId, shiftSchedule ?? null);
+			}
+			return user;
 		});
 
 		revalidatePath("/dashboard/users");
@@ -87,16 +135,24 @@ export async function updateUserAction(userId: string, formData: unknown) {
 			return { success: false as const, error: "Insufficient permissions to assign this role" };
 		}
 
-		const updated = await prisma.user.update({
-			where: { id: userId },
-			data: {
-				...parsed.data,
-				role: roleIsChanging ? (parsed.data.role as Role) : undefined,
-				name:
-					parsed.data.firstName && parsed.data.lastName
-						? `${parsed.data.firstName} ${parsed.data.lastName}`
-						: undefined,
-			},
+		const { shiftSchedule, hireDate, ...userFields } = parsed.data;
+		const updated = await prisma.$transaction(async (tx) => {
+			const user = await tx.user.update({
+				where: { id: userId },
+				data: {
+					...userFields,
+					role: roleIsChanging ? (parsed.data.role as Role) : undefined,
+					hireDate: hireDate === undefined ? undefined : (hireDate ?? null),
+					name:
+						parsed.data.firstName && parsed.data.lastName
+							? `${parsed.data.firstName} ${parsed.data.lastName}`
+							: undefined,
+				},
+			});
+			if (shiftSchedule !== undefined) {
+				await upsertShiftSchedule(tx, userId, shiftSchedule ?? null);
+			}
+			return user;
 		});
 
 		revalidatePath("/dashboard/users");

--- a/lib/date-input.test.ts
+++ b/lib/date-input.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { parseDateInputValue, toDateInputValue } from "./date-input";
+
+describe("parseDateInputValue", () => {
+	test("parses a valid YYYY-MM-DD string to UTC midnight", () => {
+		const result = parseDateInputValue("2026-04-18");
+		expect(result).not.toBeNull();
+		expect(result?.toISOString()).toBe("2026-04-18T00:00:00.000Z");
+	});
+
+	test.each([
+		["2026-02-29", "Feb 29 in a non-leap year"],
+		["2026-13-01", "month 13"],
+		["2026-00-15", "month 0"],
+		["2026-04-31", "April 31"],
+		["2026-02-30", "Feb 30"],
+	])("rejects out-of-range date %p (%s)", (input) => {
+		expect(parseDateInputValue(input)).toBeNull();
+	});
+
+	test("accepts Feb 29 in a leap year", () => {
+		const result = parseDateInputValue("2024-02-29");
+		expect(result?.toISOString()).toBe("2024-02-29T00:00:00.000Z");
+	});
+
+	test.each([
+		[""],
+		["not-a-date"],
+		["2026/04/18"],
+		["2026-4-18"],
+		["04-18-2026"],
+		["2026-04-18T00:00:00Z"],
+	])("rejects malformed input %p", (input) => {
+		expect(parseDateInputValue(input)).toBeNull();
+	});
+});
+
+describe("toDateInputValue", () => {
+	test("formats a Date as YYYY-MM-DD in UTC", () => {
+		expect(toDateInputValue(new Date("2026-04-18T00:00:00Z"))).toBe("2026-04-18");
+	});
+
+	test("pads single-digit months and days", () => {
+		expect(toDateInputValue(new Date("2026-01-05T00:00:00Z"))).toBe("2026-01-05");
+	});
+
+	test.each([[null], [undefined], [""]])("returns empty string for %p", (input) => {
+		expect(toDateInputValue(input)).toBe("");
+	});
+
+	test("returns empty string for invalid date input", () => {
+		expect(toDateInputValue("not-a-date")).toBe("");
+	});
+
+	test("round-trips with parseDateInputValue", () => {
+		const original = "2026-04-18";
+		const date = parseDateInputValue(original);
+		expect(date).not.toBeNull();
+		expect(toDateInputValue(date)).toBe(original);
+	});
+});

--- a/lib/date-input.ts
+++ b/lib/date-input.ts
@@ -1,0 +1,27 @@
+export function toDateInputValue(value: Date | string | null | undefined): string {
+	if (!value) return "";
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) return "";
+	const year = date.getUTCFullYear();
+	const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+	const day = String(date.getUTCDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+export function parseDateInputValue(value: string): Date | null {
+	if (!value) return null;
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+	if (!match) return null;
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const date = new Date(Date.UTC(year, month - 1, day));
+	if (
+		date.getUTCFullYear() !== year ||
+		date.getUTCMonth() !== month - 1 ||
+		date.getUTCDate() !== day
+	) {
+		return null;
+	}
+	return date;
+}

--- a/lib/validations/user.test.ts
+++ b/lib/validations/user.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { shiftDaySchema, shiftScheduleSchema } from "./user";
+
+const workingDay = (overrides: Partial<Record<string, unknown>> = {}) => ({
+	dayOfWeek: 1,
+	isWorking: true,
+	startTime: "09:00",
+	endTime: "17:00",
+	breakMins: 60,
+	...overrides,
+});
+
+describe("shiftDaySchema", () => {
+	test("accepts a standard working day", () => {
+		expect(shiftDaySchema.safeParse(workingDay()).success).toBe(true);
+	});
+
+	test("accepts an off day with null times", () => {
+		const result = shiftDaySchema.safeParse({
+			dayOfWeek: 0,
+			isWorking: false,
+			startTime: null,
+			endTime: null,
+			breakMins: 0,
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("requires startTime when isWorking", () => {
+		const result = shiftDaySchema.safeParse(workingDay({ startTime: null }));
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const paths = result.error.issues.map((i) => i.path.join("."));
+			expect(paths).toContain("startTime");
+		}
+	});
+
+	test("requires endTime when isWorking", () => {
+		const result = shiftDaySchema.safeParse(workingDay({ endTime: null }));
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const paths = result.error.issues.map((i) => i.path.join("."));
+			expect(paths).toContain("endTime");
+		}
+	});
+
+	test("rejects end time before start time", () => {
+		const result = shiftDaySchema.safeParse(workingDay({ startTime: "17:00", endTime: "09:00" }));
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues.some((i) => i.message.includes("after start time"))).toBe(true);
+		}
+	});
+
+	test("rejects end time equal to start time", () => {
+		const result = shiftDaySchema.safeParse(workingDay({ startTime: "09:00", endTime: "09:00" }));
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects breaks greater than or equal to the shift duration", () => {
+		const result = shiftDaySchema.safeParse(
+			workingDay({ startTime: "09:00", endTime: "10:00", breakMins: 120 }),
+		);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const paths = result.error.issues.map((i) => i.path.join("."));
+			expect(paths).toContain("breakMins");
+		}
+	});
+
+	test("rejects breaks equal to the shift duration", () => {
+		const result = shiftDaySchema.safeParse(
+			workingDay({ startTime: "09:00", endTime: "10:00", breakMins: 60 }),
+		);
+		expect(result.success).toBe(false);
+	});
+
+	test("accepts a break shorter than the shift duration", () => {
+		const result = shiftDaySchema.safeParse(
+			workingDay({ startTime: "09:00", endTime: "12:00", breakMins: 30 }),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	test.each([
+		["9:00"],
+		["24:00"],
+		["09:60"],
+		["morning"],
+		[""],
+	])("rejects invalid HH:mm %p", (bad) => {
+		const result = shiftDaySchema.safeParse(workingDay({ startTime: bad }));
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("shiftScheduleSchema", () => {
+	const fullWeek = Array.from({ length: 7 }, (_, dayOfWeek) => ({
+		dayOfWeek,
+		isWorking: dayOfWeek >= 1 && dayOfWeek <= 5,
+		startTime: dayOfWeek >= 1 && dayOfWeek <= 5 ? "09:00" : null,
+		endTime: dayOfWeek >= 1 && dayOfWeek <= 5 ? "17:00" : null,
+		breakMins: dayOfWeek >= 1 && dayOfWeek <= 5 ? 60 : 0,
+	}));
+
+	test("accepts a full week of 7 unique days", () => {
+		const result = shiftScheduleSchema.safeParse({ timezone: "Asia/Manila", days: fullWeek });
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects fewer than 7 days", () => {
+		const result = shiftScheduleSchema.safeParse({
+			timezone: "Asia/Manila",
+			days: fullWeek.slice(0, 6),
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects duplicate dayOfWeek values", () => {
+		const withDupe = [...fullWeek.slice(0, 6), { ...fullWeek[5], dayOfWeek: 0 }];
+		const result = shiftScheduleSchema.safeParse({ timezone: "Asia/Manila", days: withDupe });
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects an invalid IANA timezone", () => {
+		const result = shiftScheduleSchema.safeParse({ timezone: "Not/AZone", days: fullWeek });
+		expect(result.success).toBe(false);
+	});
+
+	test("accepts another valid IANA timezone", () => {
+		const result = shiftScheduleSchema.safeParse({ timezone: "Australia/Perth", days: fullWeek });
+		expect(result.success).toBe(true);
+	});
+});

--- a/lib/validations/user.ts
+++ b/lib/validations/user.ts
@@ -108,6 +108,30 @@ export interface ShiftScheduleFieldErrors {
 	days?: ShiftDayFieldErrors[];
 }
 
+export const TIMEZONE_OPTIONS = [
+	"Asia/Manila",
+	"Australia/Perth",
+	"Australia/Sydney",
+	"Australia/Melbourne",
+	"Australia/Brisbane",
+	"Australia/Adelaide",
+	"Pacific/Auckland",
+	"UTC",
+] as const;
+
+export const DEFAULT_SHIFT_SCHEDULE: z.infer<typeof shiftScheduleSchema> = {
+	timezone: "Asia/Manila",
+	days: [
+		{ dayOfWeek: 0, isWorking: false, startTime: null, endTime: null, breakMins: 0 },
+		{ dayOfWeek: 1, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
+		{ dayOfWeek: 2, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
+		{ dayOfWeek: 3, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
+		{ dayOfWeek: 4, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
+		{ dayOfWeek: 5, isWorking: true, startTime: "09:00", endTime: "17:00", breakMins: 60 },
+		{ dayOfWeek: 6, isWorking: false, startTime: null, endTime: null, breakMins: 0 },
+	],
+};
+
 export const createUserSchema = z.object({
 	email: z.string().email("Invalid email address"),
 	password: z.string().min(8, "Password must be at least 8 characters"),

--- a/lib/validations/user.ts
+++ b/lib/validations/user.ts
@@ -47,6 +47,19 @@ export const shiftDaySchema = z
 				path: ["endTime"],
 				message: "End time must be after start time",
 			});
+			return;
+		}
+		if (day.startTime && day.endTime) {
+			const [sh, sm] = day.startTime.split(":").map((n) => Number.parseInt(n, 10));
+			const [eh, em] = day.endTime.split(":").map((n) => Number.parseInt(n, 10));
+			const durationMins = eh * 60 + em - (sh * 60 + sm);
+			if (day.breakMins >= durationMins) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ["breakMins"],
+					message: "Break must be shorter than the shift duration",
+				});
+			}
 		}
 	});
 

--- a/lib/validations/user.ts
+++ b/lib/validations/user.ts
@@ -2,6 +2,22 @@ import { z } from "zod";
 
 const HHMM_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
 
+const SUPPORTED_TIMEZONES: ReadonlySet<string> = (() => {
+	const supported =
+		typeof Intl.supportedValuesOf === "function" ? Intl.supportedValuesOf("timeZone") : [];
+	return new Set(supported.length > 0 ? supported : ["UTC"]);
+})();
+
+function isValidTimezone(tz: string): boolean {
+	if (SUPPORTED_TIMEZONES.has(tz)) return true;
+	try {
+		new Intl.DateTimeFormat("en-US", { timeZone: tz });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export const SHIFT_DAY_LABELS = [
 	"Sunday",
 	"Monday",
@@ -64,7 +80,11 @@ export const shiftDaySchema = z
 	});
 
 export const shiftScheduleSchema = z.object({
-	timezone: z.string().min(1).default("Asia/Manila"),
+	timezone: z
+		.string()
+		.min(1)
+		.default("Asia/Manila")
+		.refine(isValidTimezone, { message: "Invalid IANA timezone" }),
 	days: z
 		.array(shiftDaySchema)
 		.length(7, "Schedule must have one entry per weekday")
@@ -76,6 +96,17 @@ export const shiftScheduleSchema = z.object({
 			{ message: "Schedule must cover days 0-6 exactly once" },
 		),
 });
+
+export interface ShiftDayFieldErrors {
+	startTime?: { message?: string };
+	endTime?: { message?: string };
+	breakMins?: { message?: string };
+}
+
+export interface ShiftScheduleFieldErrors {
+	timezone?: { message?: string };
+	days?: ShiftDayFieldErrors[];
+}
 
 export const createUserSchema = z.object({
 	email: z.string().email("Invalid email address"),

--- a/lib/validations/user.ts
+++ b/lib/validations/user.ts
@@ -77,6 +77,7 @@ export const createUserSchema = z.object({
 	departmentId: z.string().nullable().optional(),
 	isActive: z.boolean().default(true),
 	hireDate: z.coerce.date().nullable().optional(),
+	birthday: z.coerce.date().nullable().optional(),
 	shiftSchedule: shiftScheduleSchema.nullable().optional(),
 });
 

--- a/lib/validations/user.ts
+++ b/lib/validations/user.ts
@@ -1,5 +1,69 @@
 import { z } from "zod";
 
+const HHMM_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export const SHIFT_DAY_LABELS = [
+	"Sunday",
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+] as const;
+
+export const SHIFT_DAY_LABELS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+// Monday-first display order. DB still stores 0=Sun..6=Sat; this is display-only.
+export const DISPLAY_DAY_ORDER = [1, 2, 3, 4, 5, 6, 0] as const;
+
+export const shiftDaySchema = z
+	.object({
+		dayOfWeek: z.number().int().min(0).max(6),
+		isWorking: z.boolean(),
+		startTime: z.string().regex(HHMM_PATTERN, "Use 24h HH:mm format").nullable().optional(),
+		endTime: z.string().regex(HHMM_PATTERN, "Use 24h HH:mm format").nullable().optional(),
+		breakMins: z.number().int().min(0).max(720).default(0),
+	})
+	.superRefine((day, ctx) => {
+		if (!day.isWorking) return;
+		if (!day.startTime) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["startTime"],
+				message: "Start time required for working day",
+			});
+		}
+		if (!day.endTime) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["endTime"],
+				message: "End time required for working day",
+			});
+		}
+		if (day.startTime && day.endTime && day.startTime >= day.endTime) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["endTime"],
+				message: "End time must be after start time",
+			});
+		}
+	});
+
+export const shiftScheduleSchema = z.object({
+	timezone: z.string().min(1).default("Asia/Manila"),
+	days: z
+		.array(shiftDaySchema)
+		.length(7, "Schedule must have one entry per weekday")
+		.refine(
+			(days) => {
+				const seen = new Set(days.map((d) => d.dayOfWeek));
+				return seen.size === 7 && [0, 1, 2, 3, 4, 5, 6].every((d) => seen.has(d));
+			},
+			{ message: "Schedule must cover days 0-6 exactly once" },
+		),
+});
+
 export const createUserSchema = z.object({
 	email: z.string().email("Invalid email address"),
 	password: z.string().min(8, "Password must be at least 8 characters"),
@@ -12,9 +76,13 @@ export const createUserSchema = z.object({
 	role: z.enum(["STAFF", "ADMIN", "SUPERADMIN"]),
 	departmentId: z.string().nullable().optional(),
 	isActive: z.boolean().default(true),
+	hireDate: z.coerce.date().nullable().optional(),
+	shiftSchedule: shiftScheduleSchema.nullable().optional(),
 });
 
 export const updateUserSchema = createUserSchema.omit({ email: true, password: true }).partial();
 
 export type CreateUserInput = z.infer<typeof createUserSchema>;
 export type UpdateUserInput = z.infer<typeof updateUserSchema>;
+export type ShiftScheduleInput = z.infer<typeof shiftScheduleSchema>;
+export type ShiftDayInput = z.infer<typeof shiftDaySchema>;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model User {
   isActive      Boolean   @default(true) @map("is_active")
   departmentId  String?   @map("department_id")
   hireDate      DateTime? @map("hire_date") @db.Date
+  birthday      DateTime? @db.Date
   createdAt     DateTime  @default(now()) @map("created_at")
   updatedAt     DateTime  @updatedAt @map("updated_at")
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,7 +43,7 @@ model User {
   isActive      Boolean   @default(true) @map("is_active")
   departmentId  String?   @map("department_id")
   hireDate      DateTime? @map("hire_date") @db.Date
-  birthday      DateTime? @db.Date
+  birthday      DateTime? @map("birthday") @db.Date
   createdAt     DateTime  @default(now()) @map("created_at")
   updatedAt     DateTime  @updatedAt @map("updated_at")
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,23 +27,24 @@ enum NotificationType {
 }
 
 model User {
-  id            String   @id @default(cuid())
+  id            String    @id @default(cuid())
   name          String?
-  email         String   @unique
-  emailVerified Boolean  @default(false) @map("email_verified")
+  email         String    @unique
+  emailVerified Boolean   @default(false) @map("email_verified")
   image         String?
-  firstName     String   @map("first_name")
-  lastName      String   @map("last_name")
-  displayName   String?  @map("display_name")
+  firstName     String    @map("first_name")
+  lastName      String    @map("last_name")
+  displayName   String?   @map("display_name")
   phone         String?
   position      String?
   avatar        String?
-  role          Role     @default(STAFF)
-  branch        Branch?  @map("branch")
-  isActive      Boolean  @default(true) @map("is_active")
-  departmentId  String?  @map("department_id")
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  role          Role      @default(STAFF)
+  branch        Branch?   @map("branch")
+  isActive      Boolean   @default(true) @map("is_active")
+  departmentId  String?   @map("department_id")
+  hireDate      DateTime? @map("hire_date") @db.Date
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
 
   department           Department?       @relation(fields: [departmentId], references: [id])
   sessions             Session[]
@@ -53,8 +54,37 @@ model User {
   notifications        Notification[]
   cardReactions        CardReaction[]
   cardComments         CardComment[]
+  shiftSchedule        ShiftSchedule?
 
   @@map("users")
+}
+
+model ShiftSchedule {
+  id        String   @id @default(cuid())
+  userId    String   @unique @map("user_id")
+  timezone  String   @default("Asia/Manila")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  user User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  days ShiftDay[]
+
+  @@map("shift_schedules")
+}
+
+model ShiftDay {
+  id         String  @id @default(cuid())
+  scheduleId String  @map("schedule_id")
+  dayOfWeek  Int     @map("day_of_week")
+  isWorking  Boolean @default(true) @map("is_working")
+  startTime  String? @map("start_time")
+  endTime    String? @map("end_time")
+  breakMins  Int     @default(0) @map("break_mins")
+
+  schedule ShiftSchedule @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
+
+  @@unique([scheduleId, dayOfWeek])
+  @@map("shift_days")
 }
 
 model Session {


### PR DESCRIPTION
Closes #58.

## Summary

- Add **Date Hired** (nullable `DATE`) to staff records.
- Add a **structured shift schedule**: one `ShiftSchedule` per user (1:1, optional) with seven `ShiftDay` rows (one per weekday) storing `isWorking`, `startTime`/`endTime` (`HH:mm`, 24h), and `breakMins`.
- Redesign the schedule UI on the user form and detail page — per feedback the original was hard to read.

## Data model

```
User.hireDate                DateTime? @db.Date
ShiftSchedule (1:1 user)     timezone, days[]
ShiftDay (unique per day)    dayOfWeek 0-6, isWorking, startTime?, endTime?, breakMins
```

Schema pushed locally via `bunx prisma db push`. On deploy this becomes a `prisma migrate deploy` — no manual migration required since the changes are all additive (new nullable column, new tables).

## Server actions

`upsertShiftSchedule(tx, userId, schedule)` is transactional and has explicit semantics:
- `undefined` → leave schedule alone
- `null` → delete
- object → replace all seven days

## UI

**Editor** (`/dashboard/users/:id/edit`):
- Live "40h / week · 5 working days" summary bar.
- Preset buttons: `Mon–Fri 9–5`, `Mon–Fri 8–4`, `Every day 9–5`, `Clear all` — one click replaces the whole week.
- Monday-first row ordering (DB still stores 0=Sun..6=Sat; display-only).
- Off days collapse to just a toggle + "Off" instead of showing disabled inputs.
- Working days render inline: `[time] to [time]  [60] min break  →  8h`.

**Detail page**:
- Clock-icon header with weekly total hours + working-day count.
- 7-column strip (Mon → Sun), each day a small card with start/end stacked. Working days tinted with primary; off days muted.
- Dashed empty-state when no schedule is set.

## Test plan

- [ ] Edit a user with no existing schedule → click `Add schedule` → preset `Mon–Fri 9–5` → save → detail page shows the weekly strip and 40h total.
- [ ] Edit the same user → `Clear all` → save → `ShiftSchedule` row removed, detail page shows "No shift schedule configured."
- [ ] Create a new user with a hire date and a schedule in one go.
- [ ] Try setting end time before start time → inline validation error appears, save blocked.
- [ ] Leave hire date blank → saves successfully, detail page shows "—".