### PR TITLE
feat(helpme): phase 1 — ticket create/list/detail

### DIFF
--- a/app/(dashboard)/dashboard/helpme/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/[id]/page.tsx
@@ -1,0 +1,79 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { getTicketByIdForCurrentUser } from "@/lib/actions/helpme-actions";
+import { getServerSession } from "@/lib/auth-utils";
+import { TICKET_CATEGORIES } from "@/lib/validations/helpme";
+
+const STATUS_STYLES: Record<string, string> = {
+	OPEN: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+	IN_PROGRESS: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+	RESOLVED: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
+	CLOSED: "bg-gray-200 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+};
+
+const STATUS_LABEL: Record<string, string> = {
+	OPEN: "Open",
+	IN_PROGRESS: "In Progress",
+	RESOLVED: "Resolved",
+	CLOSED: "Closed",
+};
+
+const CATEGORY_LABEL = Object.fromEntries(TICKET_CATEGORIES.map((c) => [c.value, c.label]));
+
+function formatDateTime(date: Date) {
+	return new Intl.DateTimeFormat("en-AU", {
+		day: "2-digit",
+		month: "short",
+		year: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	}).format(date);
+}
+
+export default async function TicketDetailPage({ params }: { params: Promise<{ id: string }> }) {
+	const session = await getServerSession();
+	if (!session) redirect("/login");
+
+	const { id } = await params;
+	const ticket = await getTicketByIdForCurrentUser(id);
+	if (!ticket) notFound();
+
+	return (
+		<div className="max-w-4xl mx-auto p-4 md:p-6 space-y-6">
+			<Link
+				href="/dashboard/helpme"
+				className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+			>
+				<ArrowLeft size={16} /> Back to tickets
+			</Link>
+
+			<div className="rounded-2xl border bg-card p-6 space-y-4">
+				<div className="flex flex-wrap items-start justify-between gap-3">
+					<div>
+						<h1 className="text-xl font-semibold">{ticket.subject}</h1>
+						<p className="text-xs text-muted-foreground mt-1">
+							Raised by {ticket.createdBy.firstName} {ticket.createdBy.lastName} ·{" "}
+							{formatDateTime(ticket.createdAt)}
+						</p>
+					</div>
+					<div className="flex items-center gap-2">
+						<Badge variant="outline">{CATEGORY_LABEL[ticket.category]}</Badge>
+						<Badge variant="secondary" className={STATUS_STYLES[ticket.status]}>
+							{STATUS_LABEL[ticket.status]}
+						</Badge>
+					</div>
+				</div>
+
+				<div className="whitespace-pre-wrap text-sm leading-relaxed text-foreground/90">
+					{ticket.body}
+				</div>
+			</div>
+
+			<div className="rounded-2xl border border-dashed p-6 text-center text-sm text-muted-foreground">
+				Threaded replies will be available in the next release.
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/helpme/_components/ticket-form.tsx
+++ b/app/(dashboard)/dashboard/helpme/_components/ticket-form.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { createTicketAction } from "@/lib/actions/helpme-actions";
+import {
+	type CreateTicketInput,
+	createTicketSchema,
+	TICKET_CATEGORIES,
+} from "@/lib/validations/helpme";
+
+const inputClass =
+	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
+
+export function TicketForm() {
+	const router = useRouter();
+	const [isLoading, setIsLoading] = useState(false);
+
+	const {
+		register,
+		handleSubmit,
+		formState: { errors },
+	} = useForm<CreateTicketInput>({
+		resolver: zodResolver(createTicketSchema),
+		defaultValues: { subject: "", body: "", category: "HR" },
+	});
+
+	async function onSubmit(data: CreateTicketInput) {
+		setIsLoading(true);
+		try {
+			const result = await createTicketAction(data);
+			if (!result.success) {
+				const msg = typeof result.error === "string" ? result.error : "Validation failed";
+				toast.error(msg);
+				return;
+			}
+			toast.success("Ticket submitted");
+			router.push(`/dashboard/helpme/${result.data.id}`);
+			router.refresh();
+		} catch {
+			toast.error("Something went wrong");
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	return (
+		<form onSubmit={handleSubmit(onSubmit)} className="space-y-5 rounded-2xl border bg-card p-6">
+			<div>
+				<label
+					htmlFor="ticket-category"
+					className="mb-1.5 ml-1 block text-sm font-medium text-foreground/70"
+				>
+					Category
+				</label>
+				<select id="ticket-category" className={inputClass} {...register("category")}>
+					{TICKET_CATEGORIES.map((c) => (
+						<option key={c.value} value={c.value}>
+							{c.label}
+						</option>
+					))}
+				</select>
+				{errors.category && (
+					<p className="mt-1 text-sm text-destructive">{errors.category.message}</p>
+				)}
+			</div>
+
+			<div>
+				<label
+					htmlFor="ticket-subject"
+					className="mb-1.5 ml-1 block text-sm font-medium text-foreground/70"
+				>
+					Subject
+				</label>
+				<input
+					id="ticket-subject"
+					placeholder="Short summary of the issue"
+					className={inputClass}
+					{...register("subject")}
+				/>
+				{errors.subject && (
+					<p className="mt-1 text-sm text-destructive">{errors.subject.message}</p>
+				)}
+			</div>
+
+			<div>
+				<label
+					htmlFor="ticket-body"
+					className="mb-1.5 ml-1 block text-sm font-medium text-foreground/70"
+				>
+					Description
+				</label>
+				<textarea
+					id="ticket-body"
+					rows={8}
+					placeholder="Please describe the issue in detail..."
+					className={inputClass}
+					{...register("body")}
+				/>
+				{errors.body && <p className="mt-1 text-sm text-destructive">{errors.body.message}</p>}
+			</div>
+
+			<div className="flex justify-end gap-2 pt-2">
+				<button
+					type="button"
+					onClick={() => router.back()}
+					className="inline-flex items-center justify-center rounded-full border border-gray-200 bg-card px-6 py-2.5 text-sm font-medium text-foreground transition-all duration-200 hover:bg-gray-50 dark:border-white/10 dark:hover:bg-white/5"
+				>
+					Cancel
+				</button>
+				<button
+					type="submit"
+					disabled={isLoading}
+					className="inline-flex items-center justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground transition-all duration-200 hover:bg-primary/90 disabled:opacity-50"
+				>
+					{isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+					Submit Ticket
+				</button>
+			</div>
+		</form>
+	);
+}

--- a/app/(dashboard)/dashboard/helpme/_components/ticket-list.tsx
+++ b/app/(dashboard)/dashboard/helpme/_components/ticket-list.tsx
@@ -13,7 +13,7 @@ import { TICKET_CATEGORIES } from "@/lib/validations/helpme";
 type TicketRow = {
 	id: string;
 	subject: string;
-	category: "HR" | "IT_WEBSITE" | "PAYROLL" | "FACILITIES" | "OTHER";
+	category: "HR" | "IT_WEBSITE" | "FACILITIES" | "OTHER";
 	status: "OPEN" | "IN_PROGRESS" | "RESOLVED" | "CLOSED";
 	createdAt: Date;
 	updatedAt: Date;

--- a/app/(dashboard)/dashboard/helpme/_components/ticket-list.tsx
+++ b/app/(dashboard)/dashboard/helpme/_components/ticket-list.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { TICKET_CATEGORIES } from "@/lib/validations/helpme";
+
+type TicketRow = {
+	id: string;
+	subject: string;
+	category: "HR" | "IT_WEBSITE" | "PAYROLL" | "FACILITIES" | "OTHER";
+	status: "OPEN" | "IN_PROGRESS" | "RESOLVED" | "CLOSED";
+	createdAt: Date;
+	updatedAt: Date;
+	createdBy: {
+		id: string;
+		firstName: string;
+		lastName: string;
+		avatar: string | null;
+	};
+	_count: { replies: number };
+};
+
+const STATUS_STYLES: Record<TicketRow["status"], string> = {
+	OPEN: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+	IN_PROGRESS: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+	RESOLVED: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
+	CLOSED: "bg-gray-200 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+};
+
+const STATUS_LABEL: Record<TicketRow["status"], string> = {
+	OPEN: "Open",
+	IN_PROGRESS: "In Progress",
+	RESOLVED: "Resolved",
+	CLOSED: "Closed",
+};
+
+const CATEGORY_LABEL = Object.fromEntries(
+	TICKET_CATEGORIES.map((c) => [c.value, c.label]),
+) as Record<TicketRow["category"], string>;
+
+function formatDate(date: Date) {
+	return new Intl.DateTimeFormat("en-AU", {
+		day: "2-digit",
+		month: "short",
+		year: "numeric",
+	}).format(date);
+}
+
+export function TicketList({ tickets, isAdmin }: { tickets: TicketRow[]; isAdmin: boolean }) {
+	if (tickets.length === 0) {
+		return (
+			<div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
+				{isAdmin ? "No tickets have been raised yet." : "You haven’t raised any tickets yet."}
+			</div>
+		);
+	}
+
+	return (
+		<div className="rounded-lg border">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead>Subject</TableHead>
+						<TableHead>Category</TableHead>
+						<TableHead>Status</TableHead>
+						{isAdmin && <TableHead>Raised by</TableHead>}
+						<TableHead>Replies</TableHead>
+						<TableHead>Created</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{tickets.map((t) => (
+						<TableRow key={t.id} className="cursor-pointer hover:bg-muted/40">
+							<TableCell className="font-medium">
+								<Link href={`/dashboard/helpme/${t.id}`} className="hover:underline">
+									{t.subject}
+								</Link>
+							</TableCell>
+							<TableCell>{CATEGORY_LABEL[t.category]}</TableCell>
+							<TableCell>
+								<Badge variant="secondary" className={STATUS_STYLES[t.status]}>
+									{STATUS_LABEL[t.status]}
+								</Badge>
+							</TableCell>
+							{isAdmin && (
+								<TableCell>
+									{t.createdBy.firstName} {t.createdBy.lastName}
+								</TableCell>
+							)}
+							<TableCell>{t._count.replies}</TableCell>
+							<TableCell className="text-muted-foreground">{formatDate(t.createdAt)}</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/helpme/new/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/new/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "@/lib/auth-utils";
+import { TicketForm } from "../_components/ticket-form";
+
+export default async function NewTicketPage() {
+	const session = await getServerSession();
+	if (!session) redirect("/login");
+
+	return (
+		<div className="max-w-2xl mx-auto p-4 md:p-6">
+			<div className="mb-6">
+				<h1 className="text-2xl font-semibold">Raise a Ticket</h1>
+				<p className="text-sm text-muted-foreground">
+					Describe your issue and the right team will respond as soon as possible.
+				</p>
+			</div>
+			<TicketForm />
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/helpme/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { buttonVariants } from "@/components/ui/button";
 import { listTicketsForCurrentUser } from "@/lib/actions/helpme-actions";
 import { getServerSession } from "@/lib/auth-utils";
 import { TicketList } from "./_components/ticket-list";
@@ -22,7 +21,10 @@ export default async function HelpMePage() {
 							: "Raise an issue or request help from HR/IT."}
 					</p>
 				</div>
-				<Link href="/dashboard/helpme/new" className={buttonVariants({ size: "lg" })}>
+				<Link
+					href="/dashboard/helpme/new"
+					className="inline-flex items-center justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground transition-all duration-200 hover:bg-primary/90"
+				>
 					New Ticket
 				</Link>
 			</div>

--- a/app/(dashboard)/dashboard/helpme/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { buttonVariants } from "@/components/ui/button";
+import { listTicketsForCurrentUser } from "@/lib/actions/helpme-actions";
+import { getServerSession } from "@/lib/auth-utils";
+import { TicketList } from "./_components/ticket-list";
+
+export default async function HelpMePage() {
+	const session = await getServerSession();
+	if (!session) redirect("/login");
+
+	const { tickets, isAdmin } = await listTicketsForCurrentUser();
+
+	return (
+		<div className="max-w-6xl mx-auto p-4 md:p-6 space-y-6">
+			<div className="flex items-center justify-between gap-4">
+				<div>
+					<h1 className="text-2xl font-semibold">{isAdmin ? "Help Me Tickets" : "My Tickets"}</h1>
+					<p className="text-sm text-muted-foreground">
+						{isAdmin
+							? "Respond to tickets raised by staff."
+							: "Raise an issue or request help from HR/IT."}
+					</p>
+				</div>
+				<Link href="/dashboard/helpme/new" className={buttonVariants({ size: "lg" })}>
+					New Ticket
+				</Link>
+			</div>
+
+			<TicketList tickets={tickets} isAdmin={isAdmin} />
+		</div>
+	);
+}

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -5,6 +5,7 @@ import {
 	ChevronDown,
 	Heart,
 	LayoutDashboard,
+	LifeBuoy,
 	LogOut,
 	Menu,
 	Settings,
@@ -32,6 +33,7 @@ interface NavChild {
 
 interface NavItem {
 	label: string;
+	adminLabel?: string;
 	href: string;
 	icon: React.ComponentType<{ size?: number }>;
 	minRole: MinRole;
@@ -73,6 +75,13 @@ const NAV_ITEMS: NavItem[] = [
 		label: "My Profile",
 		href: "/dashboard/profile",
 		icon: UserCircle,
+		minRole: "STAFF",
+	},
+	{
+		label: "My Tickets",
+		adminLabel: "Help Me Tickets",
+		href: "/dashboard/helpme",
+		icon: LifeBuoy,
 		minRole: "STAFF",
 	},
 	{
@@ -147,7 +156,11 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
 								)}
 							>
 								<item.icon size={22} />
-								<span className="flex-1">{item.label}</span>
+								<span className="flex-1">
+									{roleLevel[userRole] >= roleLevel.ADMIN && item.adminLabel
+										? item.adminLabel
+										: item.label}
+								</span>
 								{item.href === "/dashboard/recognition" && <NotificationBadge />}
 								{hasChildren && (
 									<ChevronDown

--- a/lib/actions/helpme-actions.test.ts
+++ b/lib/actions/helpme-actions.test.ts
@@ -36,9 +36,9 @@ const mockSession = (userId: string, role: "STAFF" | "ADMIN" | "SUPERADMIN" = "S
 });
 
 const validInput = (overrides: Partial<Record<string, unknown>> = {}) => ({
-	subject: "Need help with payroll",
-	body: "My last payslip seems incorrect — please advise.",
-	category: "PAYROLL" as const,
+	subject: "Need help with HR",
+	body: "I have a question about leave balances — please advise.",
+	category: "HR" as const,
 	...overrides,
 });
 
@@ -58,8 +58,8 @@ describe("createTicketAction", () => {
 		expect(result).toEqual({ success: true, data: { id: "ticket_1" } });
 		expect(prisma.helpMeTicket.create).toHaveBeenCalledWith({
 			data: expect.objectContaining({
-				subject: "Need help with payroll",
-				category: "PAYROLL",
+				subject: "Need help with HR",
+				category: "HR",
 				createdById: STAFF_ID,
 			}),
 			select: { id: true },

--- a/lib/actions/helpme-actions.test.ts
+++ b/lib/actions/helpme-actions.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+	revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+	requireSession: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		helpMeTicket: {
+			create: vi.fn(),
+			findMany: vi.fn(),
+			findUnique: vi.fn(),
+		},
+	},
+}));
+
+import { requireSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+import {
+	createTicketAction,
+	getTicketByIdForCurrentUser,
+	listTicketsForCurrentUser,
+} from "./helpme-actions";
+
+const STAFF_ID = "staff_1";
+const OTHER_STAFF_ID = "staff_2";
+const ADMIN_ID = "admin_1";
+
+const mockSession = (userId: string, role: "STAFF" | "ADMIN" | "SUPERADMIN" = "STAFF") => ({
+	user: { id: userId, name: "Tester", role },
+	session: { id: "sess_1" },
+});
+
+const validInput = (overrides: Partial<Record<string, unknown>> = {}) => ({
+	subject: "Need help with payroll",
+	body: "My last payslip seems incorrect — please advise.",
+	category: "PAYROLL" as const,
+	...overrides,
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("createTicketAction", () => {
+	test("creates a ticket on happy path", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(STAFF_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.helpMeTicket.create).mockResolvedValue({ id: "ticket_1" } as never);
+
+		const result = await createTicketAction(validInput());
+
+		expect(result).toEqual({ success: true, data: { id: "ticket_1" } });
+		expect(prisma.helpMeTicket.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				subject: "Need help with payroll",
+				category: "PAYROLL",
+				createdById: STAFF_ID,
+			}),
+			select: { id: true },
+		});
+	});
+
+	test("returns field errors when input fails zod validation", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(STAFF_ID) as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+
+		const result = await createTicketAction(validInput({ subject: "", body: "tooshort" }));
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const err = result.error as Record<string, string[] | undefined>;
+			expect(err.subject?.length).toBeGreaterThan(0);
+			expect(err.body?.length).toBeGreaterThan(0);
+		}
+		expect(prisma.helpMeTicket.create).not.toHaveBeenCalled();
+	});
+
+	test("returns error when session is missing", async () => {
+		vi.mocked(requireSession).mockRejectedValue(new Error("Unauthorized"));
+
+		const result = await createTicketAction(validInput());
+
+		expect(result).toEqual({ success: false, error: "Unauthorized" });
+	});
+});
+
+describe("listTicketsForCurrentUser", () => {
+	test("scopes query to current user for STAFF", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(STAFF_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.helpMeTicket.findMany).mockResolvedValue([] as never);
+
+		const result = await listTicketsForCurrentUser();
+
+		expect(result.isAdmin).toBe(false);
+		expect(prisma.helpMeTicket.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({ where: { createdById: STAFF_ID } }),
+		);
+	});
+
+	test("omits scope for ADMIN (sees all)", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(ADMIN_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.helpMeTicket.findMany).mockResolvedValue([] as never);
+
+		const result = await listTicketsForCurrentUser();
+
+		expect(result.isAdmin).toBe(true);
+		expect(prisma.helpMeTicket.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({ where: undefined }),
+		);
+	});
+});
+
+describe("getTicketByIdForCurrentUser", () => {
+	test("returns ticket when STAFF is the creator", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(STAFF_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.helpMeTicket.findUnique).mockResolvedValue({
+			id: "t1",
+			createdById: STAFF_ID,
+		} as never);
+
+		const result = await getTicketByIdForCurrentUser("t1");
+
+		expect(result).not.toBeNull();
+	});
+
+	test("returns null when STAFF tries to access another user's ticket", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(STAFF_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.helpMeTicket.findUnique).mockResolvedValue({
+			id: "t1",
+			createdById: OTHER_STAFF_ID,
+		} as never);
+
+		const result = await getTicketByIdForCurrentUser("t1");
+
+		expect(result).toBeNull();
+	});
+
+	test("returns ticket for ADMIN regardless of creator", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(ADMIN_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.helpMeTicket.findUnique).mockResolvedValue({
+			id: "t1",
+			createdById: OTHER_STAFF_ID,
+		} as never);
+
+		const result = await getTicketByIdForCurrentUser("t1");
+
+		expect(result).not.toBeNull();
+	});
+
+	test("returns null when ticket does not exist", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(ADMIN_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.helpMeTicket.findUnique).mockResolvedValue(null);
+
+		const result = await getTicketByIdForCurrentUser("missing");
+
+		expect(result).toBeNull();
+	});
+});

--- a/lib/actions/helpme-actions.test.ts
+++ b/lib/actions/helpme-actions.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/db", () => ({
 		helpMeTicket: {
 			create: vi.fn(),
 			findMany: vi.fn(),
-			findUnique: vi.fn(),
+			findFirst: vi.fn(),
 		},
 	},
 }));
@@ -126,7 +126,7 @@ describe("getTicketByIdForCurrentUser", () => {
 		vi.mocked(requireSession).mockResolvedValue(
 			mockSession(STAFF_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
 		);
-		vi.mocked(prisma.helpMeTicket.findUnique).mockResolvedValue({
+		vi.mocked(prisma.helpMeTicket.findFirst).mockResolvedValue({
 			id: "t1",
 			createdById: STAFF_ID,
 		} as never);
@@ -136,25 +136,25 @@ describe("getTicketByIdForCurrentUser", () => {
 		expect(result).not.toBeNull();
 	});
 
-	test("returns null when STAFF tries to access another user's ticket", async () => {
+	test("scopes query to creator when STAFF requests a ticket", async () => {
 		vi.mocked(requireSession).mockResolvedValue(
 			mockSession(STAFF_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
 		);
-		vi.mocked(prisma.helpMeTicket.findUnique).mockResolvedValue({
-			id: "t1",
-			createdById: OTHER_STAFF_ID,
-		} as never);
+		vi.mocked(prisma.helpMeTicket.findFirst).mockResolvedValue(null);
 
 		const result = await getTicketByIdForCurrentUser("t1");
 
 		expect(result).toBeNull();
+		expect(prisma.helpMeTicket.findFirst).toHaveBeenCalledWith(
+			expect.objectContaining({ where: { id: "t1", createdById: STAFF_ID } }),
+		);
 	});
 
 	test("returns ticket for ADMIN regardless of creator", async () => {
 		vi.mocked(requireSession).mockResolvedValue(
 			mockSession(ADMIN_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
 		);
-		vi.mocked(prisma.helpMeTicket.findUnique).mockResolvedValue({
+		vi.mocked(prisma.helpMeTicket.findFirst).mockResolvedValue({
 			id: "t1",
 			createdById: OTHER_STAFF_ID,
 		} as never);
@@ -162,13 +162,16 @@ describe("getTicketByIdForCurrentUser", () => {
 		const result = await getTicketByIdForCurrentUser("t1");
 
 		expect(result).not.toBeNull();
+		expect(prisma.helpMeTicket.findFirst).toHaveBeenCalledWith(
+			expect.objectContaining({ where: { id: "t1" } }),
+		);
 	});
 
 	test("returns null when ticket does not exist", async () => {
 		vi.mocked(requireSession).mockResolvedValue(
 			mockSession(ADMIN_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
 		);
-		vi.mocked(prisma.helpMeTicket.findUnique).mockResolvedValue(null);
+		vi.mocked(prisma.helpMeTicket.findFirst).mockResolvedValue(null);
 
 		const result = await getTicketByIdForCurrentUser("missing");
 

--- a/lib/actions/helpme-actions.ts
+++ b/lib/actions/helpme-actions.ts
@@ -70,8 +70,8 @@ export async function getTicketByIdForCurrentUser(id: string) {
 	const role = session.user.role as Role;
 	const isAdmin = hasMinRole(role, "ADMIN");
 
-	const ticket = await prisma.helpMeTicket.findUnique({
-		where: { id },
+	const ticket = await prisma.helpMeTicket.findFirst({
+		where: isAdmin ? { id } : { id, createdById: session.user.id },
 		include: {
 			createdBy: {
 				select: {
@@ -79,14 +79,10 @@ export async function getTicketByIdForCurrentUser(id: string) {
 					firstName: true,
 					lastName: true,
 					avatar: true,
-					email: true,
 				},
 			},
 		},
 	});
-
-	if (!ticket) return null;
-	if (!isAdmin && ticket.createdById !== session.user.id) return null;
 
 	return ticket;
 }

--- a/lib/actions/helpme-actions.ts
+++ b/lib/actions/helpme-actions.ts
@@ -1,0 +1,92 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type { Role } from "@/app/generated/prisma/client";
+import { requireSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+import { hasMinRole } from "@/lib/permissions";
+import { createTicketSchema } from "@/lib/validations/helpme";
+
+export async function createTicketAction(formData: unknown) {
+	try {
+		const session = await requireSession();
+		const parsed = createTicketSchema.safeParse(formData);
+
+		if (!parsed.success) {
+			return {
+				success: false as const,
+				error: parsed.error.flatten().fieldErrors,
+			};
+		}
+
+		const ticket = await prisma.helpMeTicket.create({
+			data: {
+				...parsed.data,
+				createdById: session.user.id,
+			},
+			select: { id: true },
+		});
+
+		revalidatePath("/dashboard/helpme");
+		return { success: true as const, data: ticket };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to create ticket";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function listTicketsForCurrentUser() {
+	const session = await requireSession();
+	const role = session.user.role as Role;
+	const isAdmin = hasMinRole(role, "ADMIN");
+
+	const tickets = await prisma.helpMeTicket.findMany({
+		where: isAdmin ? undefined : { createdById: session.user.id },
+		orderBy: { createdAt: "desc" },
+		select: {
+			id: true,
+			subject: true,
+			category: true,
+			status: true,
+			createdAt: true,
+			updatedAt: true,
+			createdBy: {
+				select: {
+					id: true,
+					firstName: true,
+					lastName: true,
+					avatar: true,
+				},
+			},
+			_count: { select: { replies: true } },
+		},
+	});
+
+	return { tickets, isAdmin };
+}
+
+export async function getTicketByIdForCurrentUser(id: string) {
+	const session = await requireSession();
+	const role = session.user.role as Role;
+	const isAdmin = hasMinRole(role, "ADMIN");
+
+	const ticket = await prisma.helpMeTicket.findUnique({
+		where: { id },
+		include: {
+			createdBy: {
+				select: {
+					id: true,
+					firstName: true,
+					lastName: true,
+					avatar: true,
+					email: true,
+				},
+			},
+		},
+	});
+
+	if (!ticket) return null;
+	if (!isAdmin && ticket.createdById !== session.user.id) return null;
+
+	return ticket;
+}

--- a/lib/validations/helpme.ts
+++ b/lib/validations/helpme.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const TICKET_CATEGORIES = [
+	{ value: "HR", label: "HR" },
+	{ value: "IT_WEBSITE", label: "IT / Website" },
+	{ value: "PAYROLL", label: "Payroll" },
+	{ value: "FACILITIES", label: "Facilities" },
+	{ value: "OTHER", label: "Other" },
+] as const;
+
+export const createTicketSchema = z.object({
+	subject: z
+		.string()
+		.trim()
+		.min(3, "Subject must be at least 3 characters")
+		.max(120, "Subject must be 120 characters or less"),
+	body: z
+		.string()
+		.trim()
+		.min(10, "Please describe the issue (at least 10 characters)")
+		.max(5000, "Description must be 5000 characters or less"),
+	category: z.enum(["HR", "IT_WEBSITE", "PAYROLL", "FACILITIES", "OTHER"]),
+});
+
+export type CreateTicketInput = z.infer<typeof createTicketSchema>;

--- a/lib/validations/helpme.ts
+++ b/lib/validations/helpme.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 export const TICKET_CATEGORIES = [
 	{ value: "HR", label: "HR" },
 	{ value: "IT_WEBSITE", label: "IT / Website" },
-	{ value: "PAYROLL", label: "Payroll" },
 	{ value: "FACILITIES", label: "Facilities" },
 	{ value: "OTHER", label: "Other" },
 ] as const;
@@ -19,7 +18,7 @@ export const createTicketSchema = z.object({
 		.trim()
 		.min(10, "Please describe the issue (at least 10 characters)")
 		.max(5000, "Description must be 5000 characters or less"),
-	category: z.enum(["HR", "IT_WEBSITE", "PAYROLL", "FACILITIES", "OTHER"]),
+	category: z.enum(["HR", "IT_WEBSITE", "FACILITIES", "OTHER"]),
 });
 
 export type CreateTicketInput = z.infer<typeof createTicketSchema>;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,21 @@ enum ActivityAction {
   PASSWORD_RESET
 }
 
+enum TicketCategory {
+  HR
+  IT_WEBSITE
+  PAYROLL
+  FACILITIES
+  OTHER
+}
+
+enum TicketStatus {
+  OPEN
+  IN_PROGRESS
+  RESOLVED
+  CLOSED
+}
+
 model User {
   id            String    @id @default(cuid())
   name          String?
@@ -70,6 +85,8 @@ model User {
   cardComments         CardComment[]
   shiftSchedule        ShiftSchedule?
   activityLogs         ActivityLog[]     @relation("activityActor")
+  ticketsCreated       HelpMeTicket[]    @relation("ticketCreator")
+  ticketReplies        TicketReply[]     @relation("ticketReplyAuthor")
 
   @@map("users")
 }
@@ -271,4 +288,37 @@ model Notification {
   @@index([userId, isRead])
   @@index([userId, createdAt])
   @@map("notifications")
+}
+
+model HelpMeTicket {
+  id          String         @id @default(cuid())
+  subject     String
+  body        String
+  category    TicketCategory
+  status      TicketStatus   @default(OPEN)
+  createdById String         @map("created_by_id")
+  createdAt   DateTime       @default(now()) @map("created_at")
+  updatedAt   DateTime       @updatedAt @map("updated_at")
+
+  createdBy User          @relation("ticketCreator", fields: [createdById], references: [id])
+  replies   TicketReply[]
+
+  @@index([createdById, createdAt])
+  @@index([status, createdAt])
+  @@map("help_me_tickets")
+}
+
+model TicketReply {
+  id        String    @id @default(cuid())
+  ticketId  String    @map("ticket_id")
+  authorId  String    @map("author_id")
+  bodyHtml  String    @map("body_html")
+  editedAt  DateTime? @map("edited_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+
+  ticket HelpMeTicket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  author User         @relation("ticketReplyAuthor", fields: [authorId], references: [id])
+
+  @@index([ticketId, createdAt])
+  @@map("help_me_ticket_replies")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,7 +38,6 @@ enum ActivityAction {
 enum TicketCategory {
   HR
   IT_WEBSITE
-  PAYROLL
   FACILITIES
   OTHER
 }


### PR DESCRIPTION
Closes #93 · Part of #92

## Summary
- Adds Prisma models `HelpMeTicket` + placeholder `TicketReply`, with `TicketCategory` (HR / IT_WEBSITE / PAYROLL / FACILITIES / OTHER) and `TicketStatus` (OPEN / IN_PROGRESS / RESOLVED / CLOSED) enums.
- New route `/dashboard/helpme` — role-branched: STAFF see only their own tickets, ADMIN/SUPERADMIN see all (with raiser name column).
- `/dashboard/helpme/new` — staff-facing create form (react-hook-form + zod).
- `/dashboard/helpme/[id]` — detail view with the ticket body; threaded replies land in Phase 2 (#94).
- Sidebar entry next to **My Profile**: labeled "My Tickets" for STAFF, "Help Me Tickets" for ADMIN+.
- Server actions: `createTicketAction`, `listTicketsForCurrentUser`, `getTicketByIdForCurrentUser` — 9 unit tests covering happy path, zod errors, session failure, role-branched scoping, and foreign-ticket access rejection.

## Out of scope (future phases)
Threading (#94), status workflow (#95), attachments (#96), notifications (#97), floating FAB (#98).

## Test plan
- [ ] `bun run db:push` on dev DB (creates `help_me_tickets` + `help_me_ticket_replies`)
- [ ] As STAFF: create a ticket, see it in list, open detail — only own tickets visible
- [ ] As STAFF: try `GET /dashboard/helpme/<another-user-ticket-id>` → 404 (not-found, per `getTicketByIdForCurrentUser` returning null)
- [ ] As ADMIN: list shows all tickets with raiser column; open any ticket
- [ ] Sidebar shows "My Tickets" for STAFF, "Help Me Tickets" for ADMIN/SUPERADMIN
- [ ] `bunx vitest run` — 132/132 passing locally
- [ ] `bunx @biomejs/biome check` + `bunx tsc --noEmit` clean