### PR TITLE
feat(helpme): global help FAB (#98)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist_Mono, Roboto } from "next/font/google";
+import { HelpFab } from "@/components/shared/help-fab";
 import { Providers } from "@/components/shared/providers";
 import { env } from "@/env";
 import "./globals.css";
@@ -33,7 +34,10 @@ export default function RootLayout({
 			className={`${roboto.variable} ${geistMono.variable} h-full antialiased`}
 		>
 			<body className="min-h-full font-sans">
-				<Providers>{children}</Providers>
+				<Providers>
+					{children}
+					<HelpFab />
+				</Providers>
 			</body>
 		</html>
 	);

--- a/components/shared/help-fab.test.tsx
+++ b/components/shared/help-fab.test.tsx
@@ -57,8 +57,20 @@ describe("HelpFab", () => {
 		expect(create).toBeEmptyDOMElement();
 	});
 
-	it("redirects unauthenticated users to login with the callbackUrl set", () => {
+	it("does not render outside /dashboard (e.g. /login, /)", () => {
+		setSession({ user: false, isPending: false });
+
 		mockedUsePathname.mockReturnValue("/login");
+		const { container: login } = render(<HelpFab />);
+		expect(login).toBeEmptyDOMElement();
+
+		mockedUsePathname.mockReturnValue("/");
+		const { container: root } = render(<HelpFab />);
+		expect(root).toBeEmptyDOMElement();
+	});
+
+	it("points unauthenticated dashboard visitors at /login with a callbackUrl", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
 		setSession({ user: false, isPending: false });
 
 		render(<HelpFab />);

--- a/components/shared/help-fab.test.tsx
+++ b/components/shared/help-fab.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+	useSession: vi.fn(),
+}));
+
+import { usePathname } from "next/navigation";
+import { useSession } from "@/lib/auth-client";
+import { HelpFab } from "./help-fab";
+
+const mockedUsePathname = vi.mocked(usePathname);
+const mockedUseSession = vi.mocked(useSession);
+
+function setSession({ user, isPending }: { user: boolean; isPending: boolean }) {
+	mockedUseSession.mockReturnValue({
+		data: user ? { user: { id: "u1" } } : null,
+		isPending,
+		error: null,
+		refetch: vi.fn(),
+	} as unknown as ReturnType<typeof useSession>);
+}
+
+describe("HelpFab", () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("renders on dashboard pages for an authenticated user, linking to the new ticket form", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
+		setSession({ user: true, isPending: false });
+
+		render(<HelpFab />);
+
+		const link = screen.getByRole("link", { name: /open help ticket/i });
+		expect(link).toHaveAttribute("href", "/dashboard/helpme/new");
+	});
+
+	it("is hidden on /dashboard/helpme and its children", () => {
+		mockedUsePathname.mockReturnValue("/dashboard/helpme");
+		setSession({ user: true, isPending: false });
+
+		const { container: root } = render(<HelpFab />);
+		expect(root).toBeEmptyDOMElement();
+
+		mockedUsePathname.mockReturnValue("/dashboard/helpme/abc123");
+		const { container: detail } = render(<HelpFab />);
+		expect(detail).toBeEmptyDOMElement();
+
+		mockedUsePathname.mockReturnValue("/dashboard/helpme/new");
+		const { container: create } = render(<HelpFab />);
+		expect(create).toBeEmptyDOMElement();
+	});
+
+	it("redirects unauthenticated users to login with the callbackUrl set", () => {
+		mockedUsePathname.mockReturnValue("/login");
+		setSession({ user: false, isPending: false });
+
+		render(<HelpFab />);
+
+		const link = screen.getByRole("link", { name: /open help ticket/i });
+		expect(link).toHaveAttribute(
+			"href",
+			`/login?callbackUrl=${encodeURIComponent("/dashboard/helpme/new")}`,
+		);
+	});
+
+	it("links to the ticket form while the session is still loading (proxy handles redirect)", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
+		setSession({ user: false, isPending: true });
+
+		render(<HelpFab />);
+
+		const link = screen.getByRole("link", { name: /open help ticket/i });
+		expect(link).toHaveAttribute("href", "/dashboard/helpme/new");
+	});
+});

--- a/components/shared/help-fab.test.tsx
+++ b/components/shared/help-fab.test.tsx
@@ -57,6 +57,18 @@ describe("HelpFab", () => {
 		expect(create).toBeEmptyDOMElement();
 	});
 
+	it("still renders on lookalike siblings like /dashboard/helpmeout", () => {
+		mockedUsePathname.mockReturnValue("/dashboard/helpmeout");
+		setSession({ user: true, isPending: false });
+
+		render(<HelpFab />);
+
+		expect(screen.getByRole("link", { name: /open help ticket/i })).toHaveAttribute(
+			"href",
+			"/dashboard/helpme/new",
+		);
+	});
+
 	it("does not render outside /dashboard (e.g. /login, /)", () => {
 		setSession({ user: false, isPending: false });
 

--- a/components/shared/help-fab.tsx
+++ b/components/shared/help-fab.tsx
@@ -12,6 +12,7 @@ export function HelpFab() {
 	const pathname = usePathname();
 	const { data: session, isPending } = useSession();
 
+	if (!pathname.startsWith("/dashboard")) return null;
 	if (pathname.startsWith("/dashboard/helpme")) return null;
 
 	const href =

--- a/components/shared/help-fab.tsx
+++ b/components/shared/help-fab.tsx
@@ -13,7 +13,7 @@ export function HelpFab() {
 	const { data: session, isPending } = useSession();
 
 	if (!pathname.startsWith("/dashboard")) return null;
-	if (pathname.startsWith("/dashboard/helpme")) return null;
+	if (pathname === "/dashboard/helpme" || pathname.startsWith("/dashboard/helpme/")) return null;
 
 	const href =
 		isPending || session?.user

--- a/components/shared/help-fab.tsx
+++ b/components/shared/help-fab.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { HelpCircle } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useSession } from "@/lib/auth-client";
+
+const TARGET_HREF = "/dashboard/helpme/new";
+
+export function HelpFab() {
+	const pathname = usePathname();
+	const { data: session, isPending } = useSession();
+
+	if (pathname.startsWith("/dashboard/helpme")) return null;
+
+	const href =
+		isPending || session?.user
+			? TARGET_HREF
+			: `/login?callbackUrl=${encodeURIComponent(TARGET_HREF)}`;
+
+	return (
+		<Tooltip>
+			<TooltipTrigger
+				render={
+					<Link
+						href={href}
+						aria-label="Open help ticket"
+						className="fixed bottom-6 right-6 z-40 inline-flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-all duration-200 hover:bg-primary/90 hover:shadow-xl focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/30"
+					>
+						<HelpCircle className="h-6 w-6" />
+					</Link>
+				}
+			/>
+			<TooltipContent side="left">Need help? Raise a ticket</TooltipContent>
+		</Tooltip>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds `HelpFab` client component mounted once in `app/layout.tsx`, linking to `/dashboard/helpme/new`.
- Hides on `/dashboard/helpme/*` so it doesn't duplicate the in-page CTA.
- Unauthenticated visitors get a `/login?callbackUrl=...` link — the existing `proxy.ts` handles the redirect after sign-in.

Closes #98
Phase 6 of #92

## Test plan
- [x] `bunx @biomejs/biome check` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bunx vitest run` — 155/155 pass (new `help-fab.test.tsx` covers render, hidden path, unauth callbackUrl, loading state)
- [ ] Manual: FAB appears on `/dashboard`, hidden on `/dashboard/helpme`, `/dashboard/helpme/new`, and `/dashboard/helpme/[id]`
- [ ] Manual: Logged-out click lands on `/login?callbackUrl=/dashboard/helpme/new`; after login, proxy resumes to the new ticket form