### PR TITLE
chore(db): switch to prisma migrations workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev --turbopack",
-		"build": "prisma generate && prisma db execute --file ./scripts/pre-deploy.sql && prisma db push && next build",
+		"build": "prisma generate && prisma migrate deploy && next build",
 		"start": "next start",
 		"postinstall": "prisma generate",
 		"lint": "bunx @biomejs/biome check .",

--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,359 @@
+Loaded Prisma config from prisma.config.ts.
+
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "public";
+
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('SUPERADMIN', 'ADMIN', 'STAFF');
+
+-- CreateEnum
+CREATE TYPE "Branch" AS ENUM ('ISO', 'PERTH');
+
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('CARD_RECEIVED', 'CARD_EDITED', 'CARD_DELETED', 'CARD_REACTION', 'CARD_COMMENT');
+
+-- CreateEnum
+CREATE TYPE "ActivityAction" AS ENUM ('USER_SIGNED_IN', 'USER_SIGNED_OUT', 'SIGN_IN_FAILED', 'OAUTH_ACCOUNT_LINKED', 'PASSWORD_CHANGED', 'PASSWORD_RESET', 'USER_VISITED');
+
+-- CreateEnum
+CREATE TYPE "TicketCategory" AS ENUM ('HR', 'IT_WEBSITE', 'PAYROLL', 'FACILITIES', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED');
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT NOT NULL,
+    "email_verified" BOOLEAN NOT NULL DEFAULT false,
+    "image" TEXT,
+    "first_name" TEXT NOT NULL,
+    "last_name" TEXT NOT NULL,
+    "display_name" TEXT,
+    "phone" TEXT,
+    "position" TEXT,
+    "avatar" TEXT,
+    "role" "Role" NOT NULL DEFAULT 'STAFF',
+    "branch" "Branch",
+    "department_id" TEXT,
+    "hire_date" DATE,
+    "birthday" DATE,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "deleted_at" TIMESTAMP(3),
+    "deleted_by_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "shift_schedules" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "timezone" TEXT NOT NULL DEFAULT 'Asia/Manila',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "shift_schedules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "shift_days" (
+    "id" TEXT NOT NULL,
+    "schedule_id" TEXT NOT NULL,
+    "day_of_week" INTEGER NOT NULL,
+    "is_working" BOOLEAN NOT NULL DEFAULT true,
+    "start_time" TEXT,
+    "end_time" TEXT,
+    "break_mins" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "shift_days_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sessions" (
+    "id" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "token" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "user_id" TEXT NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "accounts" (
+    "id" TEXT NOT NULL,
+    "account_id" TEXT NOT NULL,
+    "provider_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "access_token" TEXT,
+    "refresh_token" TEXT,
+    "id_token" TEXT,
+    "access_token_expires_at" TIMESTAMP(3),
+    "refresh_token_expires_at" TIMESTAMP(3),
+    "scope" TEXT,
+    "password" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "verifications" (
+    "id" TEXT NOT NULL,
+    "identifier" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3),
+
+    CONSTRAINT "verifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "departments" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "departments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "app_settings" (
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "app_settings_pkey" PRIMARY KEY ("key")
+);
+
+-- CreateTable
+CREATE TABLE "monthly_leaderboard_snapshots" (
+    "id" TEXT NOT NULL,
+    "month" TEXT NOT NULL,
+    "recipients" JSONB NOT NULL,
+    "top_limit" INTEGER NOT NULL,
+    "snapshot_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "monthly_leaderboard_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "recognition_cards" (
+    "id" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "date" DATE NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "sender_id" TEXT NOT NULL,
+    "recipient_id" TEXT NOT NULL,
+    "values_people" BOOLEAN NOT NULL DEFAULT false,
+    "values_safety" BOOLEAN NOT NULL DEFAULT false,
+    "values_respect" BOOLEAN NOT NULL DEFAULT false,
+    "values_communication" BOOLEAN NOT NULL DEFAULT false,
+    "values_continuous_improvement" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "recognition_cards_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "card_reactions" (
+    "id" TEXT NOT NULL,
+    "emoji" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "card_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+
+    CONSTRAINT "card_reactions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "card_comments" (
+    "id" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "card_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+
+    CONSTRAINT "card_comments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "activity_logs" (
+    "id" TEXT NOT NULL,
+    "action" "ActivityAction" NOT NULL,
+    "actor_id" TEXT,
+    "target_type" TEXT,
+    "target_id" TEXT,
+    "metadata" JSONB,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "activity_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" TEXT NOT NULL,
+    "type" "NotificationType" NOT NULL,
+    "message" TEXT NOT NULL,
+    "is_read" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "user_id" TEXT NOT NULL,
+    "card_id" TEXT,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "help_me_tickets" (
+    "id" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "category" "TicketCategory" NOT NULL,
+    "status" "TicketStatus" NOT NULL DEFAULT 'OPEN',
+    "created_by_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "help_me_tickets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "help_me_ticket_replies" (
+    "id" TEXT NOT NULL,
+    "ticket_id" TEXT NOT NULL,
+    "author_id" TEXT NOT NULL,
+    "body_html" TEXT NOT NULL,
+    "edited_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "help_me_ticket_replies_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shift_schedules_user_id_key" ON "shift_schedules"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shift_days_schedule_id_day_of_week_key" ON "shift_days"("schedule_id", "day_of_week");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_token_key" ON "sessions"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "departments_name_key" ON "departments"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "departments_code_key" ON "departments"("code");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "monthly_leaderboard_snapshots_month_key" ON "monthly_leaderboard_snapshots"("month");
+
+-- CreateIndex
+CREATE INDEX "recognition_cards_created_at_idx" ON "recognition_cards"("created_at");
+
+-- CreateIndex
+CREATE INDEX "recognition_cards_recipient_id_created_at_idx" ON "recognition_cards"("recipient_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "recognition_cards_sender_id_created_at_idx" ON "recognition_cards"("sender_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "card_reactions_card_id_idx" ON "card_reactions"("card_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "card_reactions_card_id_user_id_emoji_key" ON "card_reactions"("card_id", "user_id", "emoji");
+
+-- CreateIndex
+CREATE INDEX "card_comments_card_id_created_at_idx" ON "card_comments"("card_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_created_at_idx" ON "activity_logs"("created_at");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_actor_id_created_at_idx" ON "activity_logs"("actor_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_action_created_at_idx" ON "activity_logs"("action", "created_at");
+
+-- CreateIndex
+CREATE INDEX "notifications_user_id_is_read_idx" ON "notifications"("user_id", "is_read");
+
+-- CreateIndex
+CREATE INDEX "notifications_user_id_created_at_idx" ON "notifications"("user_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_tickets_created_by_id_created_at_idx" ON "help_me_tickets"("created_by_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_tickets_status_created_at_idx" ON "help_me_tickets"("status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_ticket_replies_ticket_id_created_at_idx" ON "help_me_ticket_replies"("ticket_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_department_id_fkey" FOREIGN KEY ("department_id") REFERENCES "departments"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "shift_schedules" ADD CONSTRAINT "shift_schedules_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "shift_days" ADD CONSTRAINT "shift_days_schedule_id_fkey" FOREIGN KEY ("schedule_id") REFERENCES "shift_schedules"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "recognition_cards" ADD CONSTRAINT "recognition_cards_sender_id_fkey" FOREIGN KEY ("sender_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "recognition_cards" ADD CONSTRAINT "recognition_cards_recipient_id_fkey" FOREIGN KEY ("recipient_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "card_reactions" ADD CONSTRAINT "card_reactions_card_id_fkey" FOREIGN KEY ("card_id") REFERENCES "recognition_cards"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "card_reactions" ADD CONSTRAINT "card_reactions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "card_comments" ADD CONSTRAINT "card_comments_card_id_fkey" FOREIGN KEY ("card_id") REFERENCES "recognition_cards"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "card_comments" ADD CONSTRAINT "card_comments_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_actor_id_fkey" FOREIGN KEY ("actor_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_card_id_fkey" FOREIGN KEY ("card_id") REFERENCES "recognition_cards"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_tickets" ADD CONSTRAINT "help_me_tickets_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_ticket_replies" ADD CONSTRAINT "help_me_ticket_replies_ticket_id_fkey" FOREIGN KEY ("ticket_id") REFERENCES "help_me_tickets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_ticket_replies" ADD CONSTRAINT "help_me_ticket_replies_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/migrations/0002_add_missing_schema/migration.sql
+++ b/prisma/migrations/0002_add_missing_schema/migration.sql
@@ -1,0 +1,136 @@
+-- CreateEnum
+CREATE TYPE "ActivityAction" AS ENUM ('USER_SIGNED_IN', 'USER_SIGNED_OUT', 'SIGN_IN_FAILED', 'OAUTH_ACCOUNT_LINKED', 'PASSWORD_CHANGED', 'PASSWORD_RESET', 'USER_VISITED');
+
+-- CreateEnum
+CREATE TYPE "TicketCategory" AS ENUM ('HR', 'IT_WEBSITE', 'PAYROLL', 'FACILITIES', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED');
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "NotificationType" ADD VALUE 'CARD_REACTION';
+ALTER TYPE "NotificationType" ADD VALUE 'CARD_COMMENT';
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "birthday" DATE,
+ADD COLUMN     "deleted_at" TIMESTAMP(3),
+ADD COLUMN     "deleted_by_id" TEXT,
+ADD COLUMN     "hire_date" DATE;
+
+-- CreateTable
+CREATE TABLE "shift_schedules" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "timezone" TEXT NOT NULL DEFAULT 'Asia/Manila',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "shift_schedules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "shift_days" (
+    "id" TEXT NOT NULL,
+    "schedule_id" TEXT NOT NULL,
+    "day_of_week" INTEGER NOT NULL,
+    "is_working" BOOLEAN NOT NULL DEFAULT true,
+    "start_time" TEXT,
+    "end_time" TEXT,
+    "break_mins" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "shift_days_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "activity_logs" (
+    "id" TEXT NOT NULL,
+    "action" "ActivityAction" NOT NULL,
+    "actor_id" TEXT,
+    "target_type" TEXT,
+    "target_id" TEXT,
+    "metadata" JSONB,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "activity_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "help_me_tickets" (
+    "id" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "category" "TicketCategory" NOT NULL,
+    "status" "TicketStatus" NOT NULL DEFAULT 'OPEN',
+    "created_by_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "help_me_tickets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "help_me_ticket_replies" (
+    "id" TEXT NOT NULL,
+    "ticket_id" TEXT NOT NULL,
+    "author_id" TEXT NOT NULL,
+    "body_html" TEXT NOT NULL,
+    "edited_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "help_me_ticket_replies_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shift_schedules_user_id_key" ON "shift_schedules"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "shift_days_schedule_id_day_of_week_key" ON "shift_days"("schedule_id", "day_of_week");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_created_at_idx" ON "activity_logs"("created_at");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_actor_id_created_at_idx" ON "activity_logs"("actor_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "activity_logs_action_created_at_idx" ON "activity_logs"("action", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_tickets_created_by_id_created_at_idx" ON "help_me_tickets"("created_by_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_tickets_status_created_at_idx" ON "help_me_tickets"("status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "help_me_ticket_replies_ticket_id_created_at_idx" ON "help_me_ticket_replies"("ticket_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "recognition_cards_sender_id_created_at_idx" ON "recognition_cards"("sender_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "shift_schedules" ADD CONSTRAINT "shift_schedules_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "shift_days" ADD CONSTRAINT "shift_days_schedule_id_fkey" FOREIGN KEY ("schedule_id") REFERENCES "shift_schedules"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_actor_id_fkey" FOREIGN KEY ("actor_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_tickets" ADD CONSTRAINT "help_me_tickets_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_ticket_replies" ADD CONSTRAINT "help_me_ticket_replies_ticket_id_fkey" FOREIGN KEY ("ticket_id") REFERENCES "help_me_tickets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "help_me_ticket_replies" ADD CONSTRAINT "help_me_ticket_replies_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+


### PR DESCRIPTION
## Summary
- Replaces `prisma db push` build step with `prisma migrate deploy`
- Adds the two migration files (`0001_init`, `0002_add_missing_schema`) that match the already-applied records in both local and production `_prisma_migrations` tables
- Infrastructure only — no schema or application changes

## Context
Prerequisite for #110 (USER_VISITED feature). The previous attempt (#108/#109) tangled migration infra with the feature; this PR lands the infra cleanly so the feature PR can stay small.

## Test plan
- [ ] `bun run build` succeeds locally (`prisma migrate deploy` no-ops since both migrations are already applied to the dev DB)
- [ ] Vercel preview deploy succeeds — `prisma migrate deploy` no-ops against production since both records are already present
- [ ] `_prisma_migrations` table unchanged after deploy

## Notes / risks
- Both migration files correspond to the existing `_prisma_migrations` records; Prisma will see them as already applied and skip
- Do **not** revert the build script to `db push` — the workflow is now migration-based

Refs: #110