### PR TITLE
feat(recognition): disallow future dates on recognition form

### DIFF
--- a/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
@@ -265,6 +265,14 @@ export function RecognitionForm({
 
 	const senderName = session?.user ? `${session.user.firstName} ${session.user.lastName}` : "";
 
+	const todayLocal = (() => {
+		const d = new Date();
+		const yyyy = d.getFullYear();
+		const mm = String(d.getMonth() + 1).padStart(2, "0");
+		const dd = String(d.getDate()).padStart(2, "0");
+		return `${yyyy}-${mm}-${dd}`;
+	})();
+
 	const {
 		register,
 		handleSubmit,
@@ -485,6 +493,7 @@ export function RecognitionForm({
 										<span className="text-xs font-black text-black mb-1">DATE</span>
 										<input
 											type="date"
+											max={todayLocal}
 											{...register("date")}
 											className="w-full outline-none text-lg bg-transparent text-[#222]"
 										/>
@@ -600,6 +609,7 @@ export function RecognitionForm({
 										<span className="text-xs font-black text-black mb-1">DATE</span>
 										<input
 											type="date"
+											max={todayLocal}
 											{...register("date")}
 											className="w-full outline-none text-lg bg-transparent text-[#222]"
 										/>

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
@@ -12,6 +12,7 @@ import {
 	updateRecognitionCardAction,
 } from "@/lib/actions/recognition-actions";
 import { useSession } from "@/lib/auth-client";
+import { formatLocalDate } from "@/lib/date-utils";
 import {
 	type CreateRecognitionCardInput,
 	createRecognitionCardSchema,
@@ -265,13 +266,13 @@ export function RecognitionForm({
 
 	const senderName = session?.user ? `${session.user.firstName} ${session.user.lastName}` : "";
 
-	const todayLocal = (() => {
-		const d = new Date();
-		const yyyy = d.getFullYear();
-		const mm = String(d.getMonth() + 1).padStart(2, "0");
-		const dd = String(d.getDate()).padStart(2, "0");
-		return `${yyyy}-${mm}-${dd}`;
-	})();
+	const [todayLocal, setTodayLocal] = useState(() => formatLocalDate(new Date()));
+
+	useEffect(() => {
+		const refresh = () => setTodayLocal(formatLocalDate(new Date()));
+		window.addEventListener("focus", refresh);
+		return () => window.removeEventListener("focus", refresh);
+	}, []);
 
 	const {
 		register,
@@ -285,9 +286,7 @@ export function RecognitionForm({
 		defaultValues: {
 			recipientId: editDefaults?.recipientId ?? "",
 			message: editDefaults?.message ?? "",
-			date:
-				editDefaults?.date ??
-				new Date(Date.now() - new Date().getTimezoneOffset() * 60_000).toISOString().split("T")[0],
+			date: editDefaults?.date ?? formatLocalDate(new Date()),
 			valuesPeople: editDefaults?.valuesPeople ?? false,
 			valuesSafety: editDefaults?.valuesSafety ?? false,
 			valuesRespect: editDefaults?.valuesRespect ?? false,

--- a/lib/date-utils.test.ts
+++ b/lib/date-utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import { formatLocalDate, isNotFutureIsoDate, isValidIsoDate } from "./date-utils";
+
+describe("formatLocalDate", () => {
+	test("formats as YYYY-MM-DD with zero padding", () => {
+		const d = new Date(2026, 0, 5);
+		expect(formatLocalDate(d)).toBe("2026-01-05");
+	});
+
+	test("formats double-digit months and days", () => {
+		const d = new Date(2026, 10, 20);
+		expect(formatLocalDate(d)).toBe("2026-11-20");
+	});
+});
+
+describe("isValidIsoDate", () => {
+	test("accepts a well-formed real date", () => {
+		expect(isValidIsoDate("2026-04-20")).toBe(true);
+	});
+
+	test("accepts a leap-year Feb 29", () => {
+		expect(isValidIsoDate("2024-02-29")).toBe(true);
+	});
+
+	test("rejects a non-leap-year Feb 29", () => {
+		expect(isValidIsoDate("2025-02-29")).toBe(false);
+	});
+
+	test("rejects Feb 30", () => {
+		expect(isValidIsoDate("2026-02-30")).toBe(false);
+	});
+
+	test("rejects month 13", () => {
+		expect(isValidIsoDate("2026-13-01")).toBe(false);
+	});
+
+	test("rejects day 00", () => {
+		expect(isValidIsoDate("2026-04-00")).toBe(false);
+	});
+
+	test("rejects wrong format", () => {
+		expect(isValidIsoDate("2026/04/20")).toBe(false);
+		expect(isValidIsoDate("04-20-2026")).toBe(false);
+		expect(isValidIsoDate("not-a-date")).toBe(false);
+		expect(isValidIsoDate("")).toBe(false);
+	});
+});
+
+describe("isNotFutureIsoDate", () => {
+	test("accepts today", () => {
+		expect(isNotFutureIsoDate(formatLocalDate(new Date()))).toBe(true);
+	});
+
+	test("accepts a past date", () => {
+		const d = new Date();
+		d.setDate(d.getDate() - 7);
+		expect(isNotFutureIsoDate(formatLocalDate(d))).toBe(true);
+	});
+
+	test("rejects a clearly future date", () => {
+		expect(isNotFutureIsoDate("9999-12-31")).toBe(false);
+	});
+});

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -1,0 +1,24 @@
+export function formatLocalDate(date: Date): string {
+	const yyyy = date.getFullYear();
+	const mm = String(date.getMonth() + 1).padStart(2, "0");
+	const dd = String(date.getDate()).padStart(2, "0");
+	return `${yyyy}-${mm}-${dd}`;
+}
+
+export function isValidIsoDate(val: string): boolean {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(val)) return false;
+	const y = Number(val.slice(0, 4));
+	const m = Number(val.slice(5, 7));
+	const d = Number(val.slice(8, 10));
+	const parsed = new Date(Date.UTC(y, m - 1, d));
+	return (
+		parsed.getUTCFullYear() === y && parsed.getUTCMonth() === m - 1 && parsed.getUTCDate() === d
+	);
+}
+
+export function isNotFutureIsoDate(val: string): boolean {
+	const now = new Date();
+	now.setUTCDate(now.getUTCDate() + 1);
+	const maxAllowed = now.toISOString().slice(0, 10);
+	return val <= maxAllowed;
+}

--- a/lib/validations/recognition.test.ts
+++ b/lib/validations/recognition.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, test } from "vitest";
+import { formatLocalDate } from "@/lib/date-utils";
 import { createRecognitionCardSchema } from "./recognition";
+
+const today = () => formatLocalDate(new Date());
+
+const yesterday = () => {
+	const d = new Date();
+	d.setDate(d.getDate() - 1);
+	return formatLocalDate(d);
+};
 
 const validInput = (overrides: Partial<Record<string, unknown>> = {}) => ({
 	recipientId: "user_123",
 	message: "Great work on the sprint!",
-	date: "2026-04-18",
+	date: today(),
 	valuesPeople: true,
 	valuesSafety: false,
 	valuesRespect: false,
@@ -70,6 +79,52 @@ describe("createRecognitionCardSchema", () => {
 		if (!result.success) {
 			const paths = result.error.issues.map((i) => i.path.join("."));
 			expect(paths).toContain("date");
+		}
+	});
+
+	test("accepts today's date", () => {
+		const result = createRecognitionCardSchema.safeParse(validInput({ date: today() }));
+		expect(result.success).toBe(true);
+	});
+
+	test("accepts a past date", () => {
+		const result = createRecognitionCardSchema.safeParse(validInput({ date: yesterday() }));
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects a clearly future date", () => {
+		const result = createRecognitionCardSchema.safeParse(validInput({ date: "9999-12-31" }));
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(
+				result.error.issues.some(
+					(i) => i.path.join(".") === "date" && i.message === "Date cannot be in the future",
+				),
+			).toBe(true);
+		}
+	});
+
+	test("rejects a malformed date string", () => {
+		const result = createRecognitionCardSchema.safeParse(validInput({ date: "not-a-date" }));
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(
+				result.error.issues.some(
+					(i) => i.path.join(".") === "date" && i.message === "Invalid date",
+				),
+			).toBe(true);
+		}
+	});
+
+	test("rejects an invalid calendar date (Feb 30)", () => {
+		const result = createRecognitionCardSchema.safeParse(validInput({ date: "2026-02-30" }));
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(
+				result.error.issues.some(
+					(i) => i.path.join(".") === "date" && i.message === "Invalid date",
+				),
+			).toBe(true);
 		}
 	});
 

--- a/lib/validations/recognition.ts
+++ b/lib/validations/recognition.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isNotFutureIsoDate, isValidIsoDate } from "@/lib/date-utils";
 
 export const createRecognitionCardSchema = z
 	.object({
@@ -10,16 +11,8 @@ export const createRecognitionCardSchema = z
 		date: z
 			.string()
 			.min(1, "Date is required")
-			.refine(
-				(val) => {
-					if (!/^\d{4}-\d{2}-\d{2}$/.test(val)) return false;
-					const now = new Date();
-					now.setUTCDate(now.getUTCDate() + 1);
-					const maxAllowed = now.toISOString().slice(0, 10);
-					return val <= maxAllowed;
-				},
-				{ message: "Date cannot be in the future" },
-			),
+			.refine(isValidIsoDate, { message: "Invalid date" })
+			.refine(isNotFutureIsoDate, { message: "Date cannot be in the future" }),
 		valuesPeople: z.boolean(),
 		valuesSafety: z.boolean(),
 		valuesRespect: z.boolean(),

--- a/lib/validations/recognition.ts
+++ b/lib/validations/recognition.ts
@@ -7,7 +7,19 @@ export const createRecognitionCardSchema = z
 			.string()
 			.min(1, "Message is required")
 			.max(500, "Message must be 500 characters or less"),
-		date: z.string().min(1, "Date is required"),
+		date: z
+			.string()
+			.min(1, "Date is required")
+			.refine(
+				(val) => {
+					if (!/^\d{4}-\d{2}-\d{2}$/.test(val)) return false;
+					const now = new Date();
+					now.setUTCDate(now.getUTCDate() + 1);
+					const maxAllowed = now.toISOString().slice(0, 10);
+					return val <= maxAllowed;
+				},
+				{ message: "Date cannot be in the future" },
+			),
 		valuesPeople: z.boolean(),
 		valuesSafety: z.boolean(),
 		valuesRespect: z.boolean(),


### PR DESCRIPTION
## Summary
- Recognition cards record past events, so the DATE field should not accept future dates.
- Adds `max={todayLocal}` to both `<input type=\"date\">` fields in `recognition-form.tsx` (main + confirm step) — the native date picker now blocks future dates.
- Extends `createRecognitionCardSchema` with a zod refinement that rejects any date greater than today, with a 1-day UTC buffer so users in timezones ahead of UTC (e.g. Asia/Manila) aren't incorrectly rejected when submitting \"today\" during early-morning local hours.

Closes #84

## Test plan
- [ ] Open the recognition create form — the date picker does not allow selecting any date after today.
- [ ] Attempt to submit a future date by typing it directly into the input — inline error shows: \"Date cannot be in the future\".
- [ ] Today's date is accepted and saves successfully.
- [ ] A past date is accepted and saves successfully.
- [ ] Edit flow: opening an existing card with a past date still loads and saves normally.