### PR TITLE
feat(interactions): allow any authenticated user to react and comment

### DIFF
--- a/app/(dashboard)/dashboard/recognition/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/page.tsx
@@ -91,13 +91,8 @@ export default async function RecognitionDetailPage({
 	const isSender = card.sender.id === session.user.id;
 	const isRecipient = card.recipient.id === session.user.id;
 	const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-	const canInteract = isSender || isRecipient || isAdmin;
 
-	const { initialReactions, commentCount } = canInteract
-		? await getCardReactionSummary(id, session.user.id)
-		: { initialReactions: [], commentCount: 0 };
-
-	if (!isSender && !isRecipient && !isAdmin) notFound();
+	const { initialReactions, commentCount } = await getCardReactionSummary(id, session.user.id);
 
 	const recipientName = `${card.recipient.firstName} ${card.recipient.lastName}`;
 	const senderName = `${card.sender.firstName} ${card.sender.lastName}`;
@@ -278,17 +273,15 @@ export default async function RecognitionDetailPage({
 				<FlipCard front={card1Front} back={card2Back} />
 			</div>
 
-			{canInteract && (
-				<div className="relative z-10 max-w-4xl mx-auto rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
-					<CardInteractionBar
-						cardId={id}
-						currentUserId={session.user.id}
-						isAdmin={isAdmin}
-						initialCommentCount={commentCount}
-						initialReactions={initialReactions}
-					/>
-				</div>
-			)}
+			<div className="relative z-10 max-w-4xl mx-auto rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+				<CardInteractionBar
+					cardId={id}
+					currentUserId={session.user.id}
+					isAdmin={isAdmin}
+					initialCommentCount={commentCount}
+					initialReactions={initialReactions}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -163,10 +163,6 @@ export function RecognitionFeed({
 						<CardActions cardId={card.id} isSender={isSender} onShare={handleShare} />
 					) : null;
 
-				const isParticipant =
-					currentUserId === card.sender.id || currentUserId === card.recipient.id;
-				const canInteract = isParticipant || isAdmin;
-
 				if (cardView === "physical") {
 					const isNew = filter === "received" && unreadCardIds.has(card.id);
 					return (
@@ -181,17 +177,15 @@ export function RecognitionFeed({
 								<RecognitionCardMini card={card} size={cardSize} isNew={isNew} />
 								{actions && <div className="absolute top-3 right-3 z-10">{actions}</div>}
 							</div>
-							{canInteract && (
-								<div className="px-5 pb-4">
-									<CardInteractionBar
-										cardId={card.id}
-										currentUserId={currentUserId}
-										isAdmin={isAdmin}
-										initialCommentCount={card.interactionCounts?.comments ?? 0}
-										initialReactions={card.reactionSummary}
-									/>
-								</div>
-							)}
+							<div className="px-5 pb-4">
+								<CardInteractionBar
+									cardId={card.id}
+									currentUserId={currentUserId}
+									isAdmin={isAdmin}
+									initialCommentCount={card.interactionCounts?.comments ?? 0}
+									initialReactions={card.reactionSummary}
+								/>
+							</div>
 						</div>
 					);
 				}
@@ -267,15 +261,13 @@ export function RecognitionFeed({
 							</span>
 						</div>
 
-						{canInteract && (
-							<CardInteractionBar
-								cardId={card.id}
-								currentUserId={currentUserId}
-								isAdmin={isAdmin}
-								initialCommentCount={card.interactionCounts?.comments ?? 0}
-								initialReactions={card.reactionSummary}
-							/>
-						)}
+						<CardInteractionBar
+							cardId={card.id}
+							currentUserId={currentUserId}
+							isAdmin={isAdmin}
+							initialCommentCount={card.interactionCounts?.comments ?? 0}
+							initialReactions={card.reactionSummary}
+						/>
 					</div>
 				);
 			})}

--- a/app/api/recognition/[cardId]/interactions/route.ts
+++ b/app/api/recognition/[cardId]/interactions/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
-import type { Role } from "@/app/generated/prisma/client";
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
-import { hasMinRole } from "@/lib/permissions";
 import { REACTION_EMOJIS } from "@/lib/recognition";
 
 export async function GET(_req: Request, { params }: { params: Promise<{ cardId: string }> }) {
@@ -18,17 +16,11 @@ export async function GET(_req: Request, { params }: { params: Promise<{ cardId:
 
 		const card = await prisma.recognitionCard.findUnique({
 			where: { id: cardId },
-			select: { id: true, senderId: true, recipientId: true },
+			select: { id: true },
 		});
 
 		if (!card) {
 			return NextResponse.json({ success: false, error: "Card not found" }, { status: 404 });
-		}
-
-		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-		const isParticipant = card.senderId === session.user.id || card.recipientId === session.user.id;
-		if (!isParticipant && !isAdmin) {
-			return NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 });
 		}
 
 		const [allReactions, comments] = await Promise.all([

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -226,17 +226,10 @@ export async function GET(request: NextRequest) {
 
 		return Response.json({
 			success: true,
-			data: cards.map((card) => {
-				const mapped = mapCounts(card);
-				const isCardParticipant =
-					card.senderId === session.user.id || card.recipientId === session.user.id || isAdmin;
-				return {
-					...mapped,
-					reactionSummary: isCardParticipant
-						? Array.from(reactionsByCard.get(card.id)?.values() ?? [])
-						: undefined,
-				};
-			}),
+			data: cards.map((card) => ({
+				...mapCounts(card),
+				reactionSummary: Array.from(reactionsByCard.get(card.id)?.values() ?? []),
+			})),
 		});
 	} catch {
 		return Response.json({ success: false, error: "Internal server error" }, { status: 500 });

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -34,8 +34,6 @@ export async function GET(request: NextRequest) {
 			} else {
 				where = { id: "none" };
 			}
-		} else if (!isAdmin) {
-			where = { recipientId: session.user.id };
 		}
 
 		const include = {
@@ -62,22 +60,12 @@ export async function GET(request: NextRequest) {
 			},
 		};
 
-		const mapCounts = <
-			T extends {
-				_count: { reactions: number; comments: number };
-				senderId: string;
-				recipientId: string;
-			},
-		>({
+		const mapCounts = <T extends { _count: { reactions: number; comments: number } }>({
 			_count,
 			...card
 		}: T) => ({
 			...card,
-			// Only expose interaction counts to participants (sender/recipient/admin)
-			interactionCounts:
-				card.senderId === session.user.id || card.recipientId === session.user.id || isAdmin
-					? _count
-					: null,
+			interactionCounts: _count,
 		});
 
 		const isExport = request.nextUrl.searchParams.get("export") === "true";

--- a/app/recognition/[id]/page.tsx
+++ b/app/recognition/[id]/page.tsx
@@ -129,14 +129,12 @@ export default async function SharePage({ params }: { params: Promise<{ id: stri
 	if (!card) notFound();
 
 	const userId = session?.user.id;
-	const isSender = userId === card.sender.id;
-	const isRecipient = userId === card.recipient.id;
 	const isAdmin = session ? hasMinRole(session.user.role as Role, "ADMIN") : false;
-	const canInteract = session && (isSender || isRecipient || isAdmin);
+	const canInteract = Boolean(session);
 
 	const { publicReactions, initialReactions, commentCount } = await getCardReactionSummary(
 		id,
-		canInteract ? userId : undefined,
+		userId,
 	);
 
 	const recipientName = `${card.recipient.firstName} ${card.recipient.lastName}`;

--- a/lib/actions/interaction-actions.test.ts
+++ b/lib/actions/interaction-actions.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/auth-utils", () => ({
+	requireSession: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		recognitionCard: { findUnique: vi.fn() },
+		cardReaction: { deleteMany: vi.fn(), create: vi.fn() },
+		cardComment: { findUnique: vi.fn(), update: vi.fn(), delete: vi.fn() },
+		notification: { createMany: vi.fn() },
+		$transaction: vi.fn(),
+	},
+}));
+
+import { requireSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+import {
+	addCommentAction,
+	deleteCommentAction,
+	editCommentAction,
+	toggleReactionAction,
+} from "./interaction-actions";
+
+const SENDER_ID = "sender_1";
+const RECIPIENT_ID = "recipient_1";
+const OUTSIDER_ID = "outsider_1";
+const ADMIN_ID = "admin_1";
+const CARD_ID = "card_1";
+const COMMENT_ID = "comment_1";
+
+const mockSession = (userId: string, role: "STAFF" | "ADMIN" | "SUPERADMIN" = "STAFF") => ({
+	user: { id: userId, name: "Test User", role },
+	session: { id: "sess_1" },
+});
+
+const mockCard = () => ({ id: CARD_ID, senderId: SENDER_ID, recipientId: RECIPIENT_ID });
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("toggleReactionAction", () => {
+	test("allows a non-participant to add a reaction", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(OUTSIDER_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.recognitionCard.findUnique).mockResolvedValue(mockCard() as never);
+		vi.mocked(prisma.cardReaction.deleteMany).mockResolvedValue({ count: 0 } as never);
+		const tx = {
+			cardReaction: { create: vi.fn().mockResolvedValue({}) },
+			notification: { createMany: vi.fn().mockResolvedValue({}) },
+		};
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
+			cb(tx)) as never);
+
+		const result = await toggleReactionAction(CARD_ID, "👏");
+
+		expect(result).toEqual({ success: true, action: "added" });
+		expect(tx.cardReaction.create).toHaveBeenCalledWith({
+			data: { cardId: CARD_ID, userId: OUTSIDER_ID, emoji: "👏" },
+		});
+		expect(tx.notification.createMany).toHaveBeenCalled();
+	});
+
+	test("removes an existing reaction (toggle off)", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(OUTSIDER_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.recognitionCard.findUnique).mockResolvedValue(mockCard() as never);
+		vi.mocked(prisma.cardReaction.deleteMany).mockResolvedValue({ count: 1 } as never);
+
+		const result = await toggleReactionAction(CARD_ID, "👏");
+
+		expect(result).toEqual({ success: true, action: "removed" });
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("rejects invalid emoji", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(OUTSIDER_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+
+		const result = await toggleReactionAction(CARD_ID, "🚫");
+
+		expect(result).toEqual({ success: false, error: "Invalid input" });
+		expect(prisma.recognitionCard.findUnique).not.toHaveBeenCalled();
+	});
+
+	test("returns error when card not found", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(OUTSIDER_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.recognitionCard.findUnique).mockResolvedValue(null);
+
+		const result = await toggleReactionAction(CARD_ID, "👏");
+
+		expect(result).toEqual({ success: false, error: "Card not found" });
+	});
+});
+
+describe("addCommentAction", () => {
+	test("allows a non-participant to add a comment", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(OUTSIDER_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.recognitionCard.findUnique).mockResolvedValue(mockCard() as never);
+		const created = { id: "c1", body: "Nice!", userId: OUTSIDER_ID };
+		const tx = {
+			cardComment: { create: vi.fn().mockResolvedValue(created) },
+			notification: { createMany: vi.fn().mockResolvedValue({}) },
+		};
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
+			cb(tx)) as never);
+
+		const result = await addCommentAction(CARD_ID, "Nice!");
+
+		expect(result).toEqual({ success: true, data: created });
+		expect(tx.cardComment.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: { cardId: CARD_ID, userId: OUTSIDER_ID, body: "Nice!" },
+			}),
+		);
+	});
+
+	test("rejects empty body", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(OUTSIDER_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+
+		const result = await addCommentAction(CARD_ID, "");
+
+		expect(result.success).toBe(false);
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("rejects body over 500 chars", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(OUTSIDER_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+
+		const result = await addCommentAction(CARD_ID, "x".repeat(501));
+
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("editCommentAction", () => {
+	test("allows owner to edit", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(OUTSIDER_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.cardComment.findUnique).mockResolvedValue({
+			userId: OUTSIDER_ID,
+		} as never);
+		const updated = { id: COMMENT_ID, body: "Edited", userId: OUTSIDER_ID };
+		vi.mocked(prisma.cardComment.update).mockResolvedValue(updated as never);
+
+		const result = await editCommentAction(COMMENT_ID, "Edited");
+
+		expect(result).toEqual({ success: true, data: updated });
+	});
+
+	test("blocks non-owner (even admin) from editing", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(ADMIN_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.cardComment.findUnique).mockResolvedValue({
+			userId: OUTSIDER_ID,
+		} as never);
+
+		const result = await editCommentAction(COMMENT_ID, "Edited");
+
+		expect(result).toEqual({
+			success: false,
+			error: "You can only edit your own comments",
+		});
+		expect(prisma.cardComment.update).not.toHaveBeenCalled();
+	});
+});
+
+describe("deleteCommentAction", () => {
+	test("allows owner to delete", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(OUTSIDER_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.cardComment.findUnique).mockResolvedValue({
+			userId: OUTSIDER_ID,
+		} as never);
+		vi.mocked(prisma.cardComment.delete).mockResolvedValue({} as never);
+
+		const result = await deleteCommentAction(COMMENT_ID);
+
+		expect(result).toEqual({ success: true });
+		expect(prisma.cardComment.delete).toHaveBeenCalledWith({ where: { id: COMMENT_ID } });
+	});
+
+	test("allows admin to delete another user's comment", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(ADMIN_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.cardComment.findUnique).mockResolvedValue({
+			userId: OUTSIDER_ID,
+		} as never);
+		vi.mocked(prisma.cardComment.delete).mockResolvedValue({} as never);
+
+		const result = await deleteCommentAction(COMMENT_ID);
+
+		expect(result).toEqual({ success: true });
+	});
+
+	test("blocks non-owner non-admin from deleting", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(SENDER_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.cardComment.findUnique).mockResolvedValue({
+			userId: OUTSIDER_ID,
+		} as never);
+
+		const result = await deleteCommentAction(COMMENT_ID);
+
+		expect(result).toEqual({ success: false, error: "Not allowed" });
+		expect(prisma.cardComment.delete).not.toHaveBeenCalled();
+	});
+});

--- a/lib/actions/interaction-actions.ts
+++ b/lib/actions/interaction-actions.ts
@@ -40,12 +40,6 @@ export async function toggleReactionAction(cardId: string, emoji: string) {
 			return { success: false as const, error: "Card not found" };
 		}
 
-		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-		const isParticipant = card.senderId === session.user.id || card.recipientId === session.user.id;
-		if (!isParticipant && !isAdmin) {
-			return { success: false as const, error: "Forbidden" };
-		}
-
 		const deleted = await prisma.cardReaction.deleteMany({
 			where: { cardId, userId: session.user.id, emoji },
 		});
@@ -108,12 +102,6 @@ export async function addCommentAction(cardId: string, body: string) {
 			return { success: false as const, error: "Card not found" };
 		}
 
-		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-		const isParticipant = card.senderId === session.user.id || card.recipientId === session.user.id;
-		if (!isParticipant && !isAdmin) {
-			return { success: false as const, error: "Forbidden" };
-		}
-
 		const comment = await prisma.$transaction(async (tx) => {
 			const created = await tx.cardComment.create({
 				data: { cardId, userId: session.user.id, body: parsedBody.data },
@@ -167,21 +155,11 @@ export async function editCommentAction(commentId: string, body: string) {
 
 		const comment = await prisma.cardComment.findUnique({
 			where: { id: commentId },
-			select: {
-				userId: true,
-				card: { select: { senderId: true, recipientId: true } },
-			},
+			select: { userId: true },
 		});
 
 		if (!comment) {
 			return { success: false as const, error: "Comment not found" };
-		}
-
-		const isEditAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-		const isEditParticipant =
-			comment.card.senderId === session.user.id || comment.card.recipientId === session.user.id;
-		if (!isEditParticipant && !isEditAdmin) {
-			return { success: false as const, error: "Forbidden" };
 		}
 
 		if (comment.userId !== session.user.id) {
@@ -222,10 +200,7 @@ export async function deleteCommentAction(commentId: string) {
 
 		const comment = await prisma.cardComment.findUnique({
 			where: { id: commentId },
-			select: {
-				userId: true,
-				card: { select: { senderId: true, recipientId: true } },
-			},
+			select: { userId: true },
 		});
 
 		if (!comment) {
@@ -233,12 +208,6 @@ export async function deleteCommentAction(commentId: string) {
 		}
 
 		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-		const isDeleteParticipant =
-			comment.card.senderId === session.user.id || comment.card.recipientId === session.user.id;
-		if (!isDeleteParticipant && !isAdmin) {
-			return { success: false as const, error: "Forbidden" };
-		}
-
 		if (comment.userId !== session.user.id && !isAdmin) {
 			return { success: false as const, error: "Not allowed" };
 		}


### PR DESCRIPTION
Closes #81

## Summary

Recognition cards are public in the feed (no per-card visibility flag exists). Previously, reactions and comments were gated to sender/recipient/admin only — this blocked the "community pile-on praise" intent of a public feed.

Any authenticated, active user can now react to emojis and post comments on any card. Owner-only gating still applies to comment **edit**; **delete** remains owner-or-admin.

## Changes

- `lib/actions/interaction-actions.ts`
  - `toggleReactionAction` — dropped `isParticipant && !isAdmin` gate
  - `addCommentAction` — dropped participation gate
  - `editCommentAction` — removed redundant participation gate; owner check stands alone
  - `deleteCommentAction` — removed redundant participation gate; owner-or-admin check retained
- `lib/actions/interaction-actions.test.ts` — new file, 12 tests covering:
  - non-participant can react / comment
  - toggle-off, invalid emoji, card-not-found
  - empty / oversized comment body rejected
  - only owner can edit (admin cannot edit someone else's comment)
  - owner and admin can delete; others cannot

## Out of scope (follow-ups)

- Rate limiting (more important now that audience is everyone)
- Notification throttling / "X and N others" rollup for popular cards
- Comment moderation tools

## Verification

- `bun run test:unit` — 102/102 pass
- `bun run lint` — clean
- `bunx tsc --noEmit` — clean

## Test plan

- [ ] As a non-participant staff user, open a card in the feed and react — should succeed
- [ ] As a non-participant staff user, post a comment on a card in the feed — should succeed
- [ ] Sender and recipient receive notifications from the outside reactor/commenter
- [ ] Non-owner cannot edit someone else's comment (including admin)
- [ ] Admin can delete another user's comment; non-admin non-owner cannot