### PR TITLE
refactor(helpme): align /helpme UI with site design system

### DIFF
--- a/app/(dashboard)/dashboard/helpme/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/[id]/page.tsx
@@ -55,67 +55,73 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
 	const creatorDisplay = displayReplyAuthor(ticket.createdBy, viewerRole);
 
 	return (
-		<div className="max-w-4xl mx-auto p-4 md:p-6 space-y-6">
+		<div className="max-w-7xl mx-auto space-y-6 mt-2">
 			<Link
 				href="/dashboard/helpme"
-				className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+				className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
 			>
 				<ArrowLeft size={16} /> Back to tickets
 			</Link>
 
-			<div className="rounded-2xl border bg-card p-6 space-y-4">
-				<div className="flex flex-wrap items-start justify-between gap-3">
-					<div>
-						<h1 className="text-xl font-semibold">{ticket.subject}</h1>
-						<p className="text-xs text-muted-foreground mt-1">
-							Raised by {creatorDisplay.displayName} · {formatDateTime(ticket.createdAt)}
-						</p>
+			<div className="max-w-4xl space-y-6">
+				<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-8 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] space-y-5">
+					<div className="flex flex-wrap items-start justify-between gap-3">
+						<div>
+							<h1 className="text-[1.5rem] font-medium leading-tight text-foreground tracking-tight">
+								{ticket.subject}
+							</h1>
+							<p className="text-sm text-muted-foreground mt-1.5">
+								Raised by {creatorDisplay.displayName} · {formatDateTime(ticket.createdAt)}
+							</p>
+						</div>
+						<div className="flex items-center gap-2">
+							<span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs font-medium text-primary dark:bg-primary/10">
+								{CATEGORY_LABEL[ticket.category]}
+							</span>
+							<Badge variant="secondary" className={STATUS_STYLES[ticket.status]}>
+								{STATUS_LABEL[ticket.status]}
+							</Badge>
+						</div>
 					</div>
-					<div className="flex items-center gap-2">
-						<Badge variant="outline">{CATEGORY_LABEL[ticket.category]}</Badge>
-						<Badge variant="secondary" className={STATUS_STYLES[ticket.status]}>
-							{STATUS_LABEL[ticket.status]}
-						</Badge>
-					</div>
-				</div>
 
-				<div
-					className="prose prose-sm dark:prose-invert max-w-none text-foreground/90"
-					// biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized here on read to protect against any pre-rich-text legacy rows
-					dangerouslySetInnerHTML={{ __html: sanitizeReplyHtml(ticket.body) }}
-				/>
-			</div>
-
-			<div className="space-y-3">
-				<h2 className="text-sm font-medium text-muted-foreground">
-					{ticket.replies.length === 0
-						? "No replies yet"
-						: `${ticket.replies.length} repl${ticket.replies.length === 1 ? "y" : "ies"}`}
-				</h2>
-				{ticket.replies.map((r) => (
-					<ReplyItem
-						key={r.id}
-						reply={{
-							id: r.id,
-							bodyHtml: r.bodyHtml,
-							createdAt: r.createdAt.toISOString(),
-							editedAt: r.editedAt ? r.editedAt.toISOString() : null,
-							canEdit: r.authorId === viewerId,
-							author: displayReplyAuthor(r.author, viewerRole),
-						}}
+					<div
+						className="prose prose-sm dark:prose-invert max-w-none text-foreground/90"
+						// biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized here on read to protect against any pre-rich-text legacy rows
+						dangerouslySetInnerHTML={{ __html: sanitizeReplyHtml(ticket.body) }}
 					/>
-				))}
-			</div>
+				</div>
 
