### PR TITLE
feat(users): soft-delete users via deletedAt (closes #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ env.ts                             # Typed env via @t3-oss/env-nextjs
 - ADMIN can manage users, departments, and access Admin Settings
 - All authenticated users can send and view recognition cards
 - STAFF can view dashboard, recognition inbox, and edit own profile
-- Deactivated users (`isActive: false`) are blocked at proxy and session level
+- Soft-deleted users (`deletedAt != null`) are blocked at proxy and session level and hidden from the default staff directory; admins can toggle "Show deleted" to view and restore them
 
 ### Dashboard
 

--- a/app/(dashboard)/dashboard/users/(list)/deleted/page.tsx
+++ b/app/(dashboard)/dashboard/users/(list)/deleted/page.tsx
@@ -1,0 +1,17 @@
+import type { Role } from "@/app/generated/prisma/client";
+import { getAllDepartmentsAction } from "@/lib/actions/department-actions";
+import { getServerSession } from "@/lib/auth-utils";
+import { UserListClient } from "../../_components/user-list-client";
+
+export default async function UsersDeletedPage() {
+	const session = await getServerSession();
+	const departments = await getAllDepartmentsAction();
+
+	return (
+		<UserListClient
+			mode="deleted"
+			currentUserRole={session?.user.role as Role}
+			departments={departments.map((d) => ({ id: d.id, name: d.name }))}
+		/>
+	);
+}

--- a/app/(dashboard)/dashboard/users/(list)/layout.tsx
+++ b/app/(dashboard)/dashboard/users/(list)/layout.tsx
@@ -1,0 +1,25 @@
+import { redirect } from "next/navigation";
+import type { Role } from "@/app/generated/prisma/client";
+import { getServerSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+import { canViewUsers } from "@/lib/permissions";
+import { UsersTabs } from "../_components/users-tabs";
+
+export default async function UsersListLayout({ children }: { children: React.ReactNode }) {
+	const session = await getServerSession();
+	if (!session || !canViewUsers(session.user.role as Role)) {
+		redirect("/dashboard");
+	}
+
+	const [activeCount, deletedCount] = await Promise.all([
+		prisma.user.count({ where: { deletedAt: null } }),
+		prisma.user.count({ where: { deletedAt: { not: null } } }),
+	]);
+
+	return (
+		<div className="max-w-7xl mx-auto space-y-6 mt-2">
+			<UsersTabs activeCount={activeCount} deletedCount={deletedCount} />
+			{children}
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/users/(list)/layout.tsx
+++ b/app/(dashboard)/dashboard/users/(list)/layout.tsx
@@ -1,8 +1,10 @@
+import { Plus } from "lucide-react";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { Role } from "@/app/generated/prisma/client";
 import { getServerSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
-import { canViewUsers } from "@/lib/permissions";
+import { canManageUsers, canViewUsers } from "@/lib/permissions";
 import { UsersTabs } from "../_components/users-tabs";
 
 export default async function UsersListLayout({ children }: { children: React.ReactNode }) {
@@ -16,9 +18,32 @@ export default async function UsersListLayout({ children }: { children: React.Re
 		prisma.user.count({ where: { deletedAt: { not: null } } }),
 	]);
 
+	const canAdd = canManageUsers(session.user.role as Role);
+
 	return (
 		<div className="max-w-7xl mx-auto space-y-6 mt-2">
+			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+				<div>
+					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+						Staff Directory
+					</h1>
+					<p className="mt-2 text-base text-muted-foreground">
+						Manage staff accounts, roles, and department assignments.
+					</p>
+				</div>
+				{canAdd && (
+					<Link
+						href="/dashboard/users/new"
+						className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
+					>
+						<Plus className="-ml-1 h-5 w-5" />
+						Add Staff Member
+					</Link>
+				)}
+			</div>
+
 			<UsersTabs activeCount={activeCount} deletedCount={deletedCount} />
+
 			{children}
 		</div>
 	);

--- a/app/(dashboard)/dashboard/users/(list)/page.tsx
+++ b/app/(dashboard)/dashboard/users/(list)/page.tsx
@@ -1,21 +1,16 @@
-import { redirect } from "next/navigation";
 import type { Role } from "@/app/generated/prisma/client";
 import { getAllDepartmentsAction } from "@/lib/actions/department-actions";
 import { getServerSession } from "@/lib/auth-utils";
-import { canViewUsers } from "@/lib/permissions";
-import { UserListClient } from "./_components/user-list-client";
+import { UserListClient } from "../_components/user-list-client";
 
-export default async function UsersPage() {
+export default async function UsersActivePage() {
 	const session = await getServerSession();
-	if (!session || !canViewUsers(session.user.role as Role)) {
-		redirect("/dashboard");
-	}
-
 	const departments = await getAllDepartmentsAction();
 
 	return (
 		<UserListClient
-			currentUserRole={session.user.role as Role}
+			mode="active"
+			currentUserRole={session?.user.role as Role}
 			departments={departments.map((d) => ({ id: d.id, name: d.name }))}
 		/>
 	);

--- a/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
@@ -73,7 +73,6 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 					branch: user.branch ?? null,
 					role: user.role,
 					departmentId: user.departmentId,
-					isActive: user.isActive,
 					hireDate: user.hireDate,
 					birthday: user.birthday,
 					shiftSchedule: scheduleDefault,

--- a/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
@@ -24,6 +24,9 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 	]);
 
 	if (!user) notFound();
+	if (user.deletedAt !== null) {
+		redirect(`/dashboard/users/${user.id}`);
+	}
 
 	const scheduleDefault = user.shiftSchedule
 		? {

--- a/app/(dashboard)/dashboard/users/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/page.tsx
@@ -77,13 +77,15 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 					</h1>
 					<p className="mt-1 text-base text-muted-foreground truncate">{user.email}</p>
 				</div>
-				<Link
-					href={`/dashboard/users/${user.id}/edit`}
-					className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-				>
-					<Pencil className="h-4 w-4" />
-					Edit User
-				</Link>
+				{user.deletedAt === null && (
+					<Link
+						href={`/dashboard/users/${user.id}/edit`}
+						className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
+					>
+						<Pencil className="h-4 w-4" />
+						Edit User
+					</Link>
+				)}
 			</div>
 
 			<div className="grid gap-6 md:grid-cols-2">

--- a/app/(dashboard)/dashboard/users/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/page.tsx
@@ -125,8 +125,8 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 						</div>
 						<div className="flex justify-between items-center py-1">
 							<span className="text-sm text-muted-foreground">Status</span>
-							<Badge variant={user.isActive ? "outline" : "destructive"}>
-								{user.isActive ? "Active" : "Inactive"}
+							<Badge variant={user.deletedAt ? "destructive" : "outline"}>
+								{user.deletedAt ? "Deleted" : "Active"}
 							</Badge>
 						</div>
 						<InfoRow label="Date Hired" value={formatDate(user.hireDate)} />

--- a/app/(dashboard)/dashboard/users/_components/user-filter-bar.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-filter-bar.tsx
@@ -25,8 +25,6 @@ interface UserFilterBarProps {
 	onSearchChange: (value: string) => void;
 	selectedRoles: string[];
 	onSelectedRolesChange: (values: string[]) => void;
-	showDeleted: boolean;
-	onShowDeletedChange: (value: boolean) => void;
 	selectedDepartmentId: string;
 	onDepartmentChange: (value: string) => void;
 	selectedBranch: string;
@@ -44,8 +42,6 @@ export function UserFilterBar({
 	onSearchChange,
 	selectedRoles,
 	onSelectedRolesChange,
-	showDeleted,
-	onShowDeletedChange,
 	selectedDepartmentId,
 	onDepartmentChange,
 	selectedBranch,
@@ -104,16 +100,6 @@ export function UserFilterBar({
 						})}
 					</div>
 				)}
-
-				<label className="inline-flex items-center gap-2 text-xs font-medium text-muted-foreground select-none cursor-pointer">
-					<input
-						type="checkbox"
-						checked={showDeleted}
-						onChange={(e) => onShowDeletedChange(e.target.checked)}
-						className="h-3.5 w-3.5 rounded border-gray-300 text-primary focus:ring-primary"
-					/>
-					Show deleted
-				</label>
 
 				<div className="flex items-center gap-2 lg:ml-auto">
 					<select

--- a/app/(dashboard)/dashboard/users/_components/user-filter-bar.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-filter-bar.tsx
@@ -15,11 +15,6 @@ export const ROLE_OPTIONS = [
 	{ value: "SUPERADMIN", label: "Super Admin" },
 ] as const;
 
-export const STATUS_OPTIONS = [
-	{ value: "active", label: "Active" },
-	{ value: "inactive", label: "Inactive" },
-] as const;
-
 export const BRANCH_OPTIONS = [
 	{ value: "ISO", label: "ISO" },
 	{ value: "PERTH", label: "Perth" },
@@ -30,8 +25,8 @@ interface UserFilterBarProps {
 	onSearchChange: (value: string) => void;
 	selectedRoles: string[];
 	onSelectedRolesChange: (values: string[]) => void;
-	selectedStatuses: string[];
-	onSelectedStatusesChange: (values: string[]) => void;
+	showDeleted: boolean;
+	onShowDeletedChange: (value: boolean) => void;
 	selectedDepartmentId: string;
 	onDepartmentChange: (value: string) => void;
 	selectedBranch: string;
@@ -49,8 +44,8 @@ export function UserFilterBar({
 	onSearchChange,
 	selectedRoles,
 	onSelectedRolesChange,
-	selectedStatuses,
-	onSelectedStatusesChange,
+	showDeleted,
+	onShowDeletedChange,
 	selectedDepartmentId,
 	onDepartmentChange,
 	selectedBranch,
@@ -110,26 +105,15 @@ export function UserFilterBar({
 					</div>
 				)}
 
-				<div className="flex flex-wrap items-center gap-1.5">
-					{STATUS_OPTIONS.map((status) => {
-						const isActive = selectedStatuses.includes(status.value);
-						return (
-							<button
-								key={status.value}
-								type="button"
-								onClick={() => toggle(selectedStatuses, onSelectedStatusesChange, status.value)}
-								className={cn(
-									"inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
-									isActive
-										? "border-primary/20 bg-primary/5 text-primary dark:bg-primary/10"
-										: "border-gray-200 dark:border-white/10 bg-transparent text-muted-foreground hover:border-gray-300 dark:hover:border-white/20",
-								)}
-							>
-								{status.label}
-							</button>
-						);
-					})}
-				</div>
+				<label className="inline-flex items-center gap-2 text-xs font-medium text-muted-foreground select-none cursor-pointer">
+					<input
+						type="checkbox"
+						checked={showDeleted}
+						onChange={(e) => onShowDeletedChange(e.target.checked)}
+						className="h-3.5 w-3.5 rounded border-gray-300 text-primary focus:ring-primary"
+					/>
+					Show deleted
+				</label>
 
 				<div className="flex items-center gap-2 lg:ml-auto">
 					<select

--- a/app/(dashboard)/dashboard/users/_components/user-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-form.tsx
@@ -65,13 +65,11 @@ export function UserForm({
 		resolver: zodResolver((isCreate ? createUserSchema : updateUserSchema) as any),
 		defaultValues: {
 			role: "STAFF",
-			isActive: true,
 			...defaultValues,
 		},
 	});
 
 	const roleValue = watch("role");
-	const isActiveValue = watch("isActive");
 	const hireDateValue = watch("hireDate");
 	const birthdayValue = watch("birthday");
 	const shiftScheduleValue = watch("shiftSchedule");
@@ -355,19 +353,6 @@ export function UserForm({
 								onChange={(e) => setValue("hireDate", parseDateInputValue(e.target.value))}
 								className={inputClass}
 							/>
-						</div>
-
-						<div className="flex items-center gap-2 pt-1 px-1">
-							<input
-								id="isActive"
-								type="checkbox"
-								checked={isActiveValue}
-								onChange={(e) => setValue("isActive", e.target.checked)}
-								className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
-							/>
-							<label htmlFor="isActive" className="text-sm font-medium text-foreground/70">
-								Active
-							</label>
 						</div>
 					</div>
 				</section>

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -494,7 +494,7 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 						<AlertDialogAction
 							onClick={handleConfirmDelete}
 							disabled={isMutating}
-							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+							className="bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/50"
 						>
 							{isMutating ? "Deleting..." : "Delete"}
 						</AlertDialogAction>

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -99,20 +99,21 @@ function TableSkeleton() {
 }
 
 interface UserListClientProps {
+	mode: "active" | "deleted";
 	currentUserRole: string;
 	departments: DepartmentOption[];
 }
 
-export function UserListClient({ currentUserRole, departments }: UserListClientProps) {
+export function UserListClient({ mode, currentUserRole, departments }: UserListClientProps) {
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const showRoleFilter = currentUserRole === "SUPERADMIN";
+	const isDeletedView = mode === "deleted";
 
 	const [page, setPage] = useState(1);
 	const [search, setSearch] = useState("");
 	const [debouncedSearch, setDebouncedSearch] = useState("");
 	const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
-	const [showDeleted, setShowDeleted] = useState(false);
 	const [selectedDepartmentId, setSelectedDepartmentId] = useState("");
 	const [selectedBranch, setSelectedBranch] = useState("");
 	const [isExporting, setIsExporting] = useState(false);
@@ -127,12 +128,11 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 	// biome-ignore lint/correctness/useExhaustiveDependencies: filter values are triggers, not read inside effect
 	useEffect(() => {
 		setPage(1);
-	}, [debouncedSearch, selectedRoles, showDeleted, selectedDepartmentId, selectedBranch]);
+	}, [debouncedSearch, selectedRoles, selectedDepartmentId, selectedBranch]);
 
 	const hasActiveFilters =
 		search.length > 0 ||
 		selectedRoles.length > 0 ||
-		showDeleted ||
 		selectedDepartmentId.length > 0 ||
 		selectedBranch.length > 0;
 
@@ -140,7 +140,6 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 		setSearch("");
 		setDebouncedSearch("");
 		setSelectedRoles([]);
-		setShowDeleted(false);
 		setSelectedDepartmentId("");
 		setSelectedBranch("");
 	}
@@ -149,7 +148,7 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 		const effectiveSearch = searchOverride ?? debouncedSearch;
 		if (effectiveSearch) base.set("search", effectiveSearch);
 		if (selectedRoles.length > 0) base.set("roles", selectedRoles.join(","));
-		if (showDeleted) base.set("includeDeleted", "true");
+		if (isDeletedView) base.set("onlyDeleted", "true");
 		if (selectedDepartmentId) base.set("departmentId", selectedDepartmentId);
 		if (selectedBranch) base.set("branch", selectedBranch);
 		return base;
@@ -158,10 +157,10 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 	const { data, isPending, isError } = useQuery<PaginatedResponse>({
 		queryKey: [
 			"users",
+			mode,
 			page,
 			debouncedSearch,
 			selectedRoles,
-			showDeleted,
 			selectedDepartmentId,
 			selectedBranch,
 		],
@@ -255,32 +254,36 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 	}, [pagination, page]);
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-6 mt-2">
+		<div className="space-y-6">
 			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
 				<div>
 					<div className="flex items-baseline gap-3 flex-wrap">
 						<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-							Staff Directory
+							{isDeletedView ? "Deleted Staff" : "Staff Directory"}
 						</h1>
 						{pagination && (
 							<span className="text-base font-medium text-muted-foreground">
-								{pagination.total} {pagination.total === 1 ? "staff" : "staff"}
+								{pagination.total} staff
 								{hasActiveFilters && " matching"}
 							</span>
 						)}
 					</div>
 					<p className="mt-2 text-base text-muted-foreground">
-						Manage staff accounts, roles, and department assignments.
+						{isDeletedView
+							? "Restore removed accounts. Their recognition history has been preserved."
+							: "Manage staff accounts, roles, and department assignments."}
 					</p>
 				</div>
-				<button
-					type="button"
-					onClick={() => router.push("/dashboard/users/new")}
-					className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-				>
-					<Plus className="-ml-1 h-5 w-5" />
-					Add Staff Member
-				</button>
+				{!isDeletedView && (
+					<button
+						type="button"
+						onClick={() => router.push("/dashboard/users/new")}
+						className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
+					>
+						<Plus className="-ml-1 h-5 w-5" />
+						Add Staff Member
+					</button>
+				)}
 			</div>
 
 			<UserFilterBar
@@ -288,8 +291,6 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 				onSearchChange={setSearch}
 				selectedRoles={selectedRoles}
 				onSelectedRolesChange={setSelectedRoles}
-				showDeleted={showDeleted}
-				onShowDeletedChange={setShowDeleted}
 				selectedDepartmentId={selectedDepartmentId}
 				onDepartmentChange={setSelectedDepartmentId}
 				selectedBranch={selectedBranch}
@@ -321,12 +322,18 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 						)}
 					</div>
 					<p className="text-[1.5rem] font-medium text-foreground">
-						{hasActiveFilters ? "No matching staff" : "No staff yet"}
+						{hasActiveFilters
+							? "No matching staff"
+							: isDeletedView
+								? "No deleted staff"
+								: "No staff yet"}
 					</p>
 					<p className="mt-2 text-base text-muted-foreground">
 						{hasActiveFilters
 							? "No staff match your current filters."
-							: "Add your first staff member to get started."}
+							: isDeletedView
+								? "Deleted staff will appear here."
+								: "Add your first staff member to get started."}
 					</p>
 					{hasActiveFilters && (
 						<button

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -258,9 +258,17 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 		<div className="max-w-7xl mx-auto space-y-6 mt-2">
 			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
 				<div>
-					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-						Staff Directory
-					</h1>
+					<div className="flex items-baseline gap-3 flex-wrap">
+						<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+							Staff Directory
+						</h1>
+						{pagination && (
+							<span className="text-base font-medium text-muted-foreground">
+								{pagination.total} {pagination.total === 1 ? "staff" : "staff"}
+								{hasActiveFilters && " matching"}
+							</span>
+						)}
+					</div>
 					<p className="mt-2 text-base text-muted-foreground">
 						Manage staff accounts, roles, and department assignments.
 					</p>

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -6,7 +6,6 @@ import {
 	ChevronRight,
 	Eye,
 	Pencil,
-	Plus,
 	RotateCcw,
 	Search,
 	Trash2,
@@ -255,37 +254,6 @@ export function UserListClient({ mode, currentUserRole, departments }: UserListC
 
 	return (
 		<div className="space-y-6">
-			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-				<div>
-					<div className="flex items-baseline gap-3 flex-wrap">
-						<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-							{isDeletedView ? "Deleted Staff" : "Staff Directory"}
-						</h1>
-						{pagination && (
-							<span className="text-base font-medium text-muted-foreground">
-								{pagination.total} staff
-								{hasActiveFilters && " matching"}
-							</span>
-						)}
-					</div>
-					<p className="mt-2 text-base text-muted-foreground">
-						{isDeletedView
-							? "Restore removed accounts. Their recognition history has been preserved."
-							: "Manage staff accounts, roles, and department assignments."}
-					</p>
-				</div>
-				{!isDeletedView && (
-					<button
-						type="button"
-						onClick={() => router.push("/dashboard/users/new")}
-						className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-					>
-						<Plus className="-ml-1 h-5 w-5" />
-						Add Staff Member
-					</button>
-				)}
-			</div>
-
 			<UserFilterBar
 				search={search}
 				onSearchChange={setSearch}

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -7,15 +7,25 @@ import {
 	Eye,
 	Pencil,
 	Plus,
+	RotateCcw,
 	Search,
-	UserCheck,
+	Trash2,
 	Users,
-	UserX,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { UserAvatar } from "@/components/shared/user-avatar";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import {
 	Table,
@@ -25,8 +35,9 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
-import { toggleUserActiveAction } from "@/lib/actions/user-actions";
+import { restoreUserAction, softDeleteUserAction } from "@/lib/actions/user-actions";
 import { type ExportUser, generateUserCsv } from "@/lib/users";
+import { cn } from "@/lib/utils";
 import { type DepartmentOption, UserFilterBar } from "./user-filter-bar";
 
 const PAGE_SIZE = 20;
@@ -40,7 +51,7 @@ interface User {
 	avatar: string | null;
 	image: string | null;
 	role: string;
-	isActive: boolean;
+	deletedAt: string | null;
 	position: string | null;
 	branch: string | null;
 	department: { id: string; name: string; code: string } | null;
@@ -101,10 +112,12 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 	const [search, setSearch] = useState("");
 	const [debouncedSearch, setDebouncedSearch] = useState("");
 	const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
-	const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
+	const [showDeleted, setShowDeleted] = useState(false);
 	const [selectedDepartmentId, setSelectedDepartmentId] = useState("");
 	const [selectedBranch, setSelectedBranch] = useState("");
 	const [isExporting, setIsExporting] = useState(false);
+	const [deleteTarget, setDeleteTarget] = useState<User | null>(null);
+	const [isMutating, setIsMutating] = useState(false);
 
 	useEffect(() => {
 		const timer = setTimeout(() => setDebouncedSearch(search), 300);
@@ -114,12 +127,12 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 	// biome-ignore lint/correctness/useExhaustiveDependencies: filter values are triggers, not read inside effect
 	useEffect(() => {
 		setPage(1);
-	}, [debouncedSearch, selectedRoles, selectedStatuses, selectedDepartmentId, selectedBranch]);
+	}, [debouncedSearch, selectedRoles, showDeleted, selectedDepartmentId, selectedBranch]);
 
 	const hasActiveFilters =
 		search.length > 0 ||
 		selectedRoles.length > 0 ||
-		selectedStatuses.length > 0 ||
+		showDeleted ||
 		selectedDepartmentId.length > 0 ||
 		selectedBranch.length > 0;
 
@@ -127,7 +140,7 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 		setSearch("");
 		setDebouncedSearch("");
 		setSelectedRoles([]);
-		setSelectedStatuses([]);
+		setShowDeleted(false);
 		setSelectedDepartmentId("");
 		setSelectedBranch("");
 	}
@@ -136,7 +149,7 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 		const effectiveSearch = searchOverride ?? debouncedSearch;
 		if (effectiveSearch) base.set("search", effectiveSearch);
 		if (selectedRoles.length > 0) base.set("roles", selectedRoles.join(","));
-		if (selectedStatuses.length > 0) base.set("statuses", selectedStatuses.join(","));
+		if (showDeleted) base.set("includeDeleted", "true");
 		if (selectedDepartmentId) base.set("departmentId", selectedDepartmentId);
 		if (selectedBranch) base.set("branch", selectedBranch);
 		return base;
@@ -148,7 +161,7 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 			page,
 			debouncedSearch,
 			selectedRoles,
-			selectedStatuses,
+			showDeleted,
 			selectedDepartmentId,
 			selectedBranch,
 		],
@@ -167,13 +180,30 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 		staleTime: 30_000,
 	});
 
-	async function handleToggleActive(userId: string) {
-		const result = await toggleUserActiveAction(userId);
+	async function handleConfirmDelete() {
+		if (!deleteTarget) return;
+		setIsMutating(true);
+		try {
+			const result = await softDeleteUserAction(deleteTarget.id);
+			if (result.success) {
+				toast.success(`${deleteTarget.firstName} ${deleteTarget.lastName} deleted`);
+				queryClient.invalidateQueries({ queryKey: ["users"] });
+				setDeleteTarget(null);
+			} else {
+				toast.error(typeof result.error === "string" ? result.error : "Failed to delete user");
+			}
+		} finally {
+			setIsMutating(false);
+		}
+	}
+
+	async function handleRestore(user: User) {
+		const result = await restoreUserAction(user.id);
 		if (result.success) {
-			toast.success("User status updated");
+			toast.success(`${user.firstName} ${user.lastName} restored`);
 			queryClient.invalidateQueries({ queryKey: ["users"] });
 		} else {
-			toast.error(typeof result.error === "string" ? result.error : "Failed to update status");
+			toast.error(typeof result.error === "string" ? result.error : "Failed to restore user");
 		}
 	}
 
@@ -250,8 +280,8 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 				onSearchChange={setSearch}
 				selectedRoles={selectedRoles}
 				onSelectedRolesChange={setSelectedRoles}
-				selectedStatuses={selectedStatuses}
-				onSelectedStatusesChange={setSelectedStatuses}
+				showDeleted={showDeleted}
+				onShowDeletedChange={setShowDeleted}
 				selectedDepartmentId={selectedDepartmentId}
 				onDepartmentChange={setSelectedDepartmentId}
 				selectedBranch={selectedBranch}
@@ -314,75 +344,91 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 								</TableRow>
 							</TableHeader>
 							<TableBody>
-								{users.map((user) => (
-									<TableRow key={user.id} className="group">
-										<TableCell>
-											<div className="flex items-center gap-3">
-												<UserAvatar
-													firstName={user.firstName}
-													lastName={user.lastName}
-													avatar={user.avatar}
-													image={user.image}
-													size="lg"
-													className="border border-gray-100 dark:border-white/10 bg-background text-primary"
-												/>
-												<div className="min-w-0">
-													<p className="text-sm font-medium text-foreground truncate">
-														{user.firstName} {user.lastName}
-													</p>
-													<p className="text-xs text-muted-foreground truncate">{user.email}</p>
+								{users.map((user) => {
+									const isDeleted = user.deletedAt !== null;
+									return (
+										<TableRow key={user.id} className={cn("group", isDeleted && "opacity-60")}>
+											<TableCell>
+												<div className="flex items-center gap-3">
+													<UserAvatar
+														firstName={user.firstName}
+														lastName={user.lastName}
+														avatar={user.avatar}
+														image={user.image}
+														size="lg"
+														className="border border-gray-100 dark:border-white/10 bg-background text-primary"
+													/>
+													<div className="min-w-0">
+														<p className="text-sm font-medium text-foreground truncate">
+															{user.firstName} {user.lastName}
+														</p>
+														<p className="text-xs text-muted-foreground truncate">{user.email}</p>
+													</div>
 												</div>
-											</div>
-										</TableCell>
-										<TableCell>
-											<p className="text-sm font-medium text-foreground">{user.position ?? "—"}</p>
-											<p className="text-xs text-muted-foreground">
-												{user.department?.name ?? "—"}
-											</p>
-										</TableCell>
-										<TableCell>
-											<span className="text-sm text-foreground">{user.branch ?? "—"}</span>
-										</TableCell>
-										<TableCell>
-											<div className="flex flex-col gap-1.5">
-												{currentUserRole === "SUPERADMIN" && (
-													<Badge variant={roleBadgeVariant(user.role)}>{user.role}</Badge>
-												)}
-												<Badge variant={user.isActive ? "outline" : "destructive"}>
-													{user.isActive ? "Active" : "Inactive"}
-												</Badge>
-											</div>
-										</TableCell>
-										<TableCell className="text-right">
-											<div className="flex justify-end gap-1 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity [@media(hover:hover)]:group-hover:opacity-100 focus-within:opacity-100">
-												<button
-													type="button"
-													onClick={() => router.push(`/dashboard/users/${user.id}`)}
-													className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
-													aria-label="View user"
-												>
-													<Eye size={16} />
-												</button>
-												<button
-													type="button"
-													onClick={() => router.push(`/dashboard/users/${user.id}/edit`)}
-													className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
-													aria-label="Edit user"
-												>
-													<Pencil size={16} />
-												</button>
-												<button
-													type="button"
-													onClick={() => handleToggleActive(user.id)}
-													className="rounded-full p-2 text-muted-foreground hover:bg-[oklch(0.96_0.03_18)] hover:text-primary dark:hover:bg-primary/10 transition-colors"
-													aria-label={user.isActive ? "Deactivate user" : "Activate user"}
-												>
-													{user.isActive ? <UserX size={16} /> : <UserCheck size={16} />}
-												</button>
-											</div>
-										</TableCell>
-									</TableRow>
-								))}
+											</TableCell>
+											<TableCell>
+												<p className="text-sm font-medium text-foreground">
+													{user.position ?? "—"}
+												</p>
+												<p className="text-xs text-muted-foreground">
+													{user.department?.name ?? "—"}
+												</p>
+											</TableCell>
+											<TableCell>
+												<span className="text-sm text-foreground">{user.branch ?? "—"}</span>
+											</TableCell>
+											<TableCell>
+												<div className="flex flex-col gap-1.5">
+													{currentUserRole === "SUPERADMIN" && (
+														<Badge variant={roleBadgeVariant(user.role)}>{user.role}</Badge>
+													)}
+													{isDeleted && <Badge variant="destructive">Deleted</Badge>}
+												</div>
+											</TableCell>
+											<TableCell className="text-right">
+												<div className="flex justify-end gap-1 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity [@media(hover:hover)]:group-hover:opacity-100 focus-within:opacity-100">
+													<button
+														type="button"
+														onClick={() => router.push(`/dashboard/users/${user.id}`)}
+														className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
+														aria-label="View user"
+													>
+														<Eye size={16} />
+													</button>
+													{!isDeleted && (
+														<button
+															type="button"
+															onClick={() => router.push(`/dashboard/users/${user.id}/edit`)}
+															className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
+															aria-label="Edit user"
+														>
+															<Pencil size={16} />
+														</button>
+													)}
+													{isDeleted ? (
+														<button
+															type="button"
+															onClick={() => handleRestore(user)}
+															className="rounded-full p-2 text-muted-foreground hover:bg-emerald-50 hover:text-emerald-600 dark:hover:bg-emerald-500/10 transition-colors"
+															aria-label="Restore user"
+														>
+															<RotateCcw size={16} />
+														</button>
+													) : (
+														<button
+															type="button"
+															onClick={() => setDeleteTarget(user)}
+															className="rounded-full p-2 text-muted-foreground hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-500/10 transition-colors"
+															aria-label="Delete user"
+														>
+															<Trash2 size={16} />
+														</button>
+													)}
+												</div>
+											</TableCell>
+										</TableRow>
+									);
+								})}
 							</TableBody>
 						</Table>
 					</div>
@@ -421,6 +467,32 @@ export function UserListClient({ currentUserRole, departments }: UserListClientP
 					)}
 				</>
 			)}
+
+			<AlertDialog
+				open={deleteTarget !== null}
+				onOpenChange={(open) => !open && setDeleteTarget(null)}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete this user?</AlertDialogTitle>
+						<AlertDialogDescription>
+							{deleteTarget
+								? `${deleteTarget.firstName} ${deleteTarget.lastName} will lose access and be hidden from the staff directory. Their recognition history stays intact. You can restore them later.`
+								: ""}
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={isMutating}>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleConfirmDelete}
+							disabled={isMutating}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							{isMutating ? "Deleting..." : "Delete"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/users/_components/users-tabs.tsx
+++ b/app/(dashboard)/dashboard/users/_components/users-tabs.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Trash2, Users } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+interface UsersTabsProps {
+	activeCount: number;
+	deletedCount: number;
+}
+
+export function UsersTabs({ activeCount, deletedCount }: UsersTabsProps) {
+	const pathname = usePathname();
+
+	const tabs = [
+		{
+			key: "active",
+			label: "Active",
+			href: "/dashboard/users",
+			icon: Users,
+			count: activeCount,
+		},
+		{
+			key: "deleted",
+			label: "Deleted",
+			href: "/dashboard/users/deleted",
+			icon: Trash2,
+			count: deletedCount,
+		},
+	];
+
+	return (
+		<div
+			className="flex gap-1 rounded-full bg-gray-100 dark:bg-white/5 p-1 w-fit"
+			role="tablist"
+			aria-label="Staff directory"
+		>
+			{tabs.map((tab) => {
+				const isActive = pathname === tab.href;
+				const Icon = tab.icon;
+				return (
+					<Link
+						key={tab.key}
+						href={tab.href}
+						role="tab"
+						aria-selected={isActive}
+						className={cn(
+							"inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition-all duration-200",
+							isActive
+								? "bg-card text-foreground shadow-sm"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+					>
+						<Icon size={16} />
+						{tab.label}
+						<span
+							className={cn(
+								"inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 rounded-full text-xs font-medium",
+								isActive
+									? "bg-primary/10 text-primary"
+									: "bg-gray-200/70 dark:bg-white/10 text-muted-foreground",
+							)}
+						>
+							{tab.count}
+						</span>
+					</Link>
+				);
+			})}
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/users/_components/users-tabs.tsx
+++ b/app/(dashboard)/dashboard/users/_components/users-tabs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { Trash2, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -10,8 +11,29 @@ interface UsersTabsProps {
 	deletedCount: number;
 }
 
+interface CountsResponse {
+	success: boolean;
+	data: { activeCount: number; deletedCount: number };
+}
+
 export function UsersTabs({ activeCount, deletedCount }: UsersTabsProps) {
 	const pathname = usePathname();
+
+	const { data } = useQuery<CountsResponse>({
+		queryKey: ["users", "counts"],
+		queryFn: async () => {
+			const res = await fetch("/api/users/counts");
+			if (!res.ok) throw new Error("Failed to fetch counts");
+			return res.json();
+		},
+		initialData: {
+			success: true,
+			data: { activeCount, deletedCount },
+		},
+		staleTime: 30_000,
+	});
+
+	const counts = data.data;
 
 	const tabs = [
 		{
@@ -19,14 +41,14 @@ export function UsersTabs({ activeCount, deletedCount }: UsersTabsProps) {
 			label: "Active",
 			href: "/dashboard/users",
 			icon: Users,
-			count: activeCount,
+			count: counts.activeCount,
 		},
 		{
 			key: "deleted",
 			label: "Deleted",
 			href: "/dashboard/users/deleted",
 			icon: Trash2,
-			count: deletedCount,
+			count: counts.deletedCount,
 		},
 	];
 

--- a/app/api/recognition/users/route.ts
+++ b/app/api/recognition/users/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
 
 	try {
 		const users = await prisma.user.findMany({
-			where: { isActive: true },
+			where: { deletedAt: null },
 			select: {
 				id: true,
 				firstName: true,

--- a/app/api/upload/avatar/route.ts
+++ b/app/api/upload/avatar/route.ts
@@ -1,4 +1,4 @@
-import { requireSession } from "@/lib/auth-utils";
+import { AuthError, requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { deleteFromR2, extractKeyFromUrl, getAvatarKey, getPublicUrl, uploadToR2 } from "@/lib/r2";
 
@@ -55,8 +55,10 @@ export async function POST(request: Request) {
 
 		return Response.json({ success: true, data: { url } });
 	} catch (error) {
+		if (error instanceof AuthError) {
+			return Response.json({ success: false, error: error.message }, { status: error.status });
+		}
 		const message = error instanceof Error ? error.message : "Upload failed";
-		const status = message === "Unauthorized" || message === "Account deactivated" ? 401 : 500;
-		return Response.json({ success: false, error: message }, { status });
+		return Response.json({ success: false, error: message }, { status: 500 });
 	}
 }

--- a/app/api/users/counts/route.ts
+++ b/app/api/users/counts/route.ts
@@ -1,0 +1,19 @@
+import { headers } from "next/headers";
+import type { Role } from "@/app/generated/prisma/client";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { canViewUsers } from "@/lib/permissions";
+
+export async function GET() {
+	const session = await auth.api.getSession({ headers: await headers() });
+	if (!session || !canViewUsers(session.user.role as Role)) {
+		return Response.json({ success: false, error: "Forbidden" }, { status: 403 });
+	}
+
+	const [activeCount, deletedCount] = await Promise.all([
+		prisma.user.count({ where: { deletedAt: null } }),
+		prisma.user.count({ where: { deletedAt: { not: null } } }),
+	]);
+
+	return Response.json({ success: true, data: { activeCount, deletedCount } });
+}

--- a/app/api/users/counts/route.ts
+++ b/app/api/users/counts/route.ts
@@ -1,19 +1,25 @@
-import { headers } from "next/headers";
 import type { Role } from "@/app/generated/prisma/client";
-import { auth } from "@/lib/auth";
+import { AuthError, requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { canViewUsers } from "@/lib/permissions";
 
 export async function GET() {
-	const session = await auth.api.getSession({ headers: await headers() });
-	if (!session || !canViewUsers(session.user.role as Role)) {
-		return Response.json({ success: false, error: "Forbidden" }, { status: 403 });
+	try {
+		const session = await requireSession();
+		if (!canViewUsers(session.user.role as Role)) {
+			return Response.json({ success: false, error: "Forbidden" }, { status: 403 });
+		}
+
+		const [activeCount, deletedCount] = await Promise.all([
+			prisma.user.count({ where: { deletedAt: null } }),
+			prisma.user.count({ where: { deletedAt: { not: null } } }),
+		]);
+
+		return Response.json({ success: true, data: { activeCount, deletedCount } });
+	} catch (error) {
+		if (error instanceof AuthError) {
+			return Response.json({ success: false, error: error.message }, { status: error.status });
+		}
+		return Response.json({ success: false, error: "Internal server error" }, { status: 500 });
 	}
-
-	const [activeCount, deletedCount] = await Promise.all([
-		prisma.user.count({ where: { deletedAt: null } }),
-		prisma.user.count({ where: { deletedAt: { not: null } } }),
-	]);
-
-	return Response.json({ success: true, data: { activeCount, deletedCount } });
 }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,7 +1,6 @@
-import { headers } from "next/headers";
 import type { NextRequest } from "next/server";
 import type { Branch, Prisma, Role } from "@/app/generated/prisma/client";
-import { auth } from "@/lib/auth";
+import { AuthError, requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { canViewUsers } from "@/lib/permissions";
 
@@ -25,9 +24,17 @@ function parseBranch(param: string | null): Branch | null {
 }
 
 export async function GET(request: NextRequest) {
-	const session = await auth.api.getSession({ headers: await headers() });
+	let session: Awaited<ReturnType<typeof requireSession>>;
+	try {
+		session = await requireSession();
+	} catch (error) {
+		if (error instanceof AuthError) {
+			return Response.json({ success: false, error: error.message }, { status: error.status });
+		}
+		return Response.json({ success: false, error: "Internal server error" }, { status: 500 });
+	}
 
-	if (!session || !canViewUsers(session.user.role as Role)) {
+	if (!canViewUsers(session.user.role as Role)) {
 		return Response.json({ success: false, error: "Forbidden" }, { status: 403 });
 	}
 

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -7,7 +7,6 @@ import { canViewUsers } from "@/lib/permissions";
 
 const VALID_ROLES: Role[] = ["STAFF", "ADMIN", "SUPERADMIN"];
 const VALID_BRANCHES: Branch[] = ["ISO", "PERTH"];
-const VALID_STATUSES = ["active", "inactive"] as const;
 const EXPORT_LIMIT = 10_000;
 const SEARCH_MAX_LENGTH = 200;
 
@@ -17,16 +16,6 @@ function parseRoles(param: string | null): Role[] {
 		.split(",")
 		.map((r) => r.trim().toUpperCase())
 		.filter((r): r is Role => VALID_ROLES.includes(r as Role));
-}
-
-function parseStatuses(param: string | null): (typeof VALID_STATUSES)[number][] {
-	if (!param) return [];
-	return param
-		.split(",")
-		.map((s) => s.trim().toLowerCase())
-		.filter((s): s is (typeof VALID_STATUSES)[number] =>
-			VALID_STATUSES.includes(s as (typeof VALID_STATUSES)[number]),
-		);
 }
 
 function parseBranch(param: string | null): Branch | null {
@@ -46,8 +35,11 @@ export async function GET(request: NextRequest) {
 	const paginated = searchParams.get("paginated") === "true";
 	const isExport = searchParams.get("export") === "true";
 
+	const includeDeleted = searchParams.get("includeDeleted") === "true";
+
 	if (!paginated && !isExport) {
 		const users = await prisma.user.findMany({
+			where: includeDeleted ? undefined : { deletedAt: null },
 			include: { department: true },
 			orderBy: { createdAt: "desc" },
 		});
@@ -57,11 +49,14 @@ export async function GET(request: NextRequest) {
 	const search = searchParams.get("search")?.trim().slice(0, SEARCH_MAX_LENGTH);
 	const userRole = session.user.role as Role;
 	const roles = userRole === "SUPERADMIN" ? parseRoles(searchParams.get("roles")) : [];
-	const statuses = parseStatuses(searchParams.get("statuses"));
 	const departmentId = searchParams.get("departmentId")?.trim();
 	const branch = parseBranch(searchParams.get("branch"));
 
 	const conditions: Prisma.UserWhereInput[] = [];
+
+	if (!includeDeleted) {
+		conditions.push({ deletedAt: null });
+	}
 
 	if (search) {
 		const tokens = search.split(/\s+/).filter(Boolean);
@@ -80,10 +75,6 @@ export async function GET(request: NextRequest) {
 
 	if (roles.length > 0) {
 		conditions.push({ role: { in: roles } });
-	}
-
-	if (statuses.length === 1) {
-		conditions.push({ isActive: statuses[0] === "active" });
 	}
 
 	if (departmentId) {

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -36,10 +36,17 @@ export async function GET(request: NextRequest) {
 	const isExport = searchParams.get("export") === "true";
 
 	const includeDeleted = searchParams.get("includeDeleted") === "true";
+	const onlyDeleted = searchParams.get("onlyDeleted") === "true";
+
+	const deletedFilter: Prisma.UserWhereInput | null = onlyDeleted
+		? { deletedAt: { not: null } }
+		: includeDeleted
+			? null
+			: { deletedAt: null };
 
 	if (!paginated && !isExport) {
 		const users = await prisma.user.findMany({
-			where: includeDeleted ? undefined : { deletedAt: null },
+			where: deletedFilter ?? undefined,
 			include: { department: true },
 			orderBy: { createdAt: "desc" },
 		});
@@ -54,8 +61,8 @@ export async function GET(request: NextRequest) {
 
 	const conditions: Prisma.UserWhereInput[] = [];
 
-	if (!includeDeleted) {
-		conditions.push({ deletedAt: null });
+	if (deletedFilter) {
+		conditions.push(deletedFilter);
 	}
 
 	if (search) {

--- a/lib/actions/department-actions.ts
+++ b/lib/actions/department-actions.ts
@@ -68,7 +68,9 @@ export async function updateDepartmentAction(id: string, formData: unknown) {
 export async function deleteDepartmentAction(id: string) {
 	try {
 		await requireRole("ADMIN");
-		const userCount = await prisma.user.count({ where: { departmentId: id } });
+		const userCount = await prisma.user.count({
+			where: { departmentId: id, deletedAt: null },
+		});
 
 		if (userCount > 0) {
 			return {

--- a/lib/actions/department-actions.ts
+++ b/lib/actions/department-actions.ts
@@ -68,9 +68,11 @@ export async function updateDepartmentAction(id: string, formData: unknown) {
 export async function deleteDepartmentAction(id: string) {
 	try {
 		await requireRole("ADMIN");
-		const userCount = await prisma.user.count({
-			where: { departmentId: id, deletedAt: null },
-		});
+		// Count soft-deleted users too. If we ignored them, deleting the
+		// department would null out their saved `department_id` (via
+		// ON DELETE SET NULL on the optional relation) and they'd come
+		// back without a department on restore — silent data loss.
+		const userCount = await prisma.user.count({ where: { departmentId: id } });
 
 		if (userCount > 0) {
 			return {

--- a/lib/actions/recognition-actions.ts
+++ b/lib/actions/recognition-actions.ts
@@ -27,14 +27,14 @@ export async function createRecognitionCardAction(formData: unknown) {
 		}
 
 		const recipient = await prisma.user.findUnique({
-			where: { id: recipientId, isActive: true },
+			where: { id: recipientId, deletedAt: null },
 			select: { id: true },
 		});
 
 		if (!recipient) {
 			return {
 				success: false as const,
-				error: "Recipient not found or inactive",
+				error: "Recipient not found or deleted",
 			};
 		}
 
@@ -103,14 +103,14 @@ export async function updateRecognitionCardAction(cardId: string, formData: unkn
 		}
 
 		const recipient = await prisma.user.findUnique({
-			where: { id: recipientId, isActive: true },
+			where: { id: recipientId, deletedAt: null },
 			select: { id: true },
 		});
 
 		if (!recipient) {
 			return {
 				success: false as const,
-				error: "Recipient not found or inactive",
+				error: "Recipient not found or deleted",
 			};
 		}
 

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -214,7 +214,7 @@ export async function softDeleteUserAction(userId: string) {
 			return user;
 		});
 
-		revalidatePath("/dashboard/users");
+		revalidatePath("/dashboard/users", "layout");
 		return { success: true as const, data: updated };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "Failed to delete user";
@@ -244,7 +244,7 @@ export async function restoreUserAction(userId: string) {
 			data: { deletedAt: null, deletedById: null, isActive: true },
 		});
 
-		revalidatePath("/dashboard/users");
+		revalidatePath("/dashboard/users", "layout");
 		return { success: true as const, data: updated };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "Failed to restore user";

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -119,11 +119,15 @@ export async function updateUserAction(userId: string, formData: unknown) {
 
 		const targetUser = await prisma.user.findUnique({
 			where: { id: userId },
-			select: { role: true },
+			select: { role: true, deletedAt: true },
 		});
 
 		if (!targetUser) {
 			return { success: false as const, error: "User not found" };
+		}
+
+		if (targetUser.deletedAt !== null) {
+			return { success: false as const, error: "Cannot edit a deleted user. Restore them first." };
 		}
 
 		// Only gate on role-assignment permissions when the role is actually
@@ -198,7 +202,13 @@ export async function softDeleteUserAction(userId: string) {
 		const updated = await prisma.$transaction(async (tx) => {
 			const user = await tx.user.update({
 				where: { id: userId },
-				data: { deletedAt: new Date(), deletedById: session.user.id },
+				data: {
+					deletedAt: new Date(),
+					deletedById: session.user.id,
+					// Mirror into the deprecated `isActive` column so any
+					// still-running old release renders them correctly.
+					isActive: false,
+				},
 			});
 			await tx.session.deleteMany({ where: { userId } });
 			return user;
@@ -231,7 +241,7 @@ export async function restoreUserAction(userId: string) {
 
 		const updated = await prisma.user.update({
 			where: { id: userId },
-			data: { deletedAt: null, deletedById: null },
+			data: { deletedAt: null, deletedById: null, isActive: true },
 		});
 
 		revalidatePath("/dashboard/users");
@@ -268,11 +278,18 @@ export async function adminResetPasswordAction(userId: string, formData: unknown
 
 		const targetUser = await prisma.user.findUnique({
 			where: { id: userId },
-			select: { role: true },
+			select: { role: true, deletedAt: true },
 		});
 
 		if (!targetUser) {
 			return { success: false as const, error: "User not found" };
+		}
+
+		if (targetUser.deletedAt !== null) {
+			return {
+				success: false as const,
+				error: "Cannot reset password for a deleted user. Restore them first.",
+			};
 		}
 
 		if (!canAssignRole(session.user.role as Role, targetUser.role)) {

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -14,6 +14,13 @@ import {
 	updateUserSchema,
 } from "@/lib/validations/user";
 
+class LastSuperadminError extends Error {
+	constructor() {
+		super("Cannot delete the last super admin");
+		this.name = "LastSuperadminError";
+	}
+}
+
 async function upsertShiftSchedule(
 	tx: Prisma.TransactionClient,
 	userId: string,
@@ -100,7 +107,7 @@ export async function createUserAction(formData: unknown) {
 			return user;
 		});
 
-		revalidatePath("/dashboard/users");
+		revalidatePath("/dashboard/users", "layout");
 		return { success: true as const, data: updated };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "Failed to create user";
@@ -160,7 +167,7 @@ export async function updateUserAction(userId: string, formData: unknown) {
 			return user;
 		});
 
-		revalidatePath("/dashboard/users");
+		revalidatePath("/dashboard/users", "layout");
 		revalidatePath(`/dashboard/users/${userId}`);
 		return { success: true as const, data: updated };
 	} catch (error) {
@@ -190,33 +197,42 @@ export async function softDeleteUserAction(userId: string) {
 			return { success: false as const, error: "User is already deleted" };
 		}
 
-		if (target.role === "SUPERADMIN") {
-			const activeSuperadmins = await prisma.user.count({
-				where: { role: "SUPERADMIN", deletedAt: null },
-			});
-			if (activeSuperadmins <= 1) {
-				return { success: false as const, error: "Cannot delete the last super admin" };
-			}
-		}
-
-		const updated = await prisma.$transaction(async (tx) => {
-			const user = await tx.user.update({
-				where: { id: userId },
-				data: {
-					deletedAt: new Date(),
-					deletedById: session.user.id,
-					// Mirror into the deprecated `isActive` column so any
-					// still-running old release renders them correctly.
-					isActive: false,
-				},
-			});
-			await tx.session.deleteMany({ where: { userId } });
-			return user;
-		});
+		const updated = await prisma.$transaction(
+			async (tx) => {
+				// Re-check guard inside the transaction so two concurrent deletes
+				// can't both observe `count === 2` and then both succeed, leaving
+				// zero active superadmins. Serializable isolation turns any such
+				// race into a serialization failure on one of the transactions.
+				if (target.role === "SUPERADMIN") {
+					const activeSuperadmins = await tx.user.count({
+						where: { role: "SUPERADMIN", deletedAt: null },
+					});
+					if (activeSuperadmins <= 1) {
+						throw new LastSuperadminError();
+					}
+				}
+				const user = await tx.user.update({
+					where: { id: userId },
+					data: {
+						deletedAt: new Date(),
+						deletedById: session.user.id,
+						// Mirror into the deprecated `isActive` column so any
+						// still-running old release renders them correctly.
+						isActive: false,
+					},
+				});
+				await tx.session.deleteMany({ where: { userId } });
+				return user;
+			},
+			{ isolationLevel: "Serializable" },
+		);
 
 		revalidatePath("/dashboard/users", "layout");
 		return { success: true as const, data: updated };
 	} catch (error) {
+		if (error instanceof LastSuperadminError) {
+			return { success: false as const, error: error.message };
+		}
 		const message = error instanceof Error ? error.message : "Failed to delete user";
 		return { success: false as const, error: message };
 	}

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -228,6 +228,7 @@ export async function softDeleteUserAction(userId: string) {
 		);
 
 		revalidatePath("/dashboard/users", "layout");
+		revalidatePath(`/dashboard/users/${userId}`);
 		return { success: true as const, data: updated };
 	} catch (error) {
 		if (error instanceof LastSuperadminError) {
@@ -261,6 +262,7 @@ export async function restoreUserAction(userId: string) {
 		});
 
 		revalidatePath("/dashboard/users", "layout");
+		revalidatePath(`/dashboard/users/${userId}`);
 		return { success: true as const, data: updated };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "Failed to restore user";

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -4,7 +4,7 @@ import { hashPassword } from "better-auth/crypto";
 import { revalidatePath } from "next/cache";
 import type { Prisma, Role } from "@/app/generated/prisma/client";
 import { auth } from "@/lib/auth";
-import { requireRole, requireSession } from "@/lib/auth-utils";
+import { requireRole } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { canAssignRole } from "@/lib/permissions";
 import { adminResetPasswordSchema } from "@/lib/validations/auth";
@@ -340,20 +340,6 @@ export async function adminResetPasswordAction(userId: string, formData: unknown
 		return { success: true as const, data: null };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "Failed to reset password";
-		return { success: false as const, error: message };
-	}
-}
-
-export async function getUserByIdAction(userId: string) {
-	try {
-		await requireSession();
-		const user = await prisma.user.findUniqueOrThrow({
-			where: { id: userId },
-			include: { department: true },
-		});
-		return { success: true as const, data: user };
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "User not found";
 		return { success: false as const, error: message };
 	}
 }

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -90,7 +90,6 @@ export async function createUserAction(formData: unknown) {
 					position: rest.position,
 					branch: rest.branch ?? null,
 					departmentId: rest.departmentId ?? null,
-					isActive: rest.isActive,
 					hireDate: rest.hireDate ?? null,
 					birthday: rest.birthday ?? null,
 				},
@@ -166,19 +165,79 @@ export async function updateUserAction(userId: string, formData: unknown) {
 	}
 }
 
-export async function toggleUserActiveAction(userId: string) {
+export async function softDeleteUserAction(userId: string) {
 	try {
-		await requireRole("ADMIN");
-		const user = await prisma.user.findUniqueOrThrow({ where: { id: userId } });
-		const updated = await prisma.user.update({
+		const session = await requireRole("ADMIN");
+
+		if (userId === session.user.id) {
+			return { success: false as const, error: "You cannot delete your own account" };
+		}
+
+		const target = await prisma.user.findUnique({
 			where: { id: userId },
-			data: { isActive: !user.isActive },
+			select: { id: true, role: true, deletedAt: true },
+		});
+
+		if (!target) {
+			return { success: false as const, error: "User not found" };
+		}
+
+		if (target.deletedAt !== null) {
+			return { success: false as const, error: "User is already deleted" };
+		}
+
+		if (target.role === "SUPERADMIN") {
+			const activeSuperadmins = await prisma.user.count({
+				where: { role: "SUPERADMIN", deletedAt: null },
+			});
+			if (activeSuperadmins <= 1) {
+				return { success: false as const, error: "Cannot delete the last super admin" };
+			}
+		}
+
+		const updated = await prisma.$transaction(async (tx) => {
+			const user = await tx.user.update({
+				where: { id: userId },
+				data: { deletedAt: new Date(), deletedById: session.user.id },
+			});
+			await tx.session.deleteMany({ where: { userId } });
+			return user;
 		});
 
 		revalidatePath("/dashboard/users");
 		return { success: true as const, data: updated };
 	} catch (error) {
-		const message = error instanceof Error ? error.message : "Failed to update user status";
+		const message = error instanceof Error ? error.message : "Failed to delete user";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function restoreUserAction(userId: string) {
+	try {
+		await requireRole("ADMIN");
+
+		const target = await prisma.user.findUnique({
+			where: { id: userId },
+			select: { deletedAt: true },
+		});
+
+		if (!target) {
+			return { success: false as const, error: "User not found" };
+		}
+
+		if (target.deletedAt === null) {
+			return { success: false as const, error: "User is not deleted" };
+		}
+
+		const updated = await prisma.user.update({
+			where: { id: userId },
+			data: { deletedAt: null, deletedById: null },
+		});
+
+		revalidatePath("/dashboard/users");
+		return { success: true as const, data: updated };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to restore user";
 		return { success: false as const, error: message };
 	}
 }
@@ -187,6 +246,7 @@ export async function getUsersAction() {
 	try {
 		await requireRole("ADMIN");
 		const users = await prisma.user.findMany({
+			where: { deletedAt: null },
 			include: { department: true },
 			orderBy: { createdAt: "desc" },
 		});

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -15,7 +15,6 @@ export const authClient = createAuthClient({
 				position: { type: "string", required: false },
 				avatar: { type: "string", required: false },
 				role: { type: "string", required: false },
-				isActive: { type: "boolean", required: false },
 				departmentId: { type: "string", required: false },
 			},
 		}),

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -19,10 +19,10 @@ export async function requireSession() {
 	}
 	const user = await prisma.user.findUnique({
 		where: { id: session.user.id },
-		select: { isActive: true },
+		select: { deletedAt: true },
 	});
-	if (!user?.isActive) {
-		throw new Error("Account deactivated");
+	if (!user || user.deletedAt !== null) {
+		throw new Error("Account removed");
 	}
 	return session;
 }

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -5,6 +5,15 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { hasMinRole } from "@/lib/permissions";
 
+export class AuthError extends Error {
+	readonly status: 401 | 403;
+	constructor(message: string, status: 401 | 403) {
+		super(message);
+		this.name = "AuthError";
+		this.status = status;
+	}
+}
+
 export const getServerSession = cache(async () => {
 	const session = await auth.api.getSession({
 		headers: await headers(),
@@ -15,14 +24,14 @@ export const getServerSession = cache(async () => {
 export async function requireSession() {
 	const session = await getServerSession();
 	if (!session) {
-		throw new Error("Unauthorized");
+		throw new AuthError("Unauthorized", 401);
 	}
 	const user = await prisma.user.findUnique({
 		where: { id: session.user.id },
 		select: { deletedAt: true },
 	});
 	if (!user || user.deletedAt !== null) {
-		throw new Error("Account removed");
+		throw new AuthError("Account removed", 401);
 	}
 	return session;
 }
@@ -30,7 +39,7 @@ export async function requireSession() {
 export async function requireRole(minimumRole: "ADMIN" | "SUPERADMIN") {
 	const session = await requireSession();
 	if (!hasMinRole(session.user.role as Role, minimumRole)) {
-		throw new Error("Forbidden");
+		throw new AuthError("Forbidden", 403);
 	}
 	return session;
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -79,11 +79,6 @@ export const auth = betterAuth({
 				defaultValue: "STAFF",
 				input: false,
 			},
-			isActive: {
-				type: "boolean",
-				defaultValue: true,
-				input: false,
-			},
 			departmentId: {
 				type: "string",
 				required: false,

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -5,7 +5,7 @@ export interface ExportUser {
 	role: string;
 	position: string | null;
 	branch: string | null;
-	isActive: boolean;
+	deletedAt: Date | string | null;
 	department: { name: string } | null;
 }
 
@@ -36,7 +36,7 @@ export function generateUserCsv(users: ExportUser[]): string {
 		user.department?.name ?? "",
 		user.branch ?? "",
 		user.position ?? "",
-		user.isActive ? "Active" : "Inactive",
+		user.deletedAt ? "Deleted" : "Active",
 	]);
 
 	const lines = [CSV_HEADERS.join(","), ...rows.map((row) => row.map(escapeCsvField).join(","))];

--- a/lib/validations/user.ts
+++ b/lib/validations/user.ts
@@ -143,7 +143,6 @@ export const createUserSchema = z.object({
 	branch: z.enum(["ISO", "PERTH"]).nullable().optional(),
 	role: z.enum(["STAFF", "ADMIN", "SUPERADMIN"]),
 	departmentId: z.string().nullable().optional(),
-	isActive: z.boolean().default(true),
 	hireDate: z.coerce.date().nullable().optional(),
 	birthday: z.coerce.date().nullable().optional(),
 	shiftSchedule: shiftScheduleSchema.nullable().optional(),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"lint": "bunx @biomejs/biome check .",
 		"lint:fix": "bunx @biomejs/biome check --fix .",
 		"format": "bunx @biomejs/biome format --write .",
-		"db:push": "bunx prisma db push",
+		"db:push": "bunx prisma db push && bunx prisma db execute --file ./scripts/pre-deploy.sql",
 		"db:seed": "bunx prisma db seed",
 		"db:studio": "bunx prisma studio",
 		"test": "bun test",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev --turbopack",
-		"build": "prisma generate && prisma db execute --file ./scripts/pre-deploy.sql && prisma db push --accept-data-loss && next build",
+		"build": "prisma generate && prisma db execute --file ./scripts/pre-deploy.sql && prisma db push && next build",
 		"start": "next start",
 		"postinstall": "prisma generate",
 		"lint": "bunx @biomejs/biome check .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev --turbopack",
-		"build": "prisma generate && prisma db push && next build",
+		"build": "prisma generate && prisma db execute --file ./scripts/pre-deploy.sql && prisma db push --accept-data-loss && next build",
 		"start": "next start",
 		"postinstall": "prisma generate",
 		"lint": "bunx @biomejs/biome check .",

--- a/prisma/insert-hr-admins.ts
+++ b/prisma/insert-hr-admins.ts
@@ -108,7 +108,6 @@ async function insertHrAdmins() {
 				branch: "ISO",
 				departmentId: hrDepartment.id,
 				position: userData.position,
-				isActive: true,
 			},
 		});
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,10 +40,11 @@ model User {
   avatar        String?
   role          Role      @default(STAFF)
   branch        Branch?   @map("branch")
-  isActive      Boolean   @default(true) @map("is_active")
   departmentId  String?   @map("department_id")
   hireDate      DateTime? @map("hire_date") @db.Date
   birthday      DateTime? @map("birthday") @db.Date
+  deletedAt     DateTime? @map("deleted_at")
+  deletedById   String?   @map("deleted_by_id")
   createdAt     DateTime  @default(now()) @map("created_at")
   updatedAt     DateTime  @updatedAt @map("updated_at")
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,9 @@ model User {
   departmentId  String?   @map("department_id")
   hireDate      DateTime? @map("hire_date") @db.Date
   birthday      DateTime? @map("birthday") @db.Date
+  /// Deprecated: superseded by deletedAt. Retained until a follow-up
+  /// migration can drop the column after this release stabilises in prod.
+  isActive      Boolean   @default(true) @map("is_active")
   deletedAt     DateTime? @map("deleted_at")
   deletedById   String?   @map("deleted_by_id")
   createdAt     DateTime  @default(now()) @map("created_at")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -172,7 +172,6 @@ async function seed() {
 				branch: userData.branch,
 				departmentId: userData.departmentId,
 				position: userData.position ?? null,
-				isActive: true,
 			},
 		});
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -38,9 +38,9 @@ export async function proxy(request: NextRequest) {
 		}
 		const user = await prisma.user.findUnique({
 			where: { id: session.user.id },
-			select: { isActive: true },
+			select: { deletedAt: true },
 		});
-		if (!user?.isActive) {
+		if (!user || user.deletedAt !== null) {
 			const response = NextResponse.redirect(new URL("/login", request.url));
 			response.cookies.delete(sessionToken.name);
 			return response;

--- a/scripts/pre-deploy.sql
+++ b/scripts/pre-deploy.sql
@@ -1,0 +1,15 @@
+-- One-time pre-deploy migration for PR #64 (soft-delete users).
+-- Idempotent: safe to re-run. Becomes a no-op once `is_active` is dropped.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'users' AND column_name = 'is_active'
+  ) THEN
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP(3);
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_by_id TEXT;
+    UPDATE users SET deleted_at = NOW()
+      WHERE is_active = false AND deleted_at IS NULL;
+  END IF;
+END $$;

--- a/scripts/pre-deploy.sql
+++ b/scripts/pre-deploy.sql
@@ -1,5 +1,7 @@
--- One-time pre-deploy migration for PR #64 (soft-delete users).
--- Idempotent: safe to re-run. Becomes a no-op once `is_active` is dropped.
+-- Pre-deploy sync between legacy `is_active` and new `deleted_at`.
+-- Idempotent and safe to re-run. `is_active` is kept for one release as
+-- a backwards-compat column (see schema.prisma); a follow-up migration
+-- will drop it once this release is stable in prod.
 
 DO $$
 BEGIN
@@ -9,7 +11,12 @@ BEGIN
   ) THEN
     ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP(3);
     ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_by_id TEXT;
+
+    -- Mirror either column into the other so old and new readers agree
+    -- during the deploy window.
     UPDATE users SET deleted_at = NOW()
       WHERE is_active = false AND deleted_at IS NULL;
+    UPDATE users SET is_active = false
+      WHERE deleted_at IS NOT NULL AND is_active = true;
   END IF;
 END $$;

--- a/scripts/pre-deploy.sql
+++ b/scripts/pre-deploy.sql
@@ -1,7 +1,8 @@
 -- Pre-deploy sync between legacy `is_active` and new `deleted_at`.
 -- Idempotent and safe to re-run. `is_active` is kept for one release as
 -- a backwards-compat column (see schema.prisma); a follow-up migration
--- will drop it once this release is stable in prod.
+-- will drop both the column and this trigger once the release is stable
+-- in prod.
 
 DO $$
 BEGIN
@@ -12,11 +13,40 @@ BEGIN
     ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP(3);
     ALTER TABLE users ADD COLUMN IF NOT EXISTS deleted_by_id TEXT;
 
-    -- Mirror either column into the other so old and new readers agree
-    -- during the deploy window.
+    -- One-time backfill so existing rows agree before the trigger takes over.
     UPDATE users SET deleted_at = NOW()
       WHERE is_active = false AND deleted_at IS NULL;
     UPDATE users SET is_active = false
       WHERE deleted_at IS NOT NULL AND is_active = true;
+  END IF;
+END $$;
+
+-- Keep both columns in sync for the duration of the deploy window.
+-- The old release toggles `is_active` only; the new release writes both
+-- but we still want defence-in-depth in case a code path is missed.
+-- Drop this trigger in the same follow-up PR that drops `is_active`.
+CREATE OR REPLACE FUNCTION users_sync_deleted_active() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.is_active = false AND NEW.deleted_at IS NULL THEN
+    NEW.deleted_at := NOW();
+  ELSIF NEW.is_active = true AND NEW.deleted_at IS NOT NULL THEN
+    NEW.deleted_at := NULL;
+    NEW.deleted_by_id := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'users' AND column_name = 'is_active'
+  ) THEN
+    DROP TRIGGER IF EXISTS users_sync_deleted_active_trigger ON users;
+    CREATE TRIGGER users_sync_deleted_active_trigger
+      BEFORE INSERT OR UPDATE OF is_active, deleted_at ON users
+      FOR EACH ROW
+      EXECUTE FUNCTION users_sync_deleted_active();
   END IF;
 END $$;


### PR DESCRIPTION
Closes #63.

## Summary
- Replace the separate "deactivate" and "delete" concepts with a single soft-delete state on `User` (`deletedAt`, `deletedById`).
- Deleted users are blocked at proxy/session layer, hidden from the default staff directory, and excluded from the recognition recipient picker. Historical recognition cards still resolve their names normally.
- Admins get a trash action with an `AlertDialog` confirmation, a "Show deleted" filter toggle, and a Restore action.

## Notes
- Guards: can't self-delete; can't delete the last SUPERADMIN; existing sessions are revoked on delete.
- `?includeDeleted=true` escape hatch on `GET /api/users` for the "Show deleted" toggle.
- `department` delete-count now ignores deleted users.
- Existing dev DB: one previously-deactivated user was migrated to `deletedAt = now()` before the column drop.

## Test plan
- [ ] Log in as admin, go to `/dashboard/users`, delete a user → row disappears, toast shows success, user gets logged out.
- [ ] Toggle "Show deleted" → deleted user reappears (muted) with a Restore action.
- [ ] Restore → user returns to the default list and can log in again.
- [ ] Try to delete yourself → blocked with error toast.
- [ ] Try to delete the last SUPERADMIN → blocked with error toast.
- [ ] Send a recognition card → recipient picker does not list deleted users.
- [ ] View an old recognition card whose sender or recipient is deleted → still renders their name.