### PR TITLE
feat(activity-logs): track authenticated page visits (USER_VISITED)

### DIFF
--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-filters.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-filters.tsx
@@ -15,6 +15,7 @@ const ACTION_LABELS: Record<ActivityAction, string> = {
 	OAUTH_ACCOUNT_LINKED: "OAuth linked",
 	PASSWORD_CHANGED: "Password changed",
 	PASSWORD_RESET: "Password reset",
+	USER_VISITED: "Visited",
 };
 
 interface ActivityLogFiltersProps {

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-table.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-table.tsx
@@ -19,6 +19,7 @@ const ACTION_LABELS: Record<ActivityAction, string> = {
 	OAUTH_ACCOUNT_LINKED: "OAuth linked",
 	PASSWORD_CHANGED: "Password changed",
 	PASSWORD_RESET: "Password reset",
+	USER_VISITED: "Visited",
 };
 
 const DESTRUCTIVE_ACTIONS = new Set<ActivityAction>(["SIGN_IN_FAILED"]);

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
@@ -15,6 +15,7 @@ const ACTIONS: ActivityAction[] = [
 	"OAUTH_ACCOUNT_LINKED",
 	"PASSWORD_CHANGED",
 	"PASSWORD_RESET",
+	"USER_VISITED",
 ];
 
 interface SearchParams {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev --turbopack",
-		"build": "prisma generate && prisma db execute --file ./scripts/pre-deploy.sql && prisma db push && next build",
+		"build": "prisma generate && prisma migrate deploy && next build",
 		"start": "next start",
 		"postinstall": "prisma generate",
 		"lint": "bunx @biomejs/biome check .",

--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,359 @@
+Loaded Prisma config from prisma.config.ts.
+
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "public";
+
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('SUPERADMIN', 'ADMIN', 'STAFF');
+
+-- CreateEnum
+CREATE TYPE "Branch" AS ENUM ('ISO', 'PERTH');
+
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('CARD_RECEIVED', 'CARD_EDITED', 'CARD_DELETED', 'CARD_REACTION', 'CARD_COMMENT');
+
+-- CreateEnum
+CREATE TYPE "ActivityAction" AS ENUM ('USER_SIGNED_IN', 'USER_SIGNED_OUT', 'SIGN_IN_FAILED', 'OAUTH_ACCOUNT_LINKED', 'PASSWORD_CHANGED', 'PASSWORD_RESET', 'USER_VISITED');
+
+-- CreateEnum
+CREATE TYPE "TicketCategory" AS ENUM ('HR', 'IT_WEBSITE', 'PAYROLL', 'FACILITIES', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED');
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT NOT NULL,
+    "email_verified" BOOLEAN NOT NULL DEFAULT false,
+    "image" TEXT,
+    "first_name" TEXT NOT NULL,
+    "last_name" TEXT NOT NULL,
+    "display_name" TEXT,
+    "phone" TEXT,
+    "position" TEXT,
+    "avatar" TEXT,
+    "role" "Role" NOT NULL DEFAULT 'STAFF',
+    "branch" "Branch",
+    "department_id" TEXT,
+    "hire_date" DATE,
+    "birthday" DATE,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "deleted_at" TIMESTAMP(3),
+    "deleted_by_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "shift_schedules" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "timezone" TEXT NOT NULL DEFAULT 'Asia/Manila',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "shift_schedules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "shift_days" (
+    "id" TEXT NOT NULL,
+    "schedule_id" TEXT NOT NULL,
+    "day_of_week" INTEGER NOT NULL,
+    "is_working" BOOLEAN NOT NULL DEFAULT true,
+    "start_time" TEXT,
+    "end_time" TEXT,
+    "break_mins" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "shift_days_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sessions" (
+    "id" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "token" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "user_id" TEXT NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "accounts" (
+    "id" TEXT NOT NULL,
+    "account_id" TEXT NOT NULL,
+    "provider_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "access_token" TEXT,
+    "refresh_token" TEXT,
+    "id_token" TEXT,
+    "access_token_expires_at" TIMESTAMP(3),
+    "refresh_token_expires_at" TIMESTAMP(3),
+    "scope" TEXT,
+    "password" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "verifications" (
+    "id" TEXT NOT NULL,
+    "identifier" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3),
+
+    CONSTRAINT "verifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "departments" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "departments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "app_settings" (
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "app_settings_pkey" PRIMARY KEY ("key")
+);
+
+-- CreateTable
+CREATE TABLE "monthly_leaderboard_snapshots" (
+    "id" TEXT NOT NULL,
+    "month" TEXT NOT NULL,
+    "recipients" JSONB NOT NULL,
+    "top_limit" INTEGER NOT NULL,
+    "snapshot_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "monthly_leaderboard_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "recognition_cards" (
+    "id" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "date" DATE NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "sender_id" TEXT NOT NULL,
+    "recipient_id" TEXT NOT NULL,
+    "values_people" BOOLEAN NOT NULL DEFAULT false,
+    "values_safety" BOOLEAN NOT NULL DEFAULT false,
+    "values_respect" BOOLEAN NOT NULL DEFAULT false,
+    "values_communication" BOOLEAN NOT NULL DEFAULT false,
+    "values_continuous_improvement" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "recognition_cards_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "card_reactions" (
+    "id" TEXT NOT NULL,
+    "emoji" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "card_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+
+    CONSTRAINT "card_reactions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "card_comments" (
+    "id" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "card_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+
+    CONSTRAINT "card_comments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "activity_logs" (
+    "id" TEXT NOT NULL,
+    "action" "ActivityAction" NOT NULL,
+    "actor_id" TEXT,
+    "target_type" TEXT,
+    "target_id" TEXT,
+    "metadata" JSONB,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "activity_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" TEXT NOT NULL,
+    "type" "NotificationType" NOT NULL,
+    "message" TEXT NOT NULL,
+    "is_read" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "user_id" TEXT NOT NULL,
+    "card_id" TEXT,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "help_me_tickets" (
+    "id" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "category" "TicketCategory" NOT NULL,
+    "status" "TicketStatus" NOT NULL DEFAULT 'OPEN',
+    "created_by_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "help_me_tickets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "help_me_ticket_replies" (
+    "id" TEXT NOT NULL,
+    "ticket_id" TEXT NOT NULL,
+    "author_id" TEXT NOT NULL,
+    "body_html" TEXT NOT NULL,
+    "edited_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "help_me_ticket_replies_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shift_schedules_user_id_key" ON "shift_schedules"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shift_days_schedule_id_day_of_week_key" ON "shift_days"("schedule_id", "day_of_week");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_token_key" ON "sessions"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "departments_name_key" ON "departments"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "departments_code_key" ON "departments"("code");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "monthly_leaderboard_snapshots_month_key" ON "monthly_leaderboard_snapshots"("month");
+
+-- CreateIndex
+CREATE INDEX "recognition_cards_created_at_idx" ON "recognition_cards"("created_at");
+
+-- CreateIndex
+CREATE INDEX "recognition_cards_recipient_id_created_at_idx" ON "recognition_cards"("recipient_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "recognition_cards_sender_id_created_at_idx" ON "recognition_cards"("sender_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "card_reactions_card_id_idx" ON "card_reactions"("card_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "card_reactions_card_id_user_id_emoji_key" ON "card_reactions"("card_id", "user_id", "emoji");
+
+-- CreateIndex
+CREATE INDEX "card_comments_card_id_created_at_idx" ON "card_comments"("card_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_created_at_idx" ON "activity_logs"("created_at");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_actor_id_created_at_idx" ON "activity_logs"("actor_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_action_created_at_idx" ON "activity_logs"("action", "created_at");
+
+-- CreateIndex
+CREATE INDEX "notifications_user_id_is_read_idx" ON "notifications"("user_id", "is_read");
+
+-- CreateIndex
+CREATE INDEX "notifications_user_id_created_at_idx" ON "notifications"("user_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_tickets_created_by_id_created_at_idx" ON "help_me_tickets"("created_by_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_tickets_status_created_at_idx" ON "help_me_tickets"("status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_ticket_replies_ticket_id_created_at_idx" ON "help_me_ticket_replies"("ticket_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_department_id_fkey" FOREIGN KEY ("department_id") REFERENCES "departments"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "shift_schedules" ADD CONSTRAINT "shift_schedules_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "shift_days" ADD CONSTRAINT "shift_days_schedule_id_fkey" FOREIGN KEY ("schedule_id") REFERENCES "shift_schedules"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "recognition_cards" ADD CONSTRAINT "recognition_cards_sender_id_fkey" FOREIGN KEY ("sender_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "recognition_cards" ADD CONSTRAINT "recognition_cards_recipient_id_fkey" FOREIGN KEY ("recipient_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "card_reactions" ADD CONSTRAINT "card_reactions_card_id_fkey" FOREIGN KEY ("card_id") REFERENCES "recognition_cards"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "card_reactions" ADD CONSTRAINT "card_reactions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "card_comments" ADD CONSTRAINT "card_comments_card_id_fkey" FOREIGN KEY ("card_id") REFERENCES "recognition_cards"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "card_comments" ADD CONSTRAINT "card_comments_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_actor_id_fkey" FOREIGN KEY ("actor_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_card_id_fkey" FOREIGN KEY ("card_id") REFERENCES "recognition_cards"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_tickets" ADD CONSTRAINT "help_me_tickets_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_ticket_replies" ADD CONSTRAINT "help_me_ticket_replies_ticket_id_fkey" FOREIGN KEY ("ticket_id") REFERENCES "help_me_tickets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_ticket_replies" ADD CONSTRAINT "help_me_ticket_replies_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/migrations/0002_add_missing_schema/migration.sql
+++ b/prisma/migrations/0002_add_missing_schema/migration.sql
@@ -1,0 +1,136 @@
+-- CreateEnum
+CREATE TYPE "ActivityAction" AS ENUM ('USER_SIGNED_IN', 'USER_SIGNED_OUT', 'SIGN_IN_FAILED', 'OAUTH_ACCOUNT_LINKED', 'PASSWORD_CHANGED', 'PASSWORD_RESET', 'USER_VISITED');
+
+-- CreateEnum
+CREATE TYPE "TicketCategory" AS ENUM ('HR', 'IT_WEBSITE', 'PAYROLL', 'FACILITIES', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED');
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "NotificationType" ADD VALUE 'CARD_REACTION';
+ALTER TYPE "NotificationType" ADD VALUE 'CARD_COMMENT';
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "birthday" DATE,
+ADD COLUMN     "deleted_at" TIMESTAMP(3),
+ADD COLUMN     "deleted_by_id" TEXT,
+ADD COLUMN     "hire_date" DATE;
+
+-- CreateTable
+CREATE TABLE "shift_schedules" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "timezone" TEXT NOT NULL DEFAULT 'Asia/Manila',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "shift_schedules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "shift_days" (
+    "id" TEXT NOT NULL,
+    "schedule_id" TEXT NOT NULL,
+    "day_of_week" INTEGER NOT NULL,
+    "is_working" BOOLEAN NOT NULL DEFAULT true,
+    "start_time" TEXT,
+    "end_time" TEXT,
+    "break_mins" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "shift_days_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "activity_logs" (
+    "id" TEXT NOT NULL,
+    "action" "ActivityAction" NOT NULL,
+    "actor_id" TEXT,
+    "target_type" TEXT,
+    "target_id" TEXT,
+    "metadata" JSONB,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "activity_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "help_me_tickets" (
+    "id" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "category" "TicketCategory" NOT NULL,
+    "status" "TicketStatus" NOT NULL DEFAULT 'OPEN',
+    "created_by_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "help_me_tickets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "help_me_ticket_replies" (
+    "id" TEXT NOT NULL,
+    "ticket_id" TEXT NOT NULL,
+    "author_id" TEXT NOT NULL,
+    "body_html" TEXT NOT NULL,
+    "edited_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "help_me_ticket_replies_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shift_schedules_user_id_key" ON "shift_schedules"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shift_days_schedule_id_day_of_week_key" ON "shift_days"("schedule_id", "day_of_week");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_created_at_idx" ON "activity_logs"("created_at");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_actor_id_created_at_idx" ON "activity_logs"("actor_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_action_created_at_idx" ON "activity_logs"("action", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_tickets_created_by_id_created_at_idx" ON "help_me_tickets"("created_by_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_tickets_status_created_at_idx" ON "help_me_tickets"("status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_ticket_replies_ticket_id_created_at_idx" ON "help_me_ticket_replies"("ticket_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "recognition_cards_sender_id_created_at_idx" ON "recognition_cards"("sender_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "shift_schedules" ADD CONSTRAINT "shift_schedules_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "shift_days" ADD CONSTRAINT "shift_days_schedule_id_fkey" FOREIGN KEY ("schedule_id") REFERENCES "shift_schedules"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_actor_id_fkey" FOREIGN KEY ("actor_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_tickets" ADD CONSTRAINT "help_me_tickets_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_ticket_replies" ADD CONSTRAINT "help_me_ticket_replies_ticket_id_fkey" FOREIGN KEY ("ticket_id") REFERENCES "help_me_tickets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_ticket_replies" ADD CONSTRAINT "help_me_ticket_replies_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ enum ActivityAction {
   OAUTH_ACCOUNT_LINKED
   PASSWORD_CHANGED
   PASSWORD_RESET
+  USER_VISITED
 }
 
 enum TicketCategory {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,11 +1,15 @@
 import { getCookies } from "better-auth/cookies";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { extractRequestMeta, logActivity } from "@/lib/activity-log";
 import { auth } from "@/lib/auth";
 import { safeCallbackUrl, sanitizeCallbackUrl } from "@/lib/auth/safe-callback";
 import { prisma } from "@/lib/db";
 
 const { sessionToken } = getCookies(auth.options);
+
+// Cookie set once per UTC day to throttle USER_VISITED log writes
+const VISIT_COOKIE = "vl";
 
 async function resolveSession(request: NextRequest) {
 	try {
@@ -29,6 +33,9 @@ export async function proxy(request: NextRequest) {
 		return NextResponse.redirect(loginUrl);
 	}
 
+	const todayUtc = new Date().toISOString().slice(0, 10);
+	let pendingVisitActorId: string | null = null;
+
 	if (isProtected && sessionCookie) {
 		const session = await resolveSession(request);
 		if (!session) {
@@ -44,6 +51,10 @@ export async function proxy(request: NextRequest) {
 			const response = NextResponse.redirect(new URL("/login", request.url));
 			response.cookies.delete(sessionToken.name);
 			return response;
+		}
+
+		if (request.cookies.get(VISIT_COOKIE)?.value !== todayUtc) {
+			pendingVisitActorId = session.user.id;
 		}
 	}
 
@@ -63,7 +74,25 @@ export async function proxy(request: NextRequest) {
 		return NextResponse.redirect(new URL(safeCallback, request.url));
 	}
 
-	return NextResponse.next();
+	const response = NextResponse.next();
+
+	if (pendingVisitActorId) {
+		const { ipAddress, userAgent } = extractRequestMeta(request.headers);
+		void logActivity({
+			action: "USER_VISITED",
+			actorId: pendingVisitActorId,
+			ipAddress,
+			userAgent,
+		});
+		response.cookies.set(VISIT_COOKIE, todayUtc, {
+			path: "/",
+			httpOnly: true,
+			sameSite: "lax",
+			maxAge: 86400,
+		});
+	}
+
+	return response;
 }
 
 export const config = {


### PR DESCRIPTION
Closes #108

## Summary

This PR contains **two related but distinct changes**, grouped together because the migration work was required to safely ship the feature:

### 1. Prisma migrations workflow (`chore(db):` commit)

- Build script switched from `prisma db push` → `prisma migrate deploy` for tracked, reversible schema changes in production
- `0001_init` — baseline migration capturing existing schema from the prior db-push era; marked as applied against local + production DBs
- `0002_add_missing_schema` — closes drift between the baseline and schema changes accumulated across recent PRs (activity logs, helpme tickets, shift schedules, user soft-delete, `hire_date`/`birthday`, etc.)

Going forward: `bunx prisma migrate dev --name <description>` for all schema changes.

### 2. USER_VISITED tracking (`feat(activity-logs):` commit)

Users with active sessions (logged in yesterday, visiting today) previously left no trace in the activity log — `USER_SIGNED_IN` only fires on session creation. This adds `USER_VISITED`, fired once per UTC day per user on any `/dashboard/*` route.

- Add `USER_VISITED` to the `ActivityAction` enum
- `proxy.ts` writes the log via `logActivity()` (fire-and-forget, never blocks request path), throttled by an httpOnly cookie (`vl=YYYY-MM-DD`) — one log write per user per UTC day, no extra DB read on subsequent page loads
- Admin activity logs UI: "Visited" label in table + filters, `USER_VISITED` added to the filter dropdown

## Test plan

### Migrations
- [x] `bunx prisma migrate status` reports up-to-date locally
- [x] `bun run build` succeeds locally (runs `migrate deploy` → no pending)
- [x] Vercel deploy succeeds (production baselined via `migrate resolve --applied 0001_init`)

### USER_VISITED feature
- [ ] Sign in, visit multiple dashboard pages → only one `USER_VISITED` entry for the day
- [ ] Log in today, close browser, reopen tomorrow → new `USER_VISITED` entry
- [ ] User with valid session from yesterday visits `/dashboard` → `USER_VISITED` logged
- [ ] `USER_VISITED` appears in the admin activity logs filter dropdown
- [ ] Existing auth events (`USER_SIGNED_IN`, `USER_SIGNED_OUT`, etc.) unaffected
- [ ] Unauthenticated visits to `/dashboard` redirect to login — no log entry