### PR TITLE
fix(recognition): isolate card stacking context so header stays on top

### DIFF
--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -169,7 +169,7 @@ export function RecognitionFeed({
 						<div
 							key={card.id}
 							className={cn(
-								"group relative rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] overflow-hidden",
+								"group relative isolate rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] overflow-hidden",
 								cardMaxWidth,
 							)}
 						>


### PR DESCRIPTION
## Summary
- Card's inner title/checkbox list use `relative z-10` to float above a background graphic
- Sticky dashboard header also uses `z-10`, and the card wrapper wasn't a stacking context — so those inner z-10s competed with the header in the root context and won, visibly overlapping the header during scroll on `/dashboard/recognition/received` and `/sent`
- Fix: add `isolate` to the physical card wrapper so internal z-indices stay contained

## Test plan
- [ ] Visit `/dashboard/recognition/received`, scroll — cards pass cleanly beneath the header
- [ ] Visit `/dashboard/recognition/sent`, scroll — same
- [ ] Action icons (eye / share / edit) on card top-right still click through correctly
- [ ] `/dashboard/recognition/all` (admin) scrolls cleanly too