-			{ticket.status === "CLOSED" ? (
-				<div className="rounded-2xl border border-dashed p-4 text-center text-sm text-muted-foreground">
-					This ticket is closed. Create a new ticket if you need further help.
+				<div className="space-y-3">
+					<h2 className="text-sm font-medium text-muted-foreground">
+						{ticket.replies.length === 0
+							? "No replies yet"
+							: `${ticket.replies.length} repl${ticket.replies.length === 1 ? "y" : "ies"}`}
+					</h2>
+					{ticket.replies.map((r) => (
+						<ReplyItem
+							key={r.id}
+							reply={{
+								id: r.id,
+								bodyHtml: r.bodyHtml,
+								createdAt: r.createdAt.toISOString(),
+								editedAt: r.editedAt ? r.editedAt.toISOString() : null,
+								canEdit: r.authorId === viewerId,
+								author: displayReplyAuthor(r.author, viewerRole),
+							}}
+						/>
+					))}
 				</div>
-			) : (
-				<div className="rounded-2xl border bg-card p-4">
-					<ReplyForm ticketId={ticket.id} />
-				</div>
-			)}
+
+				{ticket.status === "CLOSED" ? (
+					<div className="rounded-[2rem] border border-dashed border-gray-200 dark:border-white/10 bg-card/50 p-6 text-center text-sm text-muted-foreground">
+						This ticket is closed. Create a new ticket if you need further help.
+					</div>
+				) : (
+					<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+						<ReplyForm ticketId={ticket.id} />
+					</div>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/helpme/_components/clickable-ticket-row.tsx
+++ b/app/(dashboard)/dashboard/helpme/_components/clickable-ticket-row.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import type { ReactNode } from "react";
+import { TableRow } from "@/components/ui/table";
+
+export function ClickableTicketRow({ href, children }: { href: string; children: ReactNode }) {
+	const router = useRouter();
+
+	return (
+		<TableRow
+			onClick={(e) => {
+				const target = e.target as HTMLElement;
+				if (target.closest("a")) return;
+				if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+				const selection = window.getSelection();
+				if (selection && selection.toString().length > 0) return;
+				router.push(href);
+			}}
+			className="cursor-pointer hover:bg-muted/40"
+		>
+			{children}
+		</TableRow>
+	);
+}

--- a/app/(dashboard)/dashboard/helpme/_components/reply-item.tsx
+++ b/app/(dashboard)/dashboard/helpme/_components/reply-item.tsx
@@ -85,7 +85,7 @@ export function ReplyItem({ reply }: { reply: ReplyItemData }) {
 	}
 
 	return (
-		<div className="rounded-2xl border bg-card p-4">
+		<div className="rounded-2xl border border-gray-200/60 dark:border-white/10 bg-card p-5 shadow-[0_1px_12px_-4px_rgba(0,0,0,0.03)]">
 			<div className="flex items-start gap-3">
 				<Avatar author={reply.author} />
 				<div className="min-w-0 flex-1">

--- a/app/(dashboard)/dashboard/helpme/_components/ticket-form.tsx
+++ b/app/(dashboard)/dashboard/helpme/_components/ticket-form.tsx
@@ -51,7 +51,10 @@ export function TicketForm() {
 	}
 
 	return (
-		<form onSubmit={handleSubmit(onSubmit)} className="space-y-5 rounded-2xl border bg-card p-6">
+		<form
+			onSubmit={handleSubmit(onSubmit)}
+			className="space-y-5 rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-8 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]"
+		>
 			<div>
 				<label
 					htmlFor="ticket-category"

--- a/app/(dashboard)/dashboard/helpme/_components/ticket-list.tsx
+++ b/app/(dashboard)/dashboard/helpme/_components/ticket-list.tsx
@@ -1,4 +1,8 @@
+"use client";
+
+import { LifeBuoy } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import {
 	Table,
@@ -56,19 +60,31 @@ function formatDate(date: Date) {
 }
 
 export function TicketList({ tickets, isAdmin }: { tickets: TicketRow[]; isAdmin: boolean }) {
+	const router = useRouter();
+
 	if (tickets.length === 0) {
 		return (
-			<div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
-				{isAdmin ? "No tickets have been raised yet." : "You haven’t raised any tickets yet."}
+			<div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 dark:border-white/10 bg-card p-16">
+				<div className="mb-6 rounded-full bg-background p-6">
+					<LifeBuoy size={48} className="text-muted-foreground opacity-40" />
+				</div>
+				<p className="text-[1.5rem] font-medium text-foreground">
+					{isAdmin ? "No tickets yet" : "No tickets raised yet"}
+				</p>
+				<p className="mt-2 text-base text-muted-foreground">
+					{isAdmin
+						? "Tickets raised by staff will appear here."
+						: "Need a hand? Raise a ticket and the right team will follow up."}
+				</p>
 			</div>
 		);
 	}
 
 	return (
-		<div className="rounded-lg border">
+		<div className="rounded-xl border border-gray-200/60 dark:border-white/10 bg-card overflow-hidden shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
 			<Table>
 				<TableHeader>
-					<TableRow>
+					<TableRow className="bg-muted/30 hover:bg-muted/30">
 						<TableHead>Subject</TableHead>
 						<TableHead>Category</TableHead>
 						<TableHead>Status</TableHead>
@@ -78,28 +94,44 @@ export function TicketList({ tickets, isAdmin }: { tickets: TicketRow[]; isAdmin
 					</TableRow>
 				</TableHeader>
 				<TableBody>
-					{tickets.map((t) => (
-						<TableRow key={t.id} className="cursor-pointer hover:bg-muted/40">
-							<TableCell className="font-medium">
-								<Link href={`/dashboard/helpme/${t.id}`} className="hover:underline">
-									{t.subject}
-								</Link>
-							</TableCell>
-							<TableCell>{CATEGORY_LABEL[t.category]}</TableCell>
-							<TableCell>
-								<Badge variant="secondary" className={STATUS_STYLES[t.status]}>
-									{STATUS_LABEL[t.status]}
-								</Badge>
-							</TableCell>
-							{isAdmin && (
-								<TableCell>
-									{t.createdBy.firstName} {t.createdBy.lastName}
+					{tickets.map((t) => {
+						const href = `/dashboard/helpme/${t.id}`;
+						return (
+							<TableRow
+								key={t.id}
+								onClick={() => router.push(href)}
+								onMouseEnter={() => router.prefetch(href)}
+								className="cursor-pointer hover:bg-muted/40"
+							>
+								<TableCell className="font-medium">
+									<Link
+										href={href}
+										onClick={(e) => e.stopPropagation()}
+										className="hover:underline focus-visible:underline focus-visible:outline-none"
+									>
+										{t.subject}
+									</Link>
 								</TableCell>
-							)}
-							<TableCell>{t._count.replies}</TableCell>
-							<TableCell className="text-muted-foreground">{formatDate(t.createdAt)}</TableCell>
-						</TableRow>
-					))}
+								<TableCell>
+									<span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs font-medium text-primary dark:bg-primary/10">
+										{CATEGORY_LABEL[t.category]}
+									</span>
+								</TableCell>
+								<TableCell>
+									<Badge variant="secondary" className={STATUS_STYLES[t.status]}>
+										{STATUS_LABEL[t.status]}
+									</Badge>
+								</TableCell>
+								{isAdmin && (
+									<TableCell>
+										{t.createdBy.firstName} {t.createdBy.lastName}
+									</TableCell>
+								)}
+								<TableCell>{t._count.replies}</TableCell>
+								<TableCell className="text-muted-foreground">{formatDate(t.createdAt)}</TableCell>
+							</TableRow>
+						);
+					})}
 				</TableBody>
 			</Table>
 		</div>

--- a/app/(dashboard)/dashboard/helpme/_components/ticket-list.tsx
+++ b/app/(dashboard)/dashboard/helpme/_components/ticket-list.tsx
@@ -1,8 +1,5 @@
-"use client";
-
 import { LifeBuoy } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import {
 	Table,
@@ -12,6 +9,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import { ClickableTicketRow } from "./clickable-ticket-row";
 
 type TicketRow = {
 	id: string;
@@ -60,8 +58,6 @@ function formatDate(date: Date) {
 }
 
 export function TicketList({ tickets, isAdmin }: { tickets: TicketRow[]; isAdmin: boolean }) {
-	const router = useRouter();
-
 	if (tickets.length === 0) {
 		return (
 			<div className="flex flex-col items-center justify-center rounded-xl border border-gray-200 dark:border-white/10 bg-card p-16">
@@ -97,20 +93,10 @@ export function TicketList({ tickets, isAdmin }: { tickets: TicketRow[]; isAdmin
 					{tickets.map((t) => {
 						const href = `/dashboard/helpme/${t.id}`;
 						return (
-							<TableRow
-								key={t.id}
-								onClick={() => {
-									const selection = window.getSelection();
-									if (selection && selection.toString().length > 0) return;
-									router.push(href);
-								}}
-								onMouseEnter={() => router.prefetch(href)}
-								className="cursor-pointer hover:bg-muted/40"
-							>
+							<ClickableTicketRow key={t.id} href={href}>
 								<TableCell className="font-medium">
 									<Link
 										href={href}
-										onClick={(e) => e.stopPropagation()}
 										className="hover:underline focus-visible:underline focus-visible:outline-none"
 									>
 										{t.subject}
@@ -133,7 +119,7 @@ export function TicketList({ tickets, isAdmin }: { tickets: TicketRow[]; isAdmin
 								)}
 								<TableCell>{t._count.replies}</TableCell>
 								<TableCell className="text-muted-foreground">{formatDate(t.createdAt)}</TableCell>
-							</TableRow>
+							</ClickableTicketRow>
 						);
 					})}
 				</TableBody>

--- a/app/(dashboard)/dashboard/helpme/_components/ticket-list.tsx
+++ b/app/(dashboard)/dashboard/helpme/_components/ticket-list.tsx
@@ -99,7 +99,11 @@ export function TicketList({ tickets, isAdmin }: { tickets: TicketRow[]; isAdmin
 						return (
 							<TableRow
 								key={t.id}
-								onClick={() => router.push(href)}
+								onClick={() => {
+									const selection = window.getSelection();
+									if (selection && selection.toString().length > 0) return;
+									router.push(href);
+								}}
 								onMouseEnter={() => router.prefetch(href)}
 								className="cursor-pointer hover:bg-muted/40"
 							>

--- a/app/(dashboard)/dashboard/helpme/new/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/new/page.tsx
@@ -1,3 +1,5 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getServerSession } from "@/lib/auth-utils";
 import { TicketForm } from "../_components/ticket-form";
@@ -7,14 +9,26 @@ export default async function NewTicketPage() {
 	if (!session) redirect("/login");
 
 	return (
-		<div className="max-w-2xl mx-auto p-4 md:p-6">
-			<div className="mb-6">
-				<h1 className="text-2xl font-semibold">Raise a Ticket</h1>
-				<p className="text-sm text-muted-foreground">
+		<div className="max-w-7xl mx-auto space-y-6 mt-2">
+			<Link
+				href="/dashboard/helpme"
+				className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+			>
+				<ArrowLeft size={16} /> Back to tickets
+			</Link>
+
+			<div>
+				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+					Raise a Ticket
+				</h1>
+				<p className="mt-2 text-base text-muted-foreground">
 					Describe your issue and the right team will respond as soon as possible.
 				</p>
 			</div>
-			<TicketForm />
+
+			<div className="max-w-3xl">
+				<TicketForm />
+			</div>
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/helpme/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/page.tsx
@@ -1,3 +1,4 @@
+import { Plus } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { listTicketsForCurrentUser } from "@/lib/actions/helpme-actions";
@@ -11,11 +12,13 @@ export default async function HelpMePage() {
 	const { tickets, isAdmin } = await listTicketsForCurrentUser();
 
 	return (
-		<div className="max-w-6xl mx-auto p-4 md:p-6 space-y-6">
-			<div className="flex items-center justify-between gap-4">
+		<div className="max-w-7xl mx-auto space-y-6 mt-2">
+			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
 				<div>
-					<h1 className="text-2xl font-semibold">{isAdmin ? "Help Me Tickets" : "My Tickets"}</h1>
-					<p className="text-sm text-muted-foreground">
+					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
+						{isAdmin ? "Help Me Tickets" : "My Tickets"}
+					</h1>
+					<p className="mt-2 text-base text-muted-foreground">
 						{isAdmin
 							? "Respond to tickets raised by staff."
 							: "Raise an issue or request help from HR/IT."}
@@ -23,8 +26,9 @@ export default async function HelpMePage() {
 				</div>
 				<Link
 					href="/dashboard/helpme/new"
-					className="inline-flex items-center justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground transition-all duration-200 hover:bg-primary/90"
+					className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
 				>
+					<Plus className="-ml-1 h-5 w-5" />
 					New Ticket
 				</Link>
 			</div>


### PR DESCRIPTION
Closes #101

## Summary
- Brings `/dashboard/helpme`, `/dashboard/helpme/new`, and `/dashboard/helpme/[id]` in line with the shared dashboard layout (same container, hero, CTA, table card, and empty state used by Recognition / Staff Directory / Departments).
- Detail and new-ticket pages now use `max-w-7xl` outer with left-aligned inner column so they sit flush with the rest of the app instead of being center-blocked.
- Whole ticket row is clickable (prefetches on hover); the subject stays a real `<Link>` so right-click / new-tab / keyboard nav still work.

## Changes
- `helpme/page.tsx` — `max-w-7xl` + 2.25rem hero + `<Plus />` pill CTA with shadow / focus ring
- `helpme/new/page.tsx` — same hero treatment + back link; form wrapped in left-aligned `max-w-3xl`
- `helpme/[id]/page.tsx` — ticket card upgraded to `rounded-[2rem]` + site shadow; category chip primary styling; outer `max-w-7xl` with `max-w-4xl` reading column
- `_components/ticket-list.tsx` — site-standard table card (muted header row, shadow), icon empty state, primary category chip, full-row click + prefetch (client component)
- `_components/ticket-form.tsx` — form card bumped to `rounded-[2rem]` + shadow
- `_components/reply-item.tsx` — border color + soft shadow to match

No data, schema, or validation changes — presentational only.

## Test plan
- [ ] `/dashboard/helpme` as staff: hero / CTA match other dashboard pages; empty state renders the LifeBuoy illustration when there are no tickets
- [ ] `/dashboard/helpme` as admin: table shows tickets; clicking anywhere on a row opens the detail page; right-clicking the subject offers "Open in new tab"; hovering prefetches the detail route
- [ ] `/dashboard/helpme/new`: back link returns to list; form renders inside the `rounded-[2rem]` card; cancel and submit both work
- [ ] `/dashboard/helpme/[id]`: left-aligned column matches `/new`; category chip + status badge render; replying + closed-state banner still work
- [ ] `bun run lint` passes
- [ ] `bunx tsc --noEmit` passes