### PR TITLE
fix(settings): invalidate setting caches across bundles via globalThis

### DIFF
--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -32,41 +32,57 @@ const TOP_RECOGNIZED_KEY = "top_recognized_limit";
 // Server Action invalidates a different cache instance than the one readers
 // (Route Handlers, Server Components) actually consult, leaking stale data for
 // up to CACHE_TTL_MS after a settings change.
+//
+// `generation` guards against a read/invalidate race: a reader captures the
+// generation before awaiting the DB, and only publishes its result back into
+// the shared cache if no invalidation happened during the await. Without this,
+// an in-flight reader holding pre-update data would re-poison the cache right
+// after an admin invalidates it.
+type CacheEntry<T> = { data: T | null; expiry: number; generation: number };
 const globalForSettingsCache = globalThis as unknown as {
-	oauthCache: { data: OAuthSettings | null; expiry: number };
-	topLimitCache: { data: number | null; expiry: number };
-	leaderboardCache: { data: LeaderboardVisibilitySettings | null; expiry: number };
+	oauthCache: CacheEntry<OAuthSettings>;
+	topLimitCache: CacheEntry<number>;
+	leaderboardCache: CacheEntry<LeaderboardVisibilitySettings>;
 };
-globalForSettingsCache.oauthCache ??= { data: null, expiry: 0 };
-globalForSettingsCache.topLimitCache ??= { data: null, expiry: 0 };
-globalForSettingsCache.leaderboardCache ??= { data: null, expiry: 0 };
+globalForSettingsCache.oauthCache ??= { data: null, expiry: 0, generation: 0 };
+globalForSettingsCache.topLimitCache ??= { data: null, expiry: 0, generation: 0 };
+globalForSettingsCache.leaderboardCache ??= { data: null, expiry: 0, generation: 0 };
 const oauthCache = globalForSettingsCache.oauthCache;
 const topLimitCache = globalForSettingsCache.topLimitCache;
 const leaderboardCache = globalForSettingsCache.leaderboardCache;
+
+function invalidate<T>(entry: CacheEntry<T>): void {
+	entry.data = null;
+	entry.expiry = 0;
+	entry.generation += 1;
+}
 
 export async function getOAuthSettings(): Promise<OAuthSettings> {
 	if (oauthCache.data && Date.now() < oauthCache.expiry) {
 		return oauthCache.data;
 	}
 
+	const generation = oauthCache.generation;
 	const settings = await prisma.appSetting.findMany({
 		where: { key: { in: [...OAUTH_KEYS] } },
 	});
 
 	const map = new Map(settings.map((s) => [s.key, s.value]));
-
-	oauthCache.data = {
+	const fresh: OAuthSettings = {
 		oauth_google_enabled: map.get("oauth_google_enabled") !== "false",
 		oauth_microsoft_enabled: map.get("oauth_microsoft_enabled") !== "false",
 	};
-	oauthCache.expiry = Date.now() + CACHE_TTL_MS;
 
-	return oauthCache.data;
+	if (oauthCache.generation === generation) {
+		oauthCache.data = fresh;
+		oauthCache.expiry = Date.now() + CACHE_TTL_MS;
+	}
+
+	return fresh;
 }
 
 function invalidateOAuthCache() {
-	oauthCache.data = null;
-	oauthCache.expiry = 0;
+	invalidate(oauthCache);
 }
 
 export async function getOAuthProviderAvailability() {
@@ -104,8 +120,7 @@ export async function updateOAuthSetting(
 /* ── Top Recognized Limit ────────────────────────────── */
 
 function invalidateTopLimitCache() {
-	topLimitCache.data = null;
-	topLimitCache.expiry = 0;
+	invalidate(topLimitCache);
 }
 
 export async function getTopRecognizedLimit(): Promise<number> {
@@ -113,18 +128,23 @@ export async function getTopRecognizedLimit(): Promise<number> {
 		return topLimitCache.data;
 	}
 
+	const generation = topLimitCache.generation;
 	const row = await prisma.appSetting.findUnique({
 		where: { key: TOP_RECOGNIZED_KEY },
 	});
 
 	const parsed = row ? Number.parseInt(row.value, 10) : Number.NaN;
-	topLimitCache.data =
+	const fresh =
 		Number.isNaN(parsed) || parsed < TOP_RECOGNIZED_MIN || parsed > TOP_RECOGNIZED_MAX
 			? TOP_RECOGNIZED_DEFAULT
 			: parsed;
-	topLimitCache.expiry = Date.now() + CACHE_TTL_MS;
 
-	return topLimitCache.data;
+	if (topLimitCache.generation === generation) {
+		topLimitCache.data = fresh;
+		topLimitCache.expiry = Date.now() + CACHE_TTL_MS;
+	}
+
+	return fresh;
 }
 
 export async function updateTopRecognizedLimit(
@@ -168,8 +188,7 @@ const LEADERBOARD_KEYS = [
 ];
 
 function invalidateLeaderboardCache() {
-	leaderboardCache.data = null;
-	leaderboardCache.expiry = 0;
+	invalidate(leaderboardCache);
 }
 
 function isValidIsoDate(value: string): boolean {
@@ -188,6 +207,7 @@ export async function getLeaderboardVisibilitySettings(): Promise<LeaderboardVis
 		return leaderboardCache.data;
 	}
 
+	const generation = leaderboardCache.generation;
 	const rows = await prisma.appSetting.findMany({
 		where: { key: { in: LEADERBOARD_KEYS } },
 	});
@@ -205,15 +225,19 @@ export async function getLeaderboardVisibilitySettings(): Promise<LeaderboardVis
 	const rawStart = map.get(LEADERBOARD_CUSTOM_START_KEY) ?? null;
 	const rawEnd = map.get(LEADERBOARD_CUSTOM_END_KEY) ?? null;
 
-	leaderboardCache.data = {
+	const fresh: LeaderboardVisibilitySettings = {
 		mode,
 		revealDays,
 		customStart: rawStart && isValidIsoDate(rawStart) ? rawStart : null,
 		customEnd: rawEnd && isValidIsoDate(rawEnd) ? rawEnd : null,
 	};
-	leaderboardCache.expiry = Date.now() + CACHE_TTL_MS;
 
-	return leaderboardCache.data;
+	if (leaderboardCache.generation === generation) {
+		leaderboardCache.data = fresh;
+		leaderboardCache.expiry = Date.now() + CACHE_TTL_MS;
+	}
+
+	return fresh;
 }
 
 export interface UpdateLeaderboardVisibilityInput {

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -22,18 +22,31 @@ type OAuthKey = (typeof OAUTH_KEYS)[number];
 
 export type OAuthSettings = Record<OAuthKey, boolean>;
 
-let cachedSettings: OAuthSettings | null = null;
-let cacheExpiry = 0;
 const CACHE_TTL_MS = 30_000;
 
 const TOP_RECOGNIZED_KEY = "top_recognized_limit";
 
-let cachedTopLimit: number | null = null;
-let topLimitCacheExpiry = 0;
+// Caches live on globalThis so they behave as a true process-wide singleton.
+// Server Actions and Route Handlers can land in separate bundles with distinct
+// module-scoped variables — a plain module-level `let` would mean the admin
+// Server Action invalidates a different cache instance than the one readers
+// (Route Handlers, Server Components) actually consult, leaking stale data for
+// up to CACHE_TTL_MS after a settings change.
+const globalForSettingsCache = globalThis as unknown as {
+	oauthCache: { data: OAuthSettings | null; expiry: number };
+	topLimitCache: { data: number | null; expiry: number };
+	leaderboardCache: { data: LeaderboardVisibilitySettings | null; expiry: number };
+};
+globalForSettingsCache.oauthCache ??= { data: null, expiry: 0 };
+globalForSettingsCache.topLimitCache ??= { data: null, expiry: 0 };
+globalForSettingsCache.leaderboardCache ??= { data: null, expiry: 0 };
+const oauthCache = globalForSettingsCache.oauthCache;
+const topLimitCache = globalForSettingsCache.topLimitCache;
+const leaderboardCache = globalForSettingsCache.leaderboardCache;
 
 export async function getOAuthSettings(): Promise<OAuthSettings> {
-	if (cachedSettings && Date.now() < cacheExpiry) {
-		return cachedSettings;
+	if (oauthCache.data && Date.now() < oauthCache.expiry) {
+		return oauthCache.data;
 	}
 
 	const settings = await prisma.appSetting.findMany({
@@ -42,18 +55,18 @@ export async function getOAuthSettings(): Promise<OAuthSettings> {
 
 	const map = new Map(settings.map((s) => [s.key, s.value]));
 
-	cachedSettings = {
+	oauthCache.data = {
 		oauth_google_enabled: map.get("oauth_google_enabled") !== "false",
 		oauth_microsoft_enabled: map.get("oauth_microsoft_enabled") !== "false",
 	};
-	cacheExpiry = Date.now() + CACHE_TTL_MS;
+	oauthCache.expiry = Date.now() + CACHE_TTL_MS;
 
-	return cachedSettings;
+	return oauthCache.data;
 }
 
 function invalidateOAuthCache() {
-	cachedSettings = null;
-	cacheExpiry = 0;
+	oauthCache.data = null;
+	oauthCache.expiry = 0;
 }
 
 export async function getOAuthProviderAvailability() {
@@ -91,13 +104,13 @@ export async function updateOAuthSetting(
 /* ── Top Recognized Limit ────────────────────────────── */
 
 function invalidateTopLimitCache() {
-	cachedTopLimit = null;
-	topLimitCacheExpiry = 0;
+	topLimitCache.data = null;
+	topLimitCache.expiry = 0;
 }
 
 export async function getTopRecognizedLimit(): Promise<number> {
-	if (cachedTopLimit !== null && Date.now() < topLimitCacheExpiry) {
-		return cachedTopLimit;
+	if (topLimitCache.data !== null && Date.now() < topLimitCache.expiry) {
+		return topLimitCache.data;
 	}
 
 	const row = await prisma.appSetting.findUnique({
@@ -105,13 +118,13 @@ export async function getTopRecognizedLimit(): Promise<number> {
 	});
 
 	const parsed = row ? Number.parseInt(row.value, 10) : Number.NaN;
-	cachedTopLimit =
+	topLimitCache.data =
 		Number.isNaN(parsed) || parsed < TOP_RECOGNIZED_MIN || parsed > TOP_RECOGNIZED_MAX
 			? TOP_RECOGNIZED_DEFAULT
 			: parsed;
-	topLimitCacheExpiry = Date.now() + CACHE_TTL_MS;
+	topLimitCache.expiry = Date.now() + CACHE_TTL_MS;
 
-	return cachedTopLimit;
+	return topLimitCache.data;
 }
 
 export async function updateTopRecognizedLimit(
@@ -154,12 +167,9 @@ const LEADERBOARD_KEYS = [
 	LEADERBOARD_CUSTOM_END_KEY,
 ];
 
-let cachedLeaderboard: LeaderboardVisibilitySettings | null = null;
-let leaderboardCacheExpiry = 0;
-
 function invalidateLeaderboardCache() {
-	cachedLeaderboard = null;
-	leaderboardCacheExpiry = 0;
+	leaderboardCache.data = null;
+	leaderboardCache.expiry = 0;
 }
 
 function isValidIsoDate(value: string): boolean {
@@ -174,8 +184,8 @@ function isLeaderboardMode(value: string): value is LeaderboardVisibilityMode {
 }
 
 export async function getLeaderboardVisibilitySettings(): Promise<LeaderboardVisibilitySettings> {
-	if (cachedLeaderboard && Date.now() < leaderboardCacheExpiry) {
-		return cachedLeaderboard;
+	if (leaderboardCache.data && Date.now() < leaderboardCache.expiry) {
+		return leaderboardCache.data;
 	}
 
 	const rows = await prisma.appSetting.findMany({
@@ -195,15 +205,15 @@ export async function getLeaderboardVisibilitySettings(): Promise<LeaderboardVis
 	const rawStart = map.get(LEADERBOARD_CUSTOM_START_KEY) ?? null;
 	const rawEnd = map.get(LEADERBOARD_CUSTOM_END_KEY) ?? null;
 
-	cachedLeaderboard = {
+	leaderboardCache.data = {
 		mode,
 		revealDays,
 		customStart: rawStart && isValidIsoDate(rawStart) ? rawStart : null,
 		customEnd: rawEnd && isValidIsoDate(rawEnd) ? rawEnd : null,
 	};
-	leaderboardCacheExpiry = Date.now() + CACHE_TTL_MS;
+	leaderboardCache.expiry = Date.now() + CACHE_TTL_MS;
 
-	return cachedLeaderboard;
+	return leaderboardCache.data;
 }
 
 export interface UpdateLeaderboardVisibilityInput {

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -2,6 +2,11 @@
 
 import { env } from "@/env";
 import { requireRole } from "@/lib/auth-utils";
+import {
+	getOrCreateGlobalEntry,
+	invalidateEntry,
+	readThroughCache,
+} from "@/lib/cache/settings-cache";
 import { prisma } from "@/lib/db";
 import {
 	TOP_RECOGNIZED_DEFAULT,
@@ -26,63 +31,29 @@ const CACHE_TTL_MS = 30_000;
 
 const TOP_RECOGNIZED_KEY = "top_recognized_limit";
 
-// Caches live on globalThis so they behave as a true process-wide singleton.
-// Server Actions and Route Handlers can land in separate bundles with distinct
-// module-scoped variables — a plain module-level `let` would mean the admin
-// Server Action invalidates a different cache instance than the one readers
-// (Route Handlers, Server Components) actually consult, leaking stale data for
-// up to CACHE_TTL_MS after a settings change.
-//
-// `generation` guards against a read/invalidate race: a reader captures the
-// generation before awaiting the DB, and only publishes its result back into
-// the shared cache if no invalidation happened during the await. Without this,
-// an in-flight reader holding pre-update data would re-poison the cache right
-// after an admin invalidates it.
-type CacheEntry<T> = { data: T | null; expiry: number; generation: number };
-const globalForSettingsCache = globalThis as unknown as {
-	oauthCache: CacheEntry<OAuthSettings>;
-	topLimitCache: CacheEntry<number>;
-	leaderboardCache: CacheEntry<LeaderboardVisibilitySettings>;
-};
-globalForSettingsCache.oauthCache ??= { data: null, expiry: 0, generation: 0 };
-globalForSettingsCache.topLimitCache ??= { data: null, expiry: 0, generation: 0 };
-globalForSettingsCache.leaderboardCache ??= { data: null, expiry: 0, generation: 0 };
-const oauthCache = globalForSettingsCache.oauthCache;
-const topLimitCache = globalForSettingsCache.topLimitCache;
-const leaderboardCache = globalForSettingsCache.leaderboardCache;
-
-function invalidate<T>(entry: CacheEntry<T>): void {
-	entry.data = null;
-	entry.expiry = 0;
-	entry.generation += 1;
-}
+const oauthCache = getOrCreateGlobalEntry<OAuthSettings>("accessGroupStaff.settings.oauth");
+const topLimitCache = getOrCreateGlobalEntry<number>(
+	"accessGroupStaff.settings.topRecognizedLimit",
+);
+const leaderboardCache = getOrCreateGlobalEntry<LeaderboardVisibilitySettings>(
+	"accessGroupStaff.settings.leaderboardVisibility",
+);
 
 export async function getOAuthSettings(): Promise<OAuthSettings> {
-	if (oauthCache.data && Date.now() < oauthCache.expiry) {
-		return oauthCache.data;
-	}
-
-	const generation = oauthCache.generation;
-	const settings = await prisma.appSetting.findMany({
-		where: { key: { in: [...OAUTH_KEYS] } },
+	return readThroughCache(oauthCache, CACHE_TTL_MS, async () => {
+		const settings = await prisma.appSetting.findMany({
+			where: { key: { in: [...OAUTH_KEYS] } },
+		});
+		const map = new Map(settings.map((s) => [s.key, s.value]));
+		return {
+			oauth_google_enabled: map.get("oauth_google_enabled") !== "false",
+			oauth_microsoft_enabled: map.get("oauth_microsoft_enabled") !== "false",
+		};
 	});
-
-	const map = new Map(settings.map((s) => [s.key, s.value]));
-	const fresh: OAuthSettings = {
-		oauth_google_enabled: map.get("oauth_google_enabled") !== "false",
-		oauth_microsoft_enabled: map.get("oauth_microsoft_enabled") !== "false",
-	};
-
-	if (oauthCache.generation === generation) {
-		oauthCache.data = fresh;
-		oauthCache.expiry = Date.now() + CACHE_TTL_MS;
-	}
-
-	return fresh;
 }
 
 function invalidateOAuthCache() {
-	invalidate(oauthCache);
+	invalidateEntry(oauthCache);
 }
 
 export async function getOAuthProviderAvailability() {
@@ -120,31 +91,19 @@ export async function updateOAuthSetting(
 /* ── Top Recognized Limit ────────────────────────────── */
 
 function invalidateTopLimitCache() {
-	invalidate(topLimitCache);
+	invalidateEntry(topLimitCache);
 }
 
 export async function getTopRecognizedLimit(): Promise<number> {
-	if (topLimitCache.data !== null && Date.now() < topLimitCache.expiry) {
-		return topLimitCache.data;
-	}
-
-	const generation = topLimitCache.generation;
-	const row = await prisma.appSetting.findUnique({
-		where: { key: TOP_RECOGNIZED_KEY },
-	});
-
-	const parsed = row ? Number.parseInt(row.value, 10) : Number.NaN;
-	const fresh =
-		Number.isNaN(parsed) || parsed < TOP_RECOGNIZED_MIN || parsed > TOP_RECOGNIZED_MAX
+	return readThroughCache(topLimitCache, CACHE_TTL_MS, async () => {
+		const row = await prisma.appSetting.findUnique({
+			where: { key: TOP_RECOGNIZED_KEY },
+		});
+		const parsed = row ? Number.parseInt(row.value, 10) : Number.NaN;
+		return Number.isNaN(parsed) || parsed < TOP_RECOGNIZED_MIN || parsed > TOP_RECOGNIZED_MAX
 			? TOP_RECOGNIZED_DEFAULT
 			: parsed;
-
-	if (topLimitCache.generation === generation) {
-		topLimitCache.data = fresh;
-		topLimitCache.expiry = Date.now() + CACHE_TTL_MS;
-	}
-
-	return fresh;
+	});
 }
 
 export async function updateTopRecognizedLimit(
@@ -188,7 +147,7 @@ const LEADERBOARD_KEYS = [
 ];
 
 function invalidateLeaderboardCache() {
-	invalidate(leaderboardCache);
+	invalidateEntry(leaderboardCache);
 }
 
 function isValidIsoDate(value: string): boolean {
@@ -203,41 +162,31 @@ function isLeaderboardMode(value: string): value is LeaderboardVisibilityMode {
 }
 
 export async function getLeaderboardVisibilitySettings(): Promise<LeaderboardVisibilitySettings> {
-	if (leaderboardCache.data && Date.now() < leaderboardCache.expiry) {
-		return leaderboardCache.data;
-	}
+	return readThroughCache(leaderboardCache, CACHE_TTL_MS, async () => {
+		const rows = await prisma.appSetting.findMany({
+			where: { key: { in: LEADERBOARD_KEYS } },
+		});
+		const map = new Map(rows.map((r) => [r.key, r.value]));
 
-	const generation = leaderboardCache.generation;
-	const rows = await prisma.appSetting.findMany({
-		where: { key: { in: LEADERBOARD_KEYS } },
+		const rawMode = map.get(LEADERBOARD_MODE_KEY) ?? "always";
+		const mode: LeaderboardVisibilityMode = isLeaderboardMode(rawMode) ? rawMode : "always";
+
+		const parsedDays = Number.parseInt(map.get(LEADERBOARD_DAYS_KEY) ?? "", 10);
+		const revealDays =
+			Number.isFinite(parsedDays) && parsedDays >= REVEAL_DAYS_MIN && parsedDays <= REVEAL_DAYS_MAX
+				? parsedDays
+				: REVEAL_DAYS_DEFAULT;
+
+		const rawStart = map.get(LEADERBOARD_CUSTOM_START_KEY) ?? null;
+		const rawEnd = map.get(LEADERBOARD_CUSTOM_END_KEY) ?? null;
+
+		return {
+			mode,
+			revealDays,
+			customStart: rawStart && isValidIsoDate(rawStart) ? rawStart : null,
+			customEnd: rawEnd && isValidIsoDate(rawEnd) ? rawEnd : null,
+		};
 	});
-	const map = new Map(rows.map((r) => [r.key, r.value]));
-
-	const rawMode = map.get(LEADERBOARD_MODE_KEY) ?? "always";
-	const mode: LeaderboardVisibilityMode = isLeaderboardMode(rawMode) ? rawMode : "always";
-
-	const parsedDays = Number.parseInt(map.get(LEADERBOARD_DAYS_KEY) ?? "", 10);
-	const revealDays =
-		Number.isFinite(parsedDays) && parsedDays >= REVEAL_DAYS_MIN && parsedDays <= REVEAL_DAYS_MAX
-			? parsedDays
-			: REVEAL_DAYS_DEFAULT;
-
-	const rawStart = map.get(LEADERBOARD_CUSTOM_START_KEY) ?? null;
-	const rawEnd = map.get(LEADERBOARD_CUSTOM_END_KEY) ?? null;
-
-	const fresh: LeaderboardVisibilitySettings = {
-		mode,
-		revealDays,
-		customStart: rawStart && isValidIsoDate(rawStart) ? rawStart : null,
-		customEnd: rawEnd && isValidIsoDate(rawEnd) ? rawEnd : null,
-	};
-
-	if (leaderboardCache.generation === generation) {
-		leaderboardCache.data = fresh;
-		leaderboardCache.expiry = Date.now() + CACHE_TTL_MS;
-	}
-
-	return fresh;
 }
 
 export interface UpdateLeaderboardVisibilityInput {

--- a/lib/cache/settings-cache.test.ts
+++ b/lib/cache/settings-cache.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+	type CacheEntry,
+	getOrCreateGlobalEntry,
+	invalidateEntry,
+	readThroughCache,
+} from "./settings-cache";
+
+function resetGlobal(key: string) {
+	(globalThis as unknown as Record<string, unknown>)[key] = undefined;
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+describe("getOrCreateGlobalEntry", () => {
+	const KEY = "test.settings.create";
+
+	beforeEach(() => resetGlobal(KEY));
+
+	test("creates a zero-initialized entry on first call", () => {
+		const entry = getOrCreateGlobalEntry<number>(KEY);
+		expect(entry).toEqual({ data: null, expiry: 0, generation: 0 });
+	});
+
+	test("returns the same entry on subsequent calls", () => {
+		const first = getOrCreateGlobalEntry<number>(KEY);
+		first.data = 42;
+		const second = getOrCreateGlobalEntry<number>(KEY);
+		expect(second).toBe(first);
+		expect(second.data).toBe(42);
+	});
+
+	test("replaces an entry left behind with a stale shape (HMR reload)", () => {
+		// Simulates an earlier version of the module writing the pre-generation
+		// shape. `??=` alone would keep the broken object; this guard replaces it.
+		(globalThis as unknown as Record<string, unknown>)[KEY] = {
+			data: { foo: "bar" },
+			expiry: 123,
+		};
+		const entry = getOrCreateGlobalEntry<{ foo: string }>(KEY);
+		expect(entry).toEqual({ data: null, expiry: 0, generation: 0 });
+	});
+
+	test("replaces an entry with a non-numeric generation", () => {
+		(globalThis as unknown as Record<string, unknown>)[KEY] = {
+			data: null,
+			expiry: 0,
+			generation: "0",
+		};
+		const entry = getOrCreateGlobalEntry<number>(KEY);
+		expect(entry.generation).toBe(0);
+	});
+});
+
+describe("invalidateEntry", () => {
+	test("clears data and expiry, bumps generation", () => {
+		const entry: CacheEntry<number> = { data: 42, expiry: 999, generation: 3 };
+		invalidateEntry(entry);
+		expect(entry.data).toBeNull();
+		expect(entry.expiry).toBe(0);
+		expect(entry.generation).toBe(4);
+	});
+});
+
+describe("readThroughCache", () => {
+	let entry: CacheEntry<number>;
+
+	beforeEach(() => {
+		entry = { data: null, expiry: 0, generation: 0 };
+	});
+
+	test("populates cache on cold read", async () => {
+		const result = await readThroughCache(entry, 30_000, async () => 7);
+		expect(result).toBe(7);
+		expect(entry.data).toBe(7);
+		expect(entry.expiry).toBeGreaterThan(Date.now());
+	});
+
+	test("returns cached data without calling the fetcher while fresh", async () => {
+		entry.data = 11;
+		entry.expiry = Date.now() + 60_000;
+		let calls = 0;
+		const result = await readThroughCache(entry, 30_000, async () => {
+			calls += 1;
+			return 99;
+		});
+		expect(result).toBe(11);
+		expect(calls).toBe(0);
+	});
+
+	test("re-fetches when TTL has expired", async () => {
+		entry.data = 11;
+		entry.expiry = Date.now() - 1;
+		const result = await readThroughCache(entry, 30_000, async () => 22);
+		expect(result).toBe(22);
+		expect(entry.data).toBe(22);
+	});
+
+	test("does not publish a stale read when invalidation happens mid-flight", async () => {
+		const gate = deferred<number>();
+		const read = readThroughCache(entry, 30_000, async () => gate.promise);
+
+		// Simulate an admin update committing while the fetcher is still awaiting.
+		invalidateEntry(entry);
+		expect(entry.generation).toBe(1);
+
+		gate.resolve(42);
+		const value = await read;
+
+		// The in-flight caller still observes its own fetched value (safe —
+		// their request predates the write) …
+		expect(value).toBe(42);
+		// … but the shared cache remains empty so future readers don't see the
+		// pre-invalidation snapshot.
+		expect(entry.data).toBeNull();
+		expect(entry.expiry).toBe(0);
+	});
+
+	test("two concurrent cold reads both write safely when no invalidation occurs", async () => {
+		const gateA = deferred<number>();
+		const gateB = deferred<number>();
+		const a = readThroughCache(entry, 30_000, async () => gateA.promise);
+		const b = readThroughCache(entry, 30_000, async () => gateB.promise);
+
+		gateA.resolve(1);
+		gateB.resolve(2);
+
+		const [ra, rb] = await Promise.all([a, b]);
+		expect(ra).toBe(1);
+		expect(rb).toBe(2);
+		// Last writer wins; both had generation 0, both published. Acceptable —
+		// no stale data is introduced, only a redundant write.
+		expect(entry.data).toBe(2);
+		expect(entry.generation).toBe(0);
+	});
+});

--- a/lib/cache/settings-cache.ts
+++ b/lib/cache/settings-cache.ts
@@ -1,0 +1,65 @@
+export type CacheEntry<T> = {
+	data: T | null;
+	expiry: number;
+	generation: number;
+};
+
+function isValidEntry(value: unknown): value is CacheEntry<unknown> {
+	if (typeof value !== "object" || value === null) return false;
+	const v = value as Record<string, unknown>;
+	return "data" in v && typeof v.expiry === "number" && typeof v.generation === "number";
+}
+
+// Attach an entry to globalThis so it behaves as a true process-wide singleton —
+// Server Actions and Route Handlers can compile to separate server bundles with
+// distinct module-scoped variables, and a plain module-level `let` would mean
+// the Server Action invalidates a different cache instance than the one readers
+// consult.
+//
+// Note: globalThis is per-process. On multi-instance serverless (Vercel
+// lambdas, multiple containers), each instance still holds its own cache and
+// can serve stale values for up to the TTL after an update. This helper only
+// eliminates the intra-process bundle split.
+export function getOrCreateGlobalEntry<T>(key: string): CacheEntry<T> {
+	const store = globalThis as unknown as Record<string, unknown>;
+	if (!isValidEntry(store[key])) {
+		// Replaces stale shapes left over across HMR reloads in dev, where a
+		// prior version of this file may have written an entry without the
+		// `generation` field. Without this guard, `generation += 1` on such an
+		// entry yields NaN and the cache never publishes a fresh read.
+		store[key] = { data: null, expiry: 0, generation: 0 } satisfies CacheEntry<T>;
+	}
+	return store[key] as CacheEntry<T>;
+}
+
+export function invalidateEntry<T>(entry: CacheEntry<T>): void {
+	entry.data = null;
+	entry.expiry = 0;
+	entry.generation += 1;
+}
+
+// `generation` guards against a read/invalidate race: a reader captures the
+// generation before awaiting the fetcher and only publishes its result back
+// into the shared cache if no invalidation happened during the await. Without
+// it, an in-flight reader holding pre-update data would re-poison the cache
+// right after an admin invalidates it. The caller still receives the fresh
+// read — linearizability is preserved since its request predates the write.
+export async function readThroughCache<T>(
+	entry: CacheEntry<T>,
+	ttlMs: number,
+	fetcher: () => Promise<T>,
+): Promise<T> {
+	if (entry.data !== null && Date.now() < entry.expiry) {
+		return entry.data;
+	}
+
+	const generation = entry.generation;
+	const fresh = await fetcher();
+
+	if (entry.generation === generation) {
+		entry.data = fresh;
+		entry.expiry = Date.now() + ttlMs;
+	}
+
+	return fresh;
+}


### PR DESCRIPTION
Closes #70

## Summary
- Toggling **Leaderboard Visibility** in `/dashboard/admin-settings` did not immediately reflect on `/dashboard` → Recognition Stats → Most Recognized — up to ~30s lag.
- Root cause: `lib/actions/settings-actions.ts` held its `cached*` state as plain module-scoped `let`s. Under Next.js 16 + Turbopack, Server Actions and Route Handlers can end up in separate server bundles with distinct module instances, so the Server Action's `invalidate*Cache()` cleared one copy while the `/api/recognition/stats` Route Handler kept reading its own stale copy until the TTL expired.
- Fix: promoted all three caches (leaderboard visibility, OAuth, top recognized limit) to a `globalThis`-backed store — same pattern already used for the Prisma singleton in `lib/db/index.ts`. Behavior parity is preserved (same TTL, same invalidation trigger points); only the storage location changed.

## Why the sibling caches were fixed too
- `oauthCache`: a super-admin disabling Google/Microsoft OAuth could remain accept-auth'd on `/api/auth/[...all]` for up to 30s — same bug pattern, mildly security-relevant.
- `topLimitCache`: admin changing Top-N on the same admin-settings panel hit the same 30s lag on the dashboard widget.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check lib/actions/settings-actions.ts` clean
- [x] `bun test` — 56/56 pass
- [ ] Manual: admin toggles Leaderboard Visibility → reload `/dashboard` → Most Recognized reflects new mode with no perceptible delay
- [ ] Manual: admin changes Top Recognized limit → `/dashboard` widget and `/dashboard/leaderboard` reflect the new limit on next navigation
- [ ] Manual: super-admin disables Google/Microsoft OAuth → provider immediately refused on `/api/auth/[...all]` (no 30s window)