### PR TITLE
feat(activity-logs): audit auth events with admin viewer

### DIFF
--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-filters.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-filters.tsx
@@ -1,18 +1,11 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { Search, X } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import type { ActivityAction } from "@/app/generated/prisma/client";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 
 const ACTION_LABELS: Record<ActivityAction, string> = {
 	USER_SIGNED_IN: "Signed in",
@@ -35,108 +28,135 @@ interface ActivityLogFiltersProps {
 	};
 }
 
-const ALL = "__all__";
-
 export function ActivityLogFilters({ users, actions, initial }: ActivityLogFiltersProps) {
 	const router = useRouter();
-	const [actor, setActor] = useState(initial.actor || ALL);
-	const [action, setAction] = useState(initial.action || ALL);
-	const [from, setFrom] = useState(initial.from);
-	const [to, setTo] = useState(initial.to);
+	const searchParams = useSearchParams();
+	const [, startTransition] = useTransition();
 	const [target, setTarget] = useState(initial.target);
+	const skipInitialDebounce = useRef(true);
 
-	function apply() {
-		const sp = new URLSearchParams();
-		if (actor && actor !== ALL) sp.set("actor", actor);
-		if (action && action !== ALL) sp.set("action", action);
-		if (from) sp.set("from", from);
-		if (to) sp.set("to", to);
-		if (target.trim()) sp.set("target", target.trim());
-		const qs = sp.toString();
-		router.push(qs ? `?${qs}` : "?");
-	}
+	const updateParam = useCallback(
+		(key: string, value: string) => {
+			const sp = new URLSearchParams(searchParams.toString());
+			if (value) {
+				sp.set(key, value);
+			} else {
+				sp.delete(key);
+			}
+			sp.delete("page");
+			const qs = sp.toString();
+			startTransition(() => {
+				router.push(qs ? `?${qs}` : "?");
+			});
+		},
+		[router, searchParams],
+	);
 
-	function reset() {
-		setActor(ALL);
-		setAction(ALL);
-		setFrom("");
-		setTo("");
+	useEffect(() => {
+		if (skipInitialDebounce.current) {
+			skipInitialDebounce.current = false;
+			return;
+		}
+		const timer = setTimeout(() => {
+			updateParam("target", target);
+		}, 300);
+		return () => clearTimeout(timer);
+	}, [target, updateParam]);
+
+	const hasActiveFilters =
+		!!initial.actor || !!initial.action || !!initial.from || !!initial.to || !!initial.target;
+
+	function clearAll() {
 		setTarget("");
-		router.push("?");
+		skipInitialDebounce.current = true;
+		startTransition(() => {
+			router.push("?");
+		});
 	}
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] p-6 space-y-4">
-			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
-				<div className="space-y-1.5">
-					<Label>Actor</Label>
-					<Select
-						value={actor}
-						onValueChange={(val) => {
-							if (val !== null) setActor(val);
-						}}
-					>
-						<SelectTrigger>
-							<SelectValue placeholder="All actors" />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value={ALL}>All actors</SelectItem>
-							{users.map((u) => (
-								<SelectItem key={u.id} value={u.id}>
-									{u.firstName} {u.lastName}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</div>
-
-				<div className="space-y-1.5">
-					<Label>Action</Label>
-					<Select
-						value={action}
-						onValueChange={(val) => {
-							if (val !== null) setAction(val);
-						}}
-					>
-						<SelectTrigger>
-							<SelectValue placeholder="All actions" />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value={ALL}>All actions</SelectItem>
-							{actions.map((a) => (
-								<SelectItem key={a} value={a}>
-									{ACTION_LABELS[a]}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</div>
-
-				<div className="space-y-1.5">
-					<Label>From</Label>
-					<Input type="date" value={from} onChange={(e) => setFrom(e.target.value)} />
-				</div>
-
-				<div className="space-y-1.5">
-					<Label>To</Label>
-					<Input type="date" value={to} onChange={(e) => setTo(e.target.value)} />
-				</div>
-
-				<div className="space-y-1.5">
-					<Label>Target</Label>
-					<Input
-						placeholder="e.g. google"
+		<div className="rounded-xl border border-gray-200/60 dark:border-white/10 bg-card p-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+			<div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-center">
+				<div className="relative min-w-0 lg:w-56">
+					<Search
+						size={16}
+						className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+					/>
+					<input
+						type="text"
+						placeholder="Search target..."
 						value={target}
 						onChange={(e) => setTarget(e.target.value)}
+						className="h-9 w-full rounded-full border border-input bg-transparent pl-9 pr-3 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
 					/>
 				</div>
-			</div>
 
-			<div className="flex justify-end gap-2">
-				<Button variant="outline" onClick={reset}>
-					Reset
-				</Button>
-				<Button onClick={apply}>Apply filters</Button>
+				<div className="flex flex-wrap items-center gap-2">
+					<select
+						value={initial.actor}
+						onChange={(e) => updateParam("actor", e.target.value)}
+						className={cn(
+							"h-9 rounded-lg border border-input bg-transparent px-2.5 pr-8 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30",
+							!initial.actor && "text-muted-foreground",
+						)}
+					>
+						<option value="">All actors</option>
+						{users.map((u) => (
+							<option key={u.id} value={u.id}>
+								{u.firstName} {u.lastName}
+							</option>
+						))}
+					</select>
+					<select
+						value={initial.action}
+						onChange={(e) => updateParam("action", e.target.value)}
+						className={cn(
+							"h-9 rounded-lg border border-input bg-transparent px-2.5 pr-8 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30",
+							!initial.action && "text-muted-foreground",
+						)}
+					>
+						<option value="">All actions</option>
+						{actions.map((a) => (
+							<option key={a} value={a}>
+								{ACTION_LABELS[a]}
+							</option>
+						))}
+					</select>
+				</div>
+
+				<div className="flex items-center gap-2">
+					<input
+						type="date"
+						value={initial.from}
+						onChange={(e) => updateParam("from", e.target.value)}
+						className={cn(
+							"h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30",
+							!initial.from && "text-muted-foreground",
+						)}
+					/>
+					<span className="text-xs text-muted-foreground">to</span>
+					<input
+						type="date"
+						value={initial.to}
+						onChange={(e) => updateParam("to", e.target.value)}
+						className={cn(
+							"h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30",
+							!initial.to && "text-muted-foreground",
+						)}
+					/>
+				</div>
+
+				<div className="flex items-center gap-1 shrink-0 lg:ml-auto">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={clearAll}
+						className={cn("gap-1 text-muted-foreground", !hasActiveFilters && "invisible")}
+					>
+						<X size={14} />
+						Clear
+					</Button>
+				</div>
 			</div>
 		</div>
 	);

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-filters.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-filters.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import type { ActivityAction } from "@/app/generated/prisma/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+
+const ACTION_LABELS: Record<ActivityAction, string> = {
+	USER_SIGNED_IN: "Signed in",
+	USER_SIGNED_OUT: "Signed out",
+	SIGN_IN_FAILED: "Sign-in failed",
+	OAUTH_ACCOUNT_LINKED: "OAuth linked",
+	PASSWORD_CHANGED: "Password changed",
+	PASSWORD_RESET: "Password reset",
+};
+
+interface ActivityLogFiltersProps {
+	users: Array<{ id: string; firstName: string; lastName: string; email: string }>;
+	actions: ActivityAction[];
+	initial: {
+		actor: string;
+		action: string;
+		from: string;
+		to: string;
+		target: string;
+	};
+}
+
+const ALL = "__all__";
+
+export function ActivityLogFilters({ users, actions, initial }: ActivityLogFiltersProps) {
+	const router = useRouter();
+	const [actor, setActor] = useState(initial.actor || ALL);
+	const [action, setAction] = useState(initial.action || ALL);
+	const [from, setFrom] = useState(initial.from);
+	const [to, setTo] = useState(initial.to);
+	const [target, setTarget] = useState(initial.target);
+
+	function apply() {
+		const sp = new URLSearchParams();
+		if (actor && actor !== ALL) sp.set("actor", actor);
+		if (action && action !== ALL) sp.set("action", action);
+		if (from) sp.set("from", from);
+		if (to) sp.set("to", to);
+		if (target.trim()) sp.set("target", target.trim());
+		const qs = sp.toString();
+		router.push(qs ? `?${qs}` : "?");
+	}
+
+	function reset() {
+		setActor(ALL);
+		setAction(ALL);
+		setFrom("");
+		setTo("");
+		setTarget("");
+		router.push("?");
+	}
+
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] p-6 space-y-4">
+			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+				<div className="space-y-1.5">
+					<Label>Actor</Label>
+					<Select
+						value={actor}
+						onValueChange={(val) => {
+							if (val !== null) setActor(val);
+						}}
+					>
+						<SelectTrigger>
+							<SelectValue placeholder="All actors" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value={ALL}>All actors</SelectItem>
+							{users.map((u) => (
+								<SelectItem key={u.id} value={u.id}>
+									{u.firstName} {u.lastName}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				<div className="space-y-1.5">
+					<Label>Action</Label>
+					<Select
+						value={action}
+						onValueChange={(val) => {
+							if (val !== null) setAction(val);
+						}}
+					>
+						<SelectTrigger>
+							<SelectValue placeholder="All actions" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value={ALL}>All actions</SelectItem>
+							{actions.map((a) => (
+								<SelectItem key={a} value={a}>
+									{ACTION_LABELS[a]}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				<div className="space-y-1.5">
+					<Label>From</Label>
+					<Input type="date" value={from} onChange={(e) => setFrom(e.target.value)} />
+				</div>
+
+				<div className="space-y-1.5">
+					<Label>To</Label>
+					<Input type="date" value={to} onChange={(e) => setTo(e.target.value)} />
+				</div>
+
+				<div className="space-y-1.5">
+					<Label>Target</Label>
+					<Input
+						placeholder="e.g. google"
+						value={target}
+						onChange={(e) => setTarget(e.target.value)}
+					/>
+				</div>
+			</div>
+
+			<div className="flex justify-end gap-2">
+				<Button variant="outline" onClick={reset}>
+					Reset
+				</Button>
+				<Button onClick={apply}>Apply filters</Button>
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-filters.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-filters.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import type { ActivityAction } from "@/app/generated/prisma/client";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { StaffCombobox } from "./staff-combobox";
 
 const ACTION_LABELS: Record<ActivityAction, string> = {
 	USER_SIGNED_IN: "Signed in",
@@ -92,21 +93,13 @@ export function ActivityLogFilters({ users, actions, initial }: ActivityLogFilte
 				</div>
 
 				<div className="flex flex-wrap items-center gap-2">
-					<select
+					<StaffCombobox
 						value={initial.actor}
-						onChange={(e) => updateParam("actor", e.target.value)}
-						className={cn(
-							"h-9 rounded-lg border border-input bg-transparent px-2.5 pr-8 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30",
-							!initial.actor && "text-muted-foreground",
-						)}
-					>
-						<option value="">All actors</option>
-						{users.map((u) => (
-							<option key={u.id} value={u.id}>
-								{u.firstName} {u.lastName}
-							</option>
-						))}
-					</select>
+						staff={users}
+						onChange={(id) => updateParam("actor", id)}
+						placeholder="All Staff"
+						className="w-full sm:w-56"
+					/>
 					<select
 						value={initial.action}
 						onChange={(e) => updateParam("action", e.target.value)}

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-table.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-table.tsx
@@ -1,7 +1,7 @@
+import { ChevronLeft, ChevronRight, FileSearch } from "lucide-react";
 import Link from "next/link";
 import type { ActivityAction, ActivityLog } from "@/app/generated/prisma/client";
 import { Badge } from "@/components/ui/badge";
-import { Button, buttonVariants } from "@/components/ui/button";
 import {
 	Table,
 	TableBody,
@@ -10,6 +10,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 
 const ACTION_LABELS: Record<ActivityAction, string> = {
 	USER_SIGNED_IN: "Signed in",
@@ -29,8 +30,10 @@ type LogWithActor = ActivityLog & {
 interface ActivityLogTableProps {
 	logs: LogWithActor[];
 	page: number;
+	pageSize: number;
 	totalPages: number;
 	total: number;
+	hasActiveFilters: boolean;
 	baseQuery: Record<string, string>;
 }
 
@@ -51,13 +54,9 @@ function formatTarget(log: LogWithActor): string {
 function formatMetadata(metadata: unknown): string {
 	if (!metadata) return "—";
 	if (typeof metadata === "object") {
-		try {
-			const entries = Object.entries(metadata as Record<string, unknown>);
-			if (entries.length === 0) return "—";
-			return entries.map(([k, v]) => `${k}: ${String(v)}`).join(", ");
-		} catch {
-			return "—";
-		}
+		const entries = Object.entries(metadata as Record<string, unknown>);
+		if (entries.length === 0) return "—";
+		return entries.map(([k, v]) => `${k}: ${String(v)}`).join(", ");
 	}
 	return String(metadata);
 }
@@ -71,42 +70,58 @@ function buildPageHref(base: Record<string, string>, page: number): string {
 export function ActivityLogTable({
 	logs,
 	page,
+	pageSize,
 	totalPages,
 	total,
+	hasActiveFilters,
 	baseQuery,
 }: ActivityLogTableProps) {
-	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-			<div className="flex items-center justify-between px-8 pt-6 pb-2">
-				<p className="text-sm text-muted-foreground">
-					{total} {total === 1 ? "entry" : "entries"}
+	if (logs.length === 0) {
+		return (
+			<div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 dark:border-white/10 bg-card p-16">
+				<div className="mb-6 rounded-full bg-background p-6">
+					<FileSearch size={48} className="text-muted-foreground opacity-40" />
+				</div>
+				<p className="text-[1.5rem] font-medium text-foreground">
+					{hasActiveFilters ? "No matching activity" : "No activity yet"}
 				</p>
-				<p className="text-xs text-muted-foreground">
-					Page {page} of {totalPages}
+				<p className="mt-2 text-base text-muted-foreground">
+					{hasActiveFilters
+						? "No entries match your current filters."
+						: "Auth events will appear here as they happen."}
 				</p>
+				{hasActiveFilters && (
+					<Link
+						href="?"
+						className="mt-4 text-sm font-medium text-primary hover:text-primary/80 transition-colors"
+					>
+						Clear all filters
+					</Link>
+				)}
 			</div>
+		);
+	}
 
-			<div className="overflow-x-auto">
-				<Table>
-					<TableHeader>
-						<TableRow>
-							<TableHead>When</TableHead>
-							<TableHead>Actor</TableHead>
-							<TableHead>Action</TableHead>
-							<TableHead>Target</TableHead>
-							<TableHead>Metadata</TableHead>
-							<TableHead>IP</TableHead>
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{logs.length === 0 ? (
-							<TableRow>
-								<TableCell colSpan={6} className="text-center text-sm text-muted-foreground py-10">
-									No activity found.
-								</TableCell>
+	const from = (page - 1) * pageSize + 1;
+	const to = Math.min(page * pageSize, total);
+
+	return (
+		<>
+			<div className="rounded-xl border border-gray-200/60 dark:border-white/10 bg-card overflow-hidden shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+				<div className="overflow-x-auto">
+					<Table>
+						<TableHeader>
+							<TableRow className="bg-muted/30 hover:bg-muted/30">
+								<TableHead>When</TableHead>
+								<TableHead>Actor</TableHead>
+								<TableHead>Action</TableHead>
+								<TableHead>Target</TableHead>
+								<TableHead>Metadata</TableHead>
+								<TableHead>IP</TableHead>
 							</TableRow>
-						) : (
-							logs.map((log) => (
+						</TableHeader>
+						<TableBody>
+							{logs.map((log) => (
 								<TableRow key={log.id}>
 									<TableCell className="whitespace-nowrap text-sm">
 										{formatDateTime(log.createdAt)}
@@ -141,40 +156,65 @@ export function ActivityLogTable({
 										{log.ipAddress ?? "—"}
 									</TableCell>
 								</TableRow>
-							))
-						)}
-					</TableBody>
-				</Table>
+							))}
+						</TableBody>
+					</Table>
+				</div>
 			</div>
 
 			{totalPages > 1 && (
-				<div className="flex items-center justify-end gap-2 px-8 py-4">
-					{page > 1 ? (
-						<Link
-							href={buildPageHref(baseQuery, page - 1)}
-							className={buttonVariants({ variant: "outline", size: "sm" })}
+				<div className="flex items-center justify-between pt-2">
+					<p className="text-sm text-muted-foreground">
+						Showing {from}–{to} of {total} {total === 1 ? "entry" : "entries"}
+					</p>
+					<div className="flex items-center gap-2">
+						<PagerButton
+							disabled={page <= 1}
+							href={page > 1 ? buildPageHref(baseQuery, page - 1) : undefined}
 						>
+							<ChevronLeft size={16} />
 							Previous
-						</Link>
-					) : (
-						<Button variant="outline" size="sm" disabled>
-							Previous
-						</Button>
-					)}
-					{page < totalPages ? (
-						<Link
-							href={buildPageHref(baseQuery, page + 1)}
-							className={buttonVariants({ variant: "outline", size: "sm" })}
+						</PagerButton>
+						<span className="text-sm font-medium text-foreground">
+							{page} / {totalPages}
+						</span>
+						<PagerButton
+							disabled={page >= totalPages}
+							href={page < totalPages ? buildPageHref(baseQuery, page + 1) : undefined}
 						>
 							Next
-						</Link>
-					) : (
-						<Button variant="outline" size="sm" disabled>
-							Next
-						</Button>
-					)}
+							<ChevronRight size={16} />
+						</PagerButton>
+					</div>
 				</div>
 			)}
-		</div>
+		</>
+	);
+}
+
+function PagerButton({
+	disabled,
+	href,
+	children,
+}: {
+	disabled: boolean;
+	href?: string;
+	children: React.ReactNode;
+}) {
+	const classes = cn(
+		"inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-gray-100 dark:hover:bg-white/5 transition-colors",
+		disabled && "opacity-30 pointer-events-none",
+	);
+	if (disabled || !href) {
+		return (
+			<span aria-disabled className={classes}>
+				{children}
+			</span>
+		);
+	}
+	return (
+		<Link href={href} className={classes}>
+			{children}
+		</Link>
 	);
 }

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-table.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-table.tsx
@@ -1,0 +1,180 @@
+import Link from "next/link";
+import type { ActivityAction, ActivityLog } from "@/app/generated/prisma/client";
+import { Badge } from "@/components/ui/badge";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+
+const ACTION_LABELS: Record<ActivityAction, string> = {
+	USER_SIGNED_IN: "Signed in",
+	USER_SIGNED_OUT: "Signed out",
+	SIGN_IN_FAILED: "Sign-in failed",
+	OAUTH_ACCOUNT_LINKED: "OAuth linked",
+	PASSWORD_CHANGED: "Password changed",
+	PASSWORD_RESET: "Password reset",
+};
+
+const DESTRUCTIVE_ACTIONS = new Set<ActivityAction>(["SIGN_IN_FAILED"]);
+
+type LogWithActor = ActivityLog & {
+	actor: { id: string; firstName: string; lastName: string; email: string } | null;
+};
+
+interface ActivityLogTableProps {
+	logs: LogWithActor[];
+	page: number;
+	totalPages: number;
+	total: number;
+	baseQuery: Record<string, string>;
+}
+
+function formatDateTime(date: Date): string {
+	return new Intl.DateTimeFormat("en-AU", {
+		dateStyle: "medium",
+		timeStyle: "short",
+	}).format(date);
+}
+
+function formatTarget(log: LogWithActor): string {
+	if (log.targetType && log.targetId) return `${log.targetType}:${log.targetId}`;
+	if (log.targetId) return log.targetId;
+	if (log.targetType) return log.targetType;
+	return "—";
+}
+
+function formatMetadata(metadata: unknown): string {
+	if (!metadata) return "—";
+	if (typeof metadata === "object") {
+		try {
+			const entries = Object.entries(metadata as Record<string, unknown>);
+			if (entries.length === 0) return "—";
+			return entries.map(([k, v]) => `${k}: ${String(v)}`).join(", ");
+		} catch {
+			return "—";
+		}
+	}
+	return String(metadata);
+}
+
+function buildPageHref(base: Record<string, string>, page: number): string {
+	const sp = new URLSearchParams(base);
+	sp.set("page", String(page));
+	return `?${sp.toString()}`;
+}
+
+export function ActivityLogTable({
+	logs,
+	page,
+	totalPages,
+	total,
+	baseQuery,
+}: ActivityLogTableProps) {
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
+			<div className="flex items-center justify-between px-8 pt-6 pb-2">
+				<p className="text-sm text-muted-foreground">
+					{total} {total === 1 ? "entry" : "entries"}
+				</p>
+				<p className="text-xs text-muted-foreground">
+					Page {page} of {totalPages}
+				</p>
+			</div>
+
+			<div className="overflow-x-auto">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>When</TableHead>
+							<TableHead>Actor</TableHead>
+							<TableHead>Action</TableHead>
+							<TableHead>Target</TableHead>
+							<TableHead>Metadata</TableHead>
+							<TableHead>IP</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{logs.length === 0 ? (
+							<TableRow>
+								<TableCell colSpan={6} className="text-center text-sm text-muted-foreground py-10">
+									No activity found.
+								</TableCell>
+							</TableRow>
+						) : (
+							logs.map((log) => (
+								<TableRow key={log.id}>
+									<TableCell className="whitespace-nowrap text-sm">
+										{formatDateTime(log.createdAt)}
+									</TableCell>
+									<TableCell className="text-sm">
+										{log.actor ? (
+											<div>
+												<div className="font-medium">
+													{log.actor.firstName} {log.actor.lastName}
+												</div>
+												<div className="text-xs text-muted-foreground">{log.actor.email}</div>
+											</div>
+										) : (
+											<span className="text-muted-foreground">—</span>
+										)}
+									</TableCell>
+									<TableCell>
+										<Badge
+											variant={DESTRUCTIVE_ACTIONS.has(log.action) ? "destructive" : "secondary"}
+										>
+											{ACTION_LABELS[log.action]}
+										</Badge>
+									</TableCell>
+									<TableCell className="text-sm">{formatTarget(log)}</TableCell>
+									<TableCell
+										className="text-sm max-w-xs truncate"
+										title={formatMetadata(log.metadata)}
+									>
+										{formatMetadata(log.metadata)}
+									</TableCell>
+									<TableCell className="text-sm text-muted-foreground">
+										{log.ipAddress ?? "—"}
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			{totalPages > 1 && (
+				<div className="flex items-center justify-end gap-2 px-8 py-4">
+					{page > 1 ? (
+						<Link
+							href={buildPageHref(baseQuery, page - 1)}
+							className={buttonVariants({ variant: "outline", size: "sm" })}
+						>
+							Previous
+						</Link>
+					) : (
+						<Button variant="outline" size="sm" disabled>
+							Previous
+						</Button>
+					)}
+					{page < totalPages ? (
+						<Link
+							href={buildPageHref(baseQuery, page + 1)}
+							className={buttonVariants({ variant: "outline", size: "sm" })}
+						>
+							Next
+						</Link>
+					) : (
+						<Button variant="outline" size="sm" disabled>
+							Next
+						</Button>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/staff-combobox.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/staff-combobox.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { ChevronDown, Search, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface StaffOption {
+	id: string;
+	firstName: string;
+	lastName: string;
+}
+
+interface StaffComboboxProps {
+	value: string;
+	staff: StaffOption[];
+	onChange: (id: string) => void;
+	placeholder?: string;
+	className?: string;
+}
+
+export function StaffCombobox({
+	value,
+	staff,
+	onChange,
+	placeholder = "All Staff",
+	className,
+}: StaffComboboxProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState("");
+
+	const selected = value ? (staff.find((s) => s.id === value) ?? null) : null;
+
+	const filtered = query
+		? staff.filter((s) =>
+				`${s.firstName} ${s.lastName}`.toLowerCase().includes(query.toLowerCase()),
+			)
+		: staff;
+
+	useEffect(() => {
+		function handleClickOutside(e: MouseEvent) {
+			if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+				setOpen(false);
+				setQuery("");
+			}
+		}
+		function handleKey(e: KeyboardEvent) {
+			if (e.key === "Escape") {
+				setOpen(false);
+				setQuery("");
+				inputRef.current?.blur();
+			}
+		}
+		document.addEventListener("mousedown", handleClickOutside);
+		document.addEventListener("keydown", handleKey);
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside);
+			document.removeEventListener("keydown", handleKey);
+		};
+	}, []);
+
+	function handleSelect(user: StaffOption) {
+		onChange(user.id);
+		setOpen(false);
+		setQuery("");
+	}
+
+	function handleClear() {
+		onChange("");
+		setQuery("");
+		setOpen(false);
+		inputRef.current?.focus();
+	}
+
+	return (
+		<div ref={containerRef} className={cn("relative", className)}>
+			{selected ? (
+				<div className="flex h-9 items-center justify-between rounded-full border border-input bg-transparent pl-3 pr-1 dark:bg-input/30">
+					<span className="truncate text-sm text-foreground">
+						{selected.firstName} {selected.lastName}
+					</span>
+					<button
+						type="button"
+						onClick={handleClear}
+						aria-label="Clear staff filter"
+						className="ml-2 rounded-full p-1 text-muted-foreground transition-colors hover:bg-gray-100 dark:hover:bg-white/5"
+					>
+						<X size={14} />
+					</button>
+				</div>
+			) : (
+				<div className="relative h-9">
+					<Search
+						size={16}
+						className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+					/>
+					<input
+						ref={inputRef}
+						type="text"
+						value={query}
+						placeholder={placeholder}
+						onChange={(e) => {
+							setQuery(e.target.value);
+							setOpen(true);
+						}}
+						onFocus={() => setOpen(true)}
+						className="h-9 w-full rounded-full border border-input bg-transparent pl-9 pr-8 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
+					/>
+					<ChevronDown
+						size={14}
+						className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+					/>
+				</div>
+			)}
+
+			{open && !selected && (
+				<div
+					role="listbox"
+					className="absolute left-0 right-0 top-full z-20 mt-1 max-h-60 overflow-y-auto rounded-lg border border-gray-200 bg-card shadow-lg dark:border-white/10"
+				>
+					{filtered.length === 0 ? (
+						<div className="px-3 py-2 text-sm text-muted-foreground">No staff found</div>
+					) : (
+						filtered.map((s) => (
+							<button
+								key={s.id}
+								type="button"
+								onMouseDown={(e) => e.preventDefault()}
+								onClick={() => handleSelect(s)}
+								className="flex w-full items-center px-3 py-2 text-left text-sm transition-colors hover:bg-muted"
+							>
+								{s.firstName} {s.lastName}
+							</button>
+						))
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
@@ -116,8 +116,12 @@ export default async function ActivityLogsPage({
 			<ActivityLogTable
 				logs={logs}
 				page={page}
+				pageSize={PAGE_SIZE}
 				totalPages={totalPages}
 				total={total}
+				hasActiveFilters={
+					!!params.actor || !!params.action || !!params.from || !!params.to || !!params.target
+				}
 				baseQuery={{
 					...(params.actor ? { actor: params.actor } : {}),
 					...(params.action ? { action: params.action } : {}),

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
@@ -1,0 +1,131 @@
+import { redirect } from "next/navigation";
+import type { ActivityAction, Prisma } from "@/app/generated/prisma/client";
+import { pruneActivityLogsIfNeeded } from "@/lib/activity-log";
+import { requireRole } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+import { ActivityLogFilters } from "./_components/activity-log-filters";
+import { ActivityLogTable } from "./_components/activity-log-table";
+
+const PAGE_SIZE = 50;
+
+const ACTIONS: ActivityAction[] = [
+	"USER_SIGNED_IN",
+	"USER_SIGNED_OUT",
+	"SIGN_IN_FAILED",
+	"OAUTH_ACCOUNT_LINKED",
+	"PASSWORD_CHANGED",
+	"PASSWORD_RESET",
+];
+
+interface SearchParams {
+	actor?: string;
+	action?: string;
+	from?: string;
+	to?: string;
+	target?: string;
+	page?: string;
+}
+
+function parseDate(value: string | undefined, endOfDay = false): Date | null {
+	if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+	const d = new Date(`${value}T${endOfDay ? "23:59:59.999" : "00:00:00.000"}Z`);
+	return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export default async function ActivityLogsPage({
+	searchParams,
+}: {
+	searchParams: Promise<SearchParams>;
+}) {
+	try {
+		await requireRole("ADMIN");
+	} catch {
+		redirect("/dashboard");
+	}
+
+	await pruneActivityLogsIfNeeded();
+
+	const params = await searchParams;
+	const page = Math.max(1, Number.parseInt(params.page ?? "1", 10) || 1);
+
+	const where: Prisma.ActivityLogWhereInput = {};
+	if (params.actor) where.actorId = params.actor;
+	if (params.action && (ACTIONS as readonly string[]).includes(params.action)) {
+		where.action = params.action as ActivityAction;
+	}
+	const from = parseDate(params.from);
+	const to = parseDate(params.to, true);
+	if (from || to) {
+		where.createdAt = {
+			...(from ? { gte: from } : {}),
+			...(to ? { lte: to } : {}),
+		};
+	}
+	if (params.target) {
+		where.OR = [
+			{ targetType: { contains: params.target, mode: "insensitive" } },
+			{ targetId: { contains: params.target, mode: "insensitive" } },
+		];
+	}
+
+	const [total, logs, users] = await Promise.all([
+		prisma.activityLog.count({ where }),
+		prisma.activityLog.findMany({
+			where,
+			orderBy: { createdAt: "desc" },
+			include: {
+				actor: {
+					select: { id: true, firstName: true, lastName: true, email: true },
+				},
+			},
+			take: PAGE_SIZE,
+			skip: (page - 1) * PAGE_SIZE,
+		}),
+		prisma.user.findMany({
+			where: { deletedAt: null },
+			orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+			select: { id: true, firstName: true, lastName: true, email: true },
+		}),
+	]);
+
+	const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+	return (
+		<div className="max-w-7xl mx-auto space-y-8 mt-2">
+			<div>
+				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+					Activity Logs
+				</h1>
+				<p className="mt-2 text-base text-muted-foreground">
+					Audit trail of authentication and account events.
+				</p>
+			</div>
+
+			<ActivityLogFilters
+				users={users}
+				actions={ACTIONS}
+				initial={{
+					actor: params.actor ?? "",
+					action: params.action ?? "",
+					from: params.from ?? "",
+					to: params.to ?? "",
+					target: params.target ?? "",
+				}}
+			/>
+
+			<ActivityLogTable
+				logs={logs}
+				page={page}
+				totalPages={totalPages}
+				total={total}
+				baseQuery={{
+					...(params.actor ? { actor: params.actor } : {}),
+					...(params.action ? { action: params.action } : {}),
+					...(params.from ? { from: params.from } : {}),
+					...(params.to ? { to: params.to } : {}),
+					...(params.target ? { target: params.target } : {}),
+				}}
+			/>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
@@ -26,10 +26,23 @@ interface SearchParams {
 	page?: string;
 }
 
-function parseDate(value: string | undefined, endOfDay = false): Date | null {
-	if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
-	const d = new Date(`${value}T${endOfDay ? "23:59:59.999" : "00:00:00.000"}Z`);
-	return Number.isNaN(d.getTime()) ? null : d;
+const MANILA_TZ_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+function parseManilaDayStart(value: string | undefined): Date | null {
+	if (!value) return null;
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+	if (!match) return null;
+	const year = Number.parseInt(match[1] ?? "", 10);
+	const month = Number.parseInt(match[2] ?? "", 10) - 1;
+	const day = Number.parseInt(match[3] ?? "", 10);
+	if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) return null;
+	return new Date(Date.UTC(year, month, day, 0, 0, 0, 0) - MANILA_TZ_OFFSET_MS);
+}
+
+function parseManilaDayEndExclusive(value: string | undefined): Date | null {
+	const start = parseManilaDayStart(value);
+	if (!start) return null;
+	return new Date(start.getTime() + 24 * 60 * 60 * 1000);
 }
 
 export default async function ActivityLogsPage({
@@ -46,19 +59,19 @@ export default async function ActivityLogsPage({
 	await pruneActivityLogsIfNeeded();
 
 	const params = await searchParams;
-	const page = Math.max(1, Number.parseInt(params.page ?? "1", 10) || 1);
+	const requestedPage = Math.max(1, Number.parseInt(params.page ?? "1", 10) || 1);
 
 	const where: Prisma.ActivityLogWhereInput = {};
 	if (params.actor) where.actorId = params.actor;
 	if (params.action && (ACTIONS as readonly string[]).includes(params.action)) {
 		where.action = params.action as ActivityAction;
 	}
-	const from = parseDate(params.from);
-	const to = parseDate(params.to, true);
+	const from = parseManilaDayStart(params.from);
+	const to = parseManilaDayEndExclusive(params.to);
 	if (from || to) {
 		where.createdAt = {
 			...(from ? { gte: from } : {}),
-			...(to ? { lte: to } : {}),
+			...(to ? { lt: to } : {}),
 		};
 	}
 	if (params.target) {
@@ -68,19 +81,8 @@ export default async function ActivityLogsPage({
 		];
 	}
 
-	const [total, logs, users] = await Promise.all([
+	const [total, users] = await Promise.all([
 		prisma.activityLog.count({ where }),
-		prisma.activityLog.findMany({
-			where,
-			orderBy: { createdAt: "desc" },
-			include: {
-				actor: {
-					select: { id: true, firstName: true, lastName: true, email: true },
-				},
-			},
-			take: PAGE_SIZE,
-			skip: (page - 1) * PAGE_SIZE,
-		}),
 		prisma.user.findMany({
 			where: { deletedAt: null },
 			orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
@@ -89,6 +91,19 @@ export default async function ActivityLogsPage({
 	]);
 
 	const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+	const page = Math.min(requestedPage, totalPages);
+
+	const logs = await prisma.activityLog.findMany({
+		where,
+		orderBy: { createdAt: "desc" },
+		include: {
+			actor: {
+				select: { id: true, firstName: true, lastName: true, email: true },
+			},
+		},
+		take: PAGE_SIZE,
+		skip: (page - 1) * PAGE_SIZE,
+	});
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-8 mt-2">

--- a/app/(dashboard)/dashboard/super-admin/_components/activity-log-retention.tsx
+++ b/app/(dashboard)/dashboard/super-admin/_components/activity-log-retention.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { updateActivityLogRetentionDays } from "@/lib/actions/settings-actions";
+import {
+	ACTIVITY_LOG_RETENTION_MAX,
+	ACTIVITY_LOG_RETENTION_MIN,
+} from "@/lib/activity-log-retention";
+
+export function ActivityLogRetentionPanel({ initialDays }: { initialDays: number }) {
+	const [days, setDays] = useState<string>(String(initialDays));
+	const [isPending, startTransition] = useTransition();
+
+	function handleSave() {
+		const parsed = Number.parseInt(days, 10);
+		if (
+			!Number.isInteger(parsed) ||
+			parsed < ACTIVITY_LOG_RETENTION_MIN ||
+			parsed > ACTIVITY_LOG_RETENTION_MAX
+		) {
+			toast.error(
+				`Retention must be between ${ACTIVITY_LOG_RETENTION_MIN} and ${ACTIVITY_LOG_RETENTION_MAX} days`,
+			);
+			return;
+		}
+
+		startTransition(async () => {
+			const result = await updateActivityLogRetentionDays(parsed);
+			if (!result.success) {
+				toast.error(result.error ?? "Failed to update retention");
+				return;
+			}
+			toast.success(`Activity log retention set to ${parsed} days`);
+		});
+	}
+
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
+			<div className="px-8 pt-8 pb-2">
+				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
+					Activity Log Retention
+				</h3>
+				<p className="mt-2 text-sm text-muted-foreground">
+					How many days to keep activity logs before they are pruned automatically.
+				</p>
+			</div>
+
+			<div className="px-8 py-6">
+				<div className="flex items-center justify-between gap-4 rounded-2xl border border-gray-200 dark:border-white/10 p-5">
+					<div className="flex-1">
+						<p className="text-sm font-medium text-foreground">Retention period (days)</p>
+						<p className="text-xs text-muted-foreground">
+							Between {ACTIVITY_LOG_RETENTION_MIN} and {ACTIVITY_LOG_RETENTION_MAX} days.
+						</p>
+					</div>
+
+					<div className="flex items-center gap-2">
+						<Input
+							type="number"
+							min={ACTIVITY_LOG_RETENTION_MIN}
+							max={ACTIVITY_LOG_RETENTION_MAX}
+							value={days}
+							onChange={(e) => setDays(e.target.value)}
+							className="w-28"
+							disabled={isPending}
+						/>
+						<Button onClick={handleSave} disabled={isPending}>
+							{isPending ? "Saving…" : "Save"}
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/super-admin/page.tsx
+++ b/app/(dashboard)/dashboard/super-admin/page.tsx
@@ -1,6 +1,11 @@
 import { redirect } from "next/navigation";
-import { getOAuthProviderAvailability, getOAuthSettings } from "@/lib/actions/settings-actions";
+import {
+	getActivityLogRetentionDays,
+	getOAuthProviderAvailability,
+	getOAuthSettings,
+} from "@/lib/actions/settings-actions";
 import { requireRole } from "@/lib/auth-utils";
+import { ActivityLogRetentionPanel } from "./_components/activity-log-retention";
 import { OAuthSettingsPanel } from "./_components/oauth-settings";
 
 export default async function SuperAdminPage() {
@@ -10,8 +15,11 @@ export default async function SuperAdminPage() {
 		redirect("/dashboard");
 	}
 
-	const oauthSettings = await getOAuthSettings();
-	const providerAvailability = await getOAuthProviderAvailability();
+	const [oauthSettings, providerAvailability, retentionDays] = await Promise.all([
+		getOAuthSettings(),
+		getOAuthProviderAvailability(),
+		getActivityLogRetentionDays(),
+	]);
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-8 mt-2">
@@ -28,6 +36,8 @@ export default async function SuperAdminPage() {
 				initialSettings={oauthSettings}
 				providerAvailability={providerAvailability}
 			/>
+
+			<ActivityLogRetentionPanel initialDays={retentionDays} />
 		</div>
 	);
 }

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import {
 	Building2,
+	ChevronDown,
 	Heart,
 	LayoutDashboard,
 	LogOut,
@@ -24,12 +25,20 @@ import { cn } from "@/lib/utils";
 
 type MinRole = "STAFF" | "ADMIN" | "SUPERADMIN";
 
-const NAV_ITEMS: {
+interface NavChild {
+	label: string;
+	href: string;
+}
+
+interface NavItem {
 	label: string;
 	href: string;
 	icon: React.ComponentType<{ size?: number }>;
 	minRole: MinRole;
-}[] = [
+	children?: NavChild[];
+}
+
+const NAV_ITEMS: NavItem[] = [
 	{
 		label: "Dashboard",
 		href: "/dashboard",
@@ -71,6 +80,12 @@ const NAV_ITEMS: {
 		href: "/dashboard/admin-settings",
 		icon: Settings,
 		minRole: "ADMIN",
+		children: [
+			{
+				label: "Activity Logs",
+				href: "/dashboard/admin-settings/activity-logs",
+			},
+		],
 	},
 	{
 		label: "Super Admin",
@@ -112,25 +127,63 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
 
 			<nav className="flex-1 space-y-1">
 				{filteredItems.map((item) => {
-					const isActive =
-						pathname === item.href ||
-						(item.href !== "/dashboard" && pathname.startsWith(item.href));
+					const hasChildren = !!item.children?.length;
+					const isInGroup = item.href !== "/dashboard" && pathname.startsWith(item.href);
+					const isActive = hasChildren
+						? pathname === item.href
+						: pathname === item.href ||
+							(item.href !== "/dashboard" && pathname.startsWith(item.href));
+
 					return (
-						<Link
-							key={item.href}
-							href={item.href}
-							onClick={onNavigate}
-							className={cn(
-								"flex w-full items-center gap-3 rounded-full px-4 py-3 text-sm font-medium transition-all duration-200",
-								isActive
-									? "bg-[oklch(0.96_0.03_18)] text-primary dark:bg-primary/15 dark:text-primary"
-									: "text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5",
+						<div key={item.href}>
+							<Link
+								href={item.href}
+								onClick={onNavigate}
+								className={cn(
+									"flex w-full items-center gap-3 rounded-full px-4 py-3 text-sm font-medium transition-all duration-200",
+									isActive
+										? "bg-[oklch(0.96_0.03_18)] text-primary dark:bg-primary/15 dark:text-primary"
+										: "text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5",
+								)}
+							>
+								<item.icon size={22} />
+								<span className="flex-1">{item.label}</span>
+								{item.href === "/dashboard/recognition" && <NotificationBadge />}
+								{hasChildren && (
+									<ChevronDown
+										size={16}
+										className={cn(
+											"transition-transform duration-200",
+											isInGroup ? "rotate-0" : "-rotate-90",
+										)}
+									/>
+								)}
+							</Link>
+
+							{hasChildren && isInGroup && (
+								<div className="mt-1 ml-7 space-y-1 border-l border-gray-200/60 dark:border-white/10 pl-3">
+									{item.children?.map((child) => {
+										const childActive =
+											pathname === child.href || pathname.startsWith(`${child.href}/`);
+										return (
+											<Link
+												key={child.href}
+												href={child.href}
+												onClick={onNavigate}
+												className={cn(
+													"flex w-full items-center rounded-full px-4 py-2 text-sm font-medium transition-all duration-200",
+													childActive
+														? "bg-[oklch(0.96_0.03_18)] text-primary dark:bg-primary/15 dark:text-primary"
+														: "text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5",
+												)}
+											>
+												{child.label}
+											</Link>
+										);
+									})}
+								</div>
 							)}
-						>
-							<item.icon size={22} />
-							{item.label}
-							{item.href === "/dashboard/recognition" && <NotificationBadge />}
-						</Link>
+						</div>
 					);
 				})}
 			</nav>

--- a/env.ts
+++ b/env.ts
@@ -17,6 +17,10 @@ export const env = createEnv({
 		R2_SECRET_ACCESS_KEY: z.string().min(1).optional(),
 		R2_BUCKET_NAME: z.string().min(1).optional(),
 		R2_PUBLIC_URL: z.string().url().optional(),
+		TRUST_PROXY_HEADERS: z
+			.enum(["true", "false"])
+			.default("false")
+			.transform((v) => v === "true"),
 	},
 	client: {
 		NEXT_PUBLIC_APP_URL: z.string().url(),

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -1,6 +1,12 @@
 "use server";
 
 import { env } from "@/env";
+import {
+	ACTIVITY_LOG_RETENTION_DEFAULT,
+	ACTIVITY_LOG_RETENTION_KEY,
+	ACTIVITY_LOG_RETENTION_MAX,
+	ACTIVITY_LOG_RETENTION_MIN,
+} from "@/lib/activity-log-retention";
 import { requireRole } from "@/lib/auth-utils";
 import {
 	getOrCreateGlobalEntry,
@@ -129,6 +135,49 @@ export async function updateTopRecognizedLimit(
 	});
 
 	invalidateTopLimitCache();
+
+	return { success: true };
+}
+
+/* ── Activity Log Retention ──────────────────────────── */
+
+export async function getActivityLogRetentionDays(): Promise<number> {
+	const row = await prisma.appSetting.findUnique({
+		where: { key: ACTIVITY_LOG_RETENTION_KEY },
+	});
+	const parsed = row ? Number.parseInt(row.value, 10) : Number.NaN;
+	return Number.isInteger(parsed) &&
+		parsed >= ACTIVITY_LOG_RETENTION_MIN &&
+		parsed <= ACTIVITY_LOG_RETENTION_MAX
+		? parsed
+		: ACTIVITY_LOG_RETENTION_DEFAULT;
+}
+
+export async function updateActivityLogRetentionDays(
+	days: number,
+): Promise<{ success: boolean; error?: string }> {
+	try {
+		await requireRole("SUPERADMIN");
+	} catch {
+		return { success: false, error: "Unauthorized" };
+	}
+
+	if (
+		!Number.isInteger(days) ||
+		days < ACTIVITY_LOG_RETENTION_MIN ||
+		days > ACTIVITY_LOG_RETENTION_MAX
+	) {
+		return {
+			success: false,
+			error: `Retention must be between ${ACTIVITY_LOG_RETENTION_MIN} and ${ACTIVITY_LOG_RETENTION_MAX} days`,
+		};
+	}
+
+	await prisma.appSetting.upsert({
+		where: { key: ACTIVITY_LOG_RETENTION_KEY },
+		update: { value: String(days) },
+		create: { key: ACTIVITY_LOG_RETENTION_KEY, value: String(days) },
+	});
 
 	return { success: true };
 }

--- a/lib/activity-log-retention.ts
+++ b/lib/activity-log-retention.ts
@@ -1,0 +1,4 @@
+export const ACTIVITY_LOG_RETENTION_KEY = "activity_log_retention_days";
+export const ACTIVITY_LOG_RETENTION_DEFAULT = 180;
+export const ACTIVITY_LOG_RETENTION_MIN = 30;
+export const ACTIVITY_LOG_RETENTION_MAX = 3650;

--- a/lib/activity-log.ts
+++ b/lib/activity-log.ts
@@ -1,4 +1,5 @@
 import type { ActivityAction, Prisma } from "@/app/generated/prisma/client";
+import { env } from "@/env";
 import {
 	ACTIVITY_LOG_RETENTION_DEFAULT,
 	ACTIVITY_LOG_RETENTION_KEY,
@@ -36,9 +37,16 @@ export async function logActivity(input: LogActivityInput) {
 	}
 }
 
+function firstIp(value: string | null): string | null {
+	return value?.split(",")[0]?.trim() || null;
+}
+
 export function extractRequestMeta(headers: Headers) {
-	const forwarded = headers.get("x-forwarded-for");
-	const ipAddress = forwarded?.split(",")[0]?.trim() || headers.get("x-real-ip") || null;
+	const vercel = firstIp(headers.get("x-vercel-forwarded-for"));
+	let ipAddress = vercel;
+	if (!ipAddress && env.TRUST_PROXY_HEADERS) {
+		ipAddress = headers.get("x-real-ip") || firstIp(headers.get("x-forwarded-for"));
+	}
 	const userAgent = headers.get("user-agent");
 	return { ipAddress, userAgent };
 }

--- a/lib/activity-log.ts
+++ b/lib/activity-log.ts
@@ -1,0 +1,77 @@
+import type { ActivityAction, Prisma } from "@/app/generated/prisma/client";
+import {
+	ACTIVITY_LOG_RETENTION_DEFAULT,
+	ACTIVITY_LOG_RETENTION_KEY,
+} from "@/lib/activity-log-retention";
+import { prisma } from "@/lib/db";
+
+interface LogActivityInput {
+	action: ActivityAction;
+	actorId?: string | null;
+	targetType?: string | null;
+	targetId?: string | null;
+	metadata?: Prisma.InputJsonValue;
+	ipAddress?: string | null;
+	userAgent?: string | null;
+}
+
+export async function logActivity(input: LogActivityInput) {
+	try {
+		await prisma.activityLog.create({
+			data: {
+				action: input.action,
+				actorId: input.actorId ?? null,
+				targetType: input.targetType ?? null,
+				targetId: input.targetId ?? null,
+				metadata: input.metadata,
+				ipAddress: input.ipAddress ?? null,
+				userAgent: input.userAgent ?? null,
+			},
+		});
+	} catch (err) {
+		console.error("activity-log write failed", {
+			action: input.action,
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
+
+export function extractRequestMeta(headers: Headers) {
+	const forwarded = headers.get("x-forwarded-for");
+	const ipAddress = forwarded?.split(",")[0]?.trim() || headers.get("x-real-ip") || null;
+	const userAgent = headers.get("user-agent");
+	return { ipAddress, userAgent };
+}
+
+const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const LAST_PRUNE_KEY = "activity_log_last_prune";
+
+export async function pruneActivityLogsIfNeeded() {
+	try {
+		const [lastPrune, retentionRow] = await Promise.all([
+			prisma.appSetting.findUnique({ where: { key: LAST_PRUNE_KEY } }),
+			prisma.appSetting.findUnique({ where: { key: ACTIVITY_LOG_RETENTION_KEY } }),
+		]);
+
+		const now = Date.now();
+		const lastPruneMs = lastPrune ? Number.parseInt(lastPrune.value, 10) : 0;
+		if (Number.isFinite(lastPruneMs) && now - lastPruneMs < PRUNE_INTERVAL_MS) return;
+
+		const retentionParsed = retentionRow ? Number.parseInt(retentionRow.value, 10) : Number.NaN;
+		const days = Number.isInteger(retentionParsed)
+			? retentionParsed
+			: ACTIVITY_LOG_RETENTION_DEFAULT;
+		const cutoff = new Date(now - days * 24 * 60 * 60 * 1000);
+
+		await prisma.$transaction([
+			prisma.activityLog.deleteMany({ where: { createdAt: { lt: cutoff } } }),
+			prisma.appSetting.upsert({
+				where: { key: LAST_PRUNE_KEY },
+				update: { value: String(now) },
+				create: { key: LAST_PRUNE_KEY, value: String(now) },
+			}),
+		]);
+	} catch (err) {
+		console.error("activity-log prune failed", err);
+	}
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,9 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
+import { createAuthMiddleware } from "better-auth/api";
 import { after } from "next/server";
 import { env } from "@/env";
+import { extractRequestMeta, logActivity } from "@/lib/activity-log";
 import { mapGoogleProfile, mapMicrosoftProfile } from "@/lib/auth/profile-mappers";
 import { prisma } from "@/lib/db";
 import { syncMicrosoftAvatar } from "@/lib/microsoft-avatar";
@@ -43,10 +45,87 @@ export const auth = betterAuth({
 			trustedProviders: ["google", "microsoft"],
 		},
 	},
+	hooks: {
+		after: createAuthMiddleware(async (ctx) => {
+			const headers = ctx.request?.headers ?? ctx.headers ?? new Headers();
+			const { ipAddress, userAgent } = extractRequestMeta(headers);
+			const returned = ctx.context?.returned;
+			const isError = returned instanceof Response && !returned.ok;
+			const actorId = ctx.context?.session?.user?.id ?? null;
+			const bodyEmail =
+				typeof ctx.body === "object" && ctx.body && "email" in ctx.body
+					? String((ctx.body as { email?: unknown }).email ?? "")
+					: null;
+
+			switch (ctx.path) {
+				case "/sign-in/email":
+					if (isError) {
+						await logActivity({
+							action: "SIGN_IN_FAILED",
+							metadata: bodyEmail ? { email: bodyEmail } : undefined,
+							ipAddress,
+							userAgent,
+						});
+					}
+					break;
+				case "/sign-out":
+					if (!isError && actorId) {
+						await logActivity({
+							action: "USER_SIGNED_OUT",
+							actorId,
+							ipAddress,
+							userAgent,
+						});
+					}
+					break;
+				case "/change-password":
+					if (!isError && actorId) {
+						await logActivity({
+							action: "PASSWORD_CHANGED",
+							actorId,
+							ipAddress,
+							userAgent,
+						});
+					}
+					break;
+				case "/reset-password":
+					if (!isError) {
+						await logActivity({
+							action: "PASSWORD_RESET",
+							metadata: bodyEmail ? { email: bodyEmail } : undefined,
+							ipAddress,
+							userAgent,
+						});
+					}
+					break;
+			}
+		}),
+	},
 	databaseHooks: {
+		session: {
+			create: {
+				after: async (session) => {
+					await logActivity({
+						action: "USER_SIGNED_IN",
+						actorId: session.userId,
+						ipAddress: session.ipAddress ?? null,
+						userAgent: session.userAgent ?? null,
+					});
+				},
+			},
+		},
 		account: {
 			create: {
 				after: async (account) => {
+					if (account.providerId === "google" || account.providerId === "microsoft") {
+						await logActivity({
+							action: "OAUTH_ACCOUNT_LINKED",
+							actorId: account.userId,
+							targetType: "provider",
+							targetId: account.providerId,
+						});
+					}
+
 					if (account.providerId !== "microsoft" || !account.accessToken) return;
 					const { userId, accessToken } = account;
 					const run = () =>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,15 @@ enum NotificationType {
   CARD_COMMENT
 }
 
+enum ActivityAction {
+  USER_SIGNED_IN
+  USER_SIGNED_OUT
+  SIGN_IN_FAILED
+  OAUTH_ACCOUNT_LINKED
+  PASSWORD_CHANGED
+  PASSWORD_RESET
+}
+
 model User {
   id            String    @id @default(cuid())
   name          String?
@@ -60,6 +69,7 @@ model User {
   cardReactions        CardReaction[]
   cardComments         CardComment[]
   shiftSchedule        ShiftSchedule?
+  activityLogs         ActivityLog[]     @relation("activityActor")
 
   @@map("users")
 }
@@ -224,6 +234,25 @@ model CardComment {
 
   @@index([cardId, createdAt])
   @@map("card_comments")
+}
+
+model ActivityLog {
+  id         String         @id @default(cuid())
+  action     ActivityAction
+  actorId    String?        @map("actor_id")
+  targetType String?        @map("target_type")
+  targetId   String?        @map("target_id")
+  metadata   Json?
+  ipAddress  String?        @map("ip_address")
+  userAgent  String?        @map("user_agent")
+  createdAt  DateTime       @default(now()) @map("created_at")
+
+  actor User? @relation("activityActor", fields: [actorId], references: [id], onDelete: SetNull)
+
+  @@index([createdAt])
+  @@index([actorId, createdAt])
+  @@index([action, createdAt])
+  @@map("activity_logs")
 }
 
 model Notification {


### PR DESCRIPTION
Closes #90

## Summary

- New `ActivityLog` table + `ActivityAction` enum logging 6 auth events (sign-in/out, failed sign-in, OAuth link, password change/reset).
- `/dashboard/admin-settings/activity-logs` ADMIN+ page with actor/action/date/target filters and pagination (50/page, filters preserved across pages).
- Configurable retention (default 180 days, range 30–3650) on `/dashboard/super-admin`. Pruning runs opportunistically on page load, throttled to once per 24h via an AppSetting.
- Admin Settings becomes an expandable sidebar group with Activity Logs nested underneath; auto-expands on any `/admin-settings/*` route.

## Implementation notes

- Hooks: `databaseHooks.session.create.after` catches all successful sign-ins (email + OAuth); `hooks.after` middleware handles `/sign-in/email` failures, `/sign-out`, `/change-password`, `/reset-password`; `databaseHooks.account.create.after` logs OAuth link for google/microsoft only.
- `logActivity()` is fire-and-forget (try/catch, never throws into the request path).
- Constants live in `lib/activity-log-retention.ts` so they're importable from client components without pulling in the `\"use server\"` module.

## Test plan

- [ ] Sign in with email → `USER_SIGNED_IN` entry with IP + user agent
- [ ] Sign in with wrong password → `SIGN_IN_FAILED` entry (no actor, email in metadata)
- [ ] Sign in with Google/Microsoft → both `USER_SIGNED_IN` and `OAUTH_ACCOUNT_LINKED` on first link
- [ ] Sign out → `USER_SIGNED_OUT` entry
- [ ] Change password → `PASSWORD_CHANGED` entry
- [ ] Reset password via flow → `PASSWORD_RESET` entry
- [ ] Filters work: actor, action, date range, target text
- [ ] Pagination preserves filters in URL
- [ ] STAFF user redirected away from `/dashboard/admin-settings/activity-logs`
- [ ] SUPERADMIN can change retention days on super-admin page; ADMIN cannot
- [ ] Admin Settings sidebar expands when on any `/admin-settings/*` path