### PR TITLE
feat(auth): sync Microsoft profile photo to avatar on first signup

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
+import { after } from "next/server";
 import { env } from "@/env";
 import { prisma } from "@/lib/db";
 import { syncMicrosoftAvatar } from "@/lib/microsoft-avatar";
@@ -50,12 +51,21 @@ export const auth = betterAuth({
 				after: async (account) => {
 					if (account.providerId !== "microsoft" || !account.accessToken) return;
 					const { userId, accessToken } = account;
-					void syncMicrosoftAvatar(userId, accessToken).catch((err) => {
-						console.error("Microsoft avatar sync failed", {
-							userId,
-							error: err instanceof Error ? err.message : String(err),
+					const run = () =>
+						syncMicrosoftAvatar(userId, accessToken).catch((err) => {
+							console.error("Microsoft avatar sync failed", {
+								userId,
+								error: err instanceof Error ? err.message : String(err),
+							});
 						});
-					});
+					// next/server `after` uses Vercel's waitUntil so the serverless
+					// invocation stays alive until the sync completes. Falls back to
+					// awaiting inline when called outside a request (e.g. seed scripts).
+					try {
+						after(run);
+					} catch {
+						await run();
+					}
 				},
 			},
 		},

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,6 +2,7 @@ import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { env } from "@/env";
 import { prisma } from "@/lib/db";
+import { syncMicrosoftAvatar } from "@/lib/microsoft-avatar";
 
 const socialProviders: Record<string, unknown> = {
 	google: {
@@ -20,6 +21,7 @@ if (env.MICROSOFT_CLIENT_ID && env.MICROSOFT_CLIENT_SECRET) {
 		clientId: env.MICROSOFT_CLIENT_ID,
 		clientSecret: env.MICROSOFT_CLIENT_SECRET,
 		tenantId: env.MICROSOFT_TENANT_ID ?? "common",
+		scope: ["User.Read", "openid", "profile", "email"],
 		mapProfileToUser: (profile: { given_name: string; family_name: string }) => ({
 			firstName: profile.given_name,
 			lastName: profile.family_name,
@@ -40,6 +42,22 @@ export const auth = betterAuth({
 		accountLinking: {
 			enabled: true,
 			trustedProviders: ["google", "microsoft"],
+		},
+	},
+	databaseHooks: {
+		account: {
+			create: {
+				after: async (account) => {
+					if (account.providerId !== "microsoft" || !account.accessToken) return;
+					const { userId, accessToken } = account;
+					void syncMicrosoftAvatar(userId, accessToken).catch((err) => {
+						console.error("Microsoft avatar sync failed", {
+							userId,
+							error: err instanceof Error ? err.message : String(err),
+						});
+					});
+				},
+			},
 		},
 	},
 	user: {

--- a/lib/microsoft-avatar.ts
+++ b/lib/microsoft-avatar.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/db";
-import { getAvatarKey, getPublicUrl, uploadToR2 } from "@/lib/r2";
+import { deleteFromR2, getAvatarKey, getPublicUrl, uploadToR2 } from "@/lib/r2";
 
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
 const MAX_SIZE = 2_000_000;
@@ -27,8 +27,15 @@ export async function syncMicrosoftAvatar(userId: string, accessToken: string): 
 	const key = getAvatarKey(userId, contentType);
 	await uploadToR2(key, buffer, contentType);
 
-	await prisma.user.update({
-		where: { id: userId },
+	// Conditional update: only writes if avatar is still null. If the user
+	// uploaded a custom avatar while we were fetching from Graph, count === 0
+	// and we clean up the orphaned R2 object. Guarantees manual upload wins.
+	const result = await prisma.user.updateMany({
+		where: { id: userId, avatar: null },
 		data: { avatar: getPublicUrl(key) },
 	});
+
+	if (result.count === 0) {
+		await deleteFromR2(key).catch(() => {});
+	}
 }

--- a/lib/microsoft-avatar.ts
+++ b/lib/microsoft-avatar.ts
@@ -1,0 +1,34 @@
+import { prisma } from "@/lib/db";
+import { getAvatarKey, getPublicUrl, uploadToR2 } from "@/lib/r2";
+
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const MAX_SIZE = 2_000_000;
+const GRAPH_PHOTO_URL = "https://graph.microsoft.com/v1.0/me/photo/$value";
+
+export async function syncMicrosoftAvatar(userId: string, accessToken: string): Promise<void> {
+	const user = await prisma.user.findUnique({
+		where: { id: userId },
+		select: { avatar: true },
+	});
+	if (!user || user.avatar) return;
+
+	const res = await fetch(GRAPH_PHOTO_URL, {
+		headers: { Authorization: `Bearer ${accessToken}` },
+	});
+	if (!res.ok) return;
+
+	const rawContentType = res.headers.get("content-type") ?? "image/jpeg";
+	const contentType = rawContentType.split(";")[0]?.trim() ?? "image/jpeg";
+	if (!ALLOWED_TYPES.includes(contentType)) return;
+
+	const buffer = Buffer.from(await res.arrayBuffer());
+	if (buffer.byteLength === 0 || buffer.byteLength > MAX_SIZE) return;
+
+	const key = getAvatarKey(userId, contentType);
+	await uploadToR2(key, buffer, contentType);
+
+	await prisma.user.update({
+		where: { id: userId },
+		data: { avatar: getPublicUrl(key) },
+	});
+}

--- a/lib/microsoft-avatar.ts
+++ b/lib/microsoft-avatar.ts
@@ -27,15 +27,20 @@ export async function syncMicrosoftAvatar(userId: string, accessToken: string): 
 	const key = getAvatarKey(userId, contentType);
 	await uploadToR2(key, buffer, contentType);
 
-	// Conditional update: only writes if avatar is still null. If the user
-	// uploaded a custom avatar while we were fetching from Graph, count === 0
-	// and we clean up the orphaned R2 object. Guarantees manual upload wins.
-	const result = await prisma.user.updateMany({
-		where: { id: userId, avatar: null },
-		data: { avatar: getPublicUrl(key) },
-	});
+	// Conditional update: only writes if avatar is still null, so a manual
+	// upload that landed during the Graph fetch always wins. Any failure path
+	// after uploadToR2 must clean up the R2 object to avoid orphaned blobs.
+	try {
+		const result = await prisma.user.updateMany({
+			where: { id: userId, avatar: null },
+			data: { avatar: getPublicUrl(key) },
+		});
 
-	if (result.count === 0) {
+		if (result.count === 0) {
+			await deleteFromR2(key).catch(() => {});
+		}
+	} catch (err) {
 		await deleteFromR2(key).catch(() => {});
+		throw err;
 	}
 }


### PR DESCRIPTION
Closes #67

## Summary
- Fetch Microsoft profile photo via Graph `/me/photo/$value` on first OAuth signup and store it in R2 as the user's avatar.
- First-signup-only: gated on `users.avatar === NULL`, so later manual uploads via `/dashboard/profile` are never overwritten.
- Fire-and-forget inside `databaseHooks.account.create.after` — login redirect latency is unaffected.
- Added `User.Read` scope to the Microsoft provider (required for Graph `/me/photo`).

## Regression prevention
- **Provider gate** (`providerId !== "microsoft"`) keeps Google / email-password flows untouched.
- **Idempotency gate** (`if (user.avatar) return`) ensures re-signin / account re-link never clobbers an uploaded photo.
- **Fail-open**: Graph 404 (no photo), 403 (scope not granted), R2 unconfigured, or non-image content are all silently skipped — signup still succeeds.
- **Same URL shape** as manual uploads (`getPublicUrl(getAvatarKey(...))`), so all avatar consumers (header, recognition feed, leaderboard, emails) work unchanged.
- **Existing upload route unchanged** (`app/api/upload/avatar/route.ts`). Its delete-old-key logic automatically cleans up a Microsoft-sourced R2 object if the user later uploads their own.
- **No schema / migration** — reuses `users.avatar`.
- **No token logging** — `accessToken` is used only in-memory.
- **Soft 2MB cap** on the fetched blob to avoid abusive payloads.

## Test plan
- [ ] Email/password signup: no Microsoft calls made, works as before.
- [ ] Google signup: no Microsoft calls made, works as before.
- [ ] Fresh Microsoft signup with a profile photo → avatar populated within a few seconds, renders in header.
- [ ] Microsoft signup without a profile photo → signup succeeds, `users.avatar` stays `NULL`, no user-visible error.
- [ ] Upload a custom avatar → sign out → re-signin via Microsoft → custom avatar preserved.
- [ ] Manual upload after Microsoft-synced avatar → old R2 key deleted, new one stored.
- [ ] Azure app registration has `User.Read` delegated permission granted (otherwise Graph returns 403 and hook fails gracefully).
- [x] `bun run lint` clean.