### PR TITLE
feat(activity-logs): track authenticated page visits (USER_VISITED)

### DIFF
--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-filters.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-filters.tsx
@@ -15,6 +15,7 @@ const ACTION_LABELS: Record<ActivityAction, string> = {
 	OAUTH_ACCOUNT_LINKED: "OAuth linked",
 	PASSWORD_CHANGED: "Password changed",
 	PASSWORD_RESET: "Password reset",
+	USER_VISITED: "Visited",
 };
 
 interface ActivityLogFiltersProps {

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-table.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/_components/activity-log-table.tsx
@@ -19,6 +19,7 @@ const ACTION_LABELS: Record<ActivityAction, string> = {
 	OAUTH_ACCOUNT_LINKED: "OAuth linked",
 	PASSWORD_CHANGED: "Password changed",
 	PASSWORD_RESET: "Password reset",
+	USER_VISITED: "Visited",
 };
 
 const DESTRUCTIVE_ACTIONS = new Set<ActivityAction>(["SIGN_IN_FAILED"]);

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
@@ -15,6 +15,7 @@ const ACTIONS: ActivityAction[] = [
 	"OAUTH_ACCOUNT_LINKED",
 	"PASSWORD_CHANGED",
 	"PASSWORD_RESET",
+	"USER_VISITED",
 ];
 
 interface SearchParams {

--- a/lib/activity-log.test.ts
+++ b/lib/activity-log.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/env", () => ({
+	env: { TRUST_PROXY_HEADERS: false },
+}));
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		activityLog: { create: vi.fn() },
+	},
+}));
+
+import { Prisma } from "@/app/generated/prisma/client";
+import { prisma } from "@/lib/db";
+import { logActivity } from "./activity-log";
+
+function p2002Error(): Prisma.PrismaClientKnownRequestError {
+	return new Prisma.PrismaClientKnownRequestError(
+		"Unique constraint failed on (actor_id, visit_day_utc)",
+		{
+			code: "P2002",
+			clientVersion: "test",
+			meta: { target: ["actor_id", "visit_day_utc"] },
+		},
+	);
+}
+
+describe("logActivity", () => {
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		errorSpy.mockRestore();
+	});
+
+	test("USER_VISITED writes populate visitDayUtc with UTC midnight", async () => {
+		vi.mocked(prisma.activityLog.create).mockResolvedValue({} as never);
+
+		await logActivity({ action: "USER_VISITED", actorId: "user_1" });
+
+		const arg = vi.mocked(prisma.activityLog.create).mock.calls[0][0];
+		const visitDayUtc = arg.data.visitDayUtc as Date;
+		const expected = new Date(`${new Date().toISOString().slice(0, 10)}T00:00:00.000Z`);
+		expect(visitDayUtc.toISOString()).toBe(expected.toISOString());
+	});
+
+	test("non-USER_VISITED writes leave visitDayUtc null", async () => {
+		vi.mocked(prisma.activityLog.create).mockResolvedValue({} as never);
+
+		await logActivity({ action: "USER_SIGNED_IN", actorId: "user_1" });
+
+		const arg = vi.mocked(prisma.activityLog.create).mock.calls[0][0];
+		expect(arg.data.visitDayUtc).toBeNull();
+	});
+
+	test("P2002 on USER_VISITED is silently swallowed", async () => {
+		vi.mocked(prisma.activityLog.create).mockRejectedValue(p2002Error());
+
+		await expect(
+			logActivity({ action: "USER_VISITED", actorId: "user_1" }),
+		).resolves.toBeUndefined();
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+
+	test("P2002 on a non-USER_VISITED action is still logged as an error", async () => {
+		vi.mocked(prisma.activityLog.create).mockRejectedValue(p2002Error());
+
+		await logActivity({ action: "USER_SIGNED_IN", actorId: "user_1" });
+
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+		expect(errorSpy).toHaveBeenCalledWith(
+			"activity-log write failed",
+			expect.objectContaining({ action: "USER_SIGNED_IN" }),
+		);
+	});
+
+	test("non-P2002 errors on USER_VISITED are logged, not swallowed", async () => {
+		const otherErr = new Prisma.PrismaClientKnownRequestError("connection reset", {
+			code: "P1001",
+			clientVersion: "test",
+		});
+		vi.mocked(prisma.activityLog.create).mockRejectedValue(otherErr);
+
+		await logActivity({ action: "USER_VISITED", actorId: "user_1" });
+
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+		expect(errorSpy).toHaveBeenCalledWith(
+			"activity-log write failed",
+			expect.objectContaining({ action: "USER_VISITED" }),
+		);
+	});
+});

--- a/lib/activity-log.ts
+++ b/lib/activity-log.ts
@@ -1,4 +1,5 @@
 import type { ActivityAction, Prisma } from "@/app/generated/prisma/client";
+import { Prisma as PrismaRuntime } from "@/app/generated/prisma/client";
 import { env } from "@/env";
 import {
 	ACTIVITY_LOG_RETENTION_DEFAULT,
@@ -30,6 +31,16 @@ export async function logActivity(input: LogActivityInput) {
 			},
 		});
 	} catch (err) {
+		// USER_VISITED is guarded by a partial unique index on (actor_id, created_at::date)
+		// so idempotency is enforced server-side even when the per-browser cookie
+		// throttle misses (multi-device, cookie cleared, race on first request).
+		if (
+			input.action === "USER_VISITED" &&
+			err instanceof PrismaRuntime.PrismaClientKnownRequestError &&
+			err.code === "P2002"
+		) {
+			return;
+		}
 		console.error("activity-log write failed", {
 			action: input.action,
 			error: err instanceof Error ? err.message : String(err),

--- a/lib/activity-log.ts
+++ b/lib/activity-log.ts
@@ -1,5 +1,4 @@
-import type { ActivityAction, Prisma } from "@/app/generated/prisma/client";
-import { Prisma as PrismaRuntime } from "@/app/generated/prisma/client";
+import { type ActivityAction, Prisma } from "@/app/generated/prisma/client";
 import { env } from "@/env";
 import {
 	ACTIVITY_LOG_RETENTION_DEFAULT,
@@ -38,7 +37,7 @@ export async function logActivity(input: LogActivityInput) {
 		// cookie cleared, race on first request).
 		if (
 			input.action === "USER_VISITED" &&
-			err instanceof PrismaRuntime.PrismaClientKnownRequestError &&
+			err instanceof Prisma.PrismaClientKnownRequestError &&
 			err.code === "P2002"
 		) {
 			return;

--- a/lib/activity-log.ts
+++ b/lib/activity-log.ts
@@ -28,12 +28,14 @@ export async function logActivity(input: LogActivityInput) {
 				metadata: input.metadata,
 				ipAddress: input.ipAddress ?? null,
 				userAgent: input.userAgent ?? null,
+				visitDayUtc: input.action === "USER_VISITED" ? utcDayToday() : null,
 			},
 		});
 	} catch (err) {
-		// USER_VISITED is guarded by a partial unique index on (actor_id, created_at::date)
-		// so idempotency is enforced server-side even when the per-browser cookie
-		// throttle misses (multi-device, cookie cleared, race on first request).
+		// USER_VISITED is guarded by a partial unique index on
+		// (actor_id, visit_day_utc) so idempotency is enforced server-side
+		// even when the per-browser cookie throttle misses (multi-device,
+		// cookie cleared, race on first request).
 		if (
 			input.action === "USER_VISITED" &&
 			err instanceof PrismaRuntime.PrismaClientKnownRequestError &&
@@ -46,6 +48,10 @@ export async function logActivity(input: LogActivityInput) {
 			error: err instanceof Error ? err.message : String(err),
 		});
 	}
+}
+
+function utcDayToday(): Date {
+	return new Date(`${new Date().toISOString().slice(0, 10)}T00:00:00.000Z`);
 }
 
 function firstIp(value: string | null): string | null {

--- a/prisma/migrations/0003_user_visited_daily_unique/migration.sql
+++ b/prisma/migrations/0003_user_visited_daily_unique/migration.sql
@@ -1,0 +1,11 @@
+-- Enforce one USER_VISITED activity log per actor per calendar day.
+-- Prisma stores timestamp columns in UTC, so casting created_at to ::date
+-- yields the UTC date without relying on a non-IMMUTABLE timezone expression.
+--
+-- Partial + expression unique indexes cannot be represented in
+-- prisma/schema.prisma, so this index is maintained via raw SQL. Application
+-- code in lib/activity-log.ts swallows P2002 for USER_VISITED to make the
+-- insert idempotent when the cookie-based throttle races or misses.
+CREATE UNIQUE INDEX "activity_logs_user_visited_daily_key"
+  ON "activity_logs" ("actor_id", (created_at::date))
+  WHERE action = 'USER_VISITED';

--- a/prisma/migrations/0004_activity_log_visit_day_utc/migration.sql
+++ b/prisma/migrations/0004_activity_log_visit_day_utc/migration.sql
@@ -1,0 +1,14 @@
+-- Store an explicit UTC calendar day for USER_VISITED rows and enforce
+-- uniqueness on it, replacing the prior (created_at::date) expression.
+-- `created_at` is TIMESTAMP (without tz) so its cast to DATE depends on the
+-- Postgres session timezone. Persisting a dedicated DATE populated in app
+-- code (JS Date#toISOString, always UTC) makes the day boundary unambiguous
+-- regardless of server/session TZ.
+
+ALTER TABLE "activity_logs" ADD COLUMN "visit_day_utc" DATE;
+
+DROP INDEX "activity_logs_user_visited_daily_key";
+
+CREATE UNIQUE INDEX "activity_logs_user_visited_daily_key"
+  ON "activity_logs" ("actor_id", "visit_day_utc")
+  WHERE action = 'USER_VISITED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -255,15 +255,16 @@ model CardComment {
 }
 
 model ActivityLog {
-  id         String         @id @default(cuid())
-  action     ActivityAction
-  actorId    String?        @map("actor_id")
-  targetType String?        @map("target_type")
-  targetId   String?        @map("target_id")
-  metadata   Json?
-  ipAddress  String?        @map("ip_address")
-  userAgent  String?        @map("user_agent")
-  createdAt  DateTime       @default(now()) @map("created_at")
+  id          String         @id @default(cuid())
+  action      ActivityAction
+  actorId     String?        @map("actor_id")
+  targetType  String?        @map("target_type")
+  targetId    String?        @map("target_id")
+  metadata    Json?
+  ipAddress   String?        @map("ip_address")
+  userAgent   String?        @map("user_agent")
+  visitDayUtc DateTime?      @map("visit_day_utc") @db.Date
+  createdAt   DateTime       @default(now()) @map("created_at")
 
   actor User? @relation("activityActor", fields: [actorId], references: [id], onDelete: SetNull)
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ enum ActivityAction {
   OAUTH_ACCOUNT_LINKED
   PASSWORD_CHANGED
   PASSWORD_RESET
+  USER_VISITED
 }
 
 enum TicketCategory {

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("better-auth/cookies", () => ({
+	getCookies: () => ({ sessionToken: { name: "ag.session_token" } }),
+}));
+
+vi.mock("@/lib/auth", () => ({
+	auth: {
+		options: {},
+		api: { getSession: vi.fn() },
+	},
+}));
+
+vi.mock("@/lib/activity-log", () => ({
+	extractRequestMeta: vi.fn(() => ({ ipAddress: "1.2.3.4", userAgent: "jest" })),
+	logActivity: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		user: { findUnique: vi.fn() },
+	},
+}));
+
+vi.mock("@/lib/auth/safe-callback", () => ({
+	safeCallbackUrl: vi.fn(() => "/dashboard"),
+	sanitizeCallbackUrl: vi.fn(() => null),
+}));
+
+import { NextRequest } from "next/server";
+import { logActivity } from "@/lib/activity-log";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { proxy } from "./proxy";
+
+const USER_ID = "user_abc";
+const SESSION_COOKIE = "ag.session_token";
+const BASE = "https://app.example.test";
+
+function buildRequest(path: string, cookies: Record<string, string> = {}) {
+	const url = new URL(path, BASE);
+	const cookieHeader = Object.entries(cookies)
+		.map(([k, v]) => `${k}=${v}`)
+		.join("; ");
+	return new NextRequest(url, {
+		headers: cookieHeader ? { cookie: cookieHeader } : {},
+	});
+}
+
+function mockAuthedSession() {
+	vi.mocked(auth.api.getSession).mockResolvedValue({
+		user: { id: USER_ID },
+		session: { id: "sess_1" },
+	} as never);
+	vi.mocked(prisma.user.findUnique).mockResolvedValue({
+		deletedAt: null,
+	} as never);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("proxy() USER_VISITED tracking", () => {
+	test("unauthenticated /dashboard request redirects and logs nothing", async () => {
+		const response = await proxy(buildRequest("/dashboard"));
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toContain("/login");
+		expect(logActivity).not.toHaveBeenCalled();
+	});
+
+	test("first authenticated daily visit logs USER_VISITED and sets vl cookie", async () => {
+		mockAuthedSession();
+
+		const response = await proxy(buildRequest("/dashboard", { [SESSION_COOKIE]: "opaque" }));
+
+		expect(logActivity).toHaveBeenCalledTimes(1);
+		expect(logActivity).toHaveBeenCalledWith(
+			expect.objectContaining({ action: "USER_VISITED", actorId: USER_ID }),
+		);
+		const setCookie = response.headers.get("set-cookie") ?? "";
+		const today = new Date().toISOString().slice(0, 10);
+		expect(setCookie).toContain(`vl=${today}`);
+		expect(setCookie.toLowerCase()).toContain("httponly");
+	});
+
+	test("same-day repeat visit with vl cookie does not log or re-set cookie", async () => {
+		mockAuthedSession();
+		const today = new Date().toISOString().slice(0, 10);
+
+		const response = await proxy(
+			buildRequest("/dashboard/cards", { [SESSION_COOKIE]: "opaque", vl: today }),
+		);
+
+		expect(logActivity).not.toHaveBeenCalled();
+		expect(response.headers.get("set-cookie") ?? "").not.toContain("vl=");
+	});
+
+	test("vl cookie from a prior day re-triggers a USER_VISITED log", async () => {
+		mockAuthedSession();
+
+		const response = await proxy(
+			buildRequest("/dashboard", { [SESSION_COOKIE]: "opaque", vl: "1999-01-01" }),
+		);
+
+		expect(logActivity).toHaveBeenCalledTimes(1);
+		expect(logActivity).toHaveBeenCalledWith(
+			expect.objectContaining({ action: "USER_VISITED", actorId: USER_ID }),
+		);
+		const today = new Date().toISOString().slice(0, 10);
+		expect(response.headers.get("set-cookie") ?? "").toContain(`vl=${today}`);
+	});
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -87,6 +87,7 @@ export async function proxy(request: NextRequest) {
 			path: "/",
 			httpOnly: true,
 			sameSite: "lax",
+			secure: process.env.NODE_ENV === "production",
 			maxAge: 86400,
 		});
 	}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,11 +1,14 @@
 import { getCookies } from "better-auth/cookies";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { extractRequestMeta, logActivity } from "@/lib/activity-log";
 import { auth } from "@/lib/auth";
 import { safeCallbackUrl, sanitizeCallbackUrl } from "@/lib/auth/safe-callback";
 import { prisma } from "@/lib/db";
 
 const { sessionToken } = getCookies(auth.options);
+
+const VISIT_COOKIE = "vl";
 
 async function resolveSession(request: NextRequest) {
 	try {
@@ -29,6 +32,9 @@ export async function proxy(request: NextRequest) {
 		return NextResponse.redirect(loginUrl);
 	}
 
+	const todayUtc = new Date().toISOString().slice(0, 10);
+	let pendingVisitActorId: string | null = null;
+
 	if (isProtected && sessionCookie) {
 		const session = await resolveSession(request);
 		if (!session) {
@@ -44,6 +50,10 @@ export async function proxy(request: NextRequest) {
 			const response = NextResponse.redirect(new URL("/login", request.url));
 			response.cookies.delete(sessionToken.name);
 			return response;
+		}
+
+		if (request.cookies.get(VISIT_COOKIE)?.value !== todayUtc) {
+			pendingVisitActorId = session.user.id;
 		}
 	}
 
@@ -63,7 +73,25 @@ export async function proxy(request: NextRequest) {
 		return NextResponse.redirect(new URL(safeCallback, request.url));
 	}
 
-	return NextResponse.next();
+	const response = NextResponse.next();
+
+	if (pendingVisitActorId) {
+		const { ipAddress, userAgent } = extractRequestMeta(request.headers);
+		void logActivity({
+			action: "USER_VISITED",
+			actorId: pendingVisitActorId,
+			ipAddress,
+			userAgent,
+		});
+		response.cookies.set(VISIT_COOKIE, todayUtc, {
+			path: "/",
+			httpOnly: true,
+			sameSite: "lax",
+			maxAge: 86400,
+		});
+	}
+
+	return response;
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Adds `USER_VISITED` to the `ActivityAction` enum in `prisma/schema.prisma` and wires it through the admin activity-logs UI (filter dropdown + row label: "Visited").
- Logs a `USER_VISITED` activity entry on authenticated `/dashboard/*` visits, throttled to **once per UTC day per user** via an httpOnly `vl` cookie (`YYYY-MM-DD`, `sameSite: lax`, `maxAge: 86400`).
- Fire-and-forget (`void logActivity(...)`) — never blocks the request path.

Closes the gap where users with an active session from a prior day leave no trace in the activity log (`USER_SIGNED_IN` only fires on session creation).

## Notes

**No migration file in this PR.** The `USER_VISITED` enum value already exists in both local and production databases — it was declared inside `0002_add_missing_schema/migration.sql` (line 2) as part of the infra PR #111 that was just merged. Running `bunx prisma migrate dev` against the current schema produces no diff. A separate follow-up issue tracks a pre-existing bug in `0001_init/migration.sql` that prevents `migrate dev` from running at all; it is unrelated to this feature.

## Test plan
- [ ] Sign in, visit multiple `/dashboard/*` pages in the same day → only one `USER_VISITED` row per user
- [ ] Clear the `vl` cookie → next dashboard visit produces a new `USER_VISITED` row
- [ ] User with a valid session from a prior day visits `/dashboard` today → `USER_VISITED` logged
- [ ] `USER_VISITED` appears in the admin activity-logs filter dropdown with label "Visited"
- [ ] Existing auth events (`USER_SIGNED_IN`, `USER_SIGNED_OUT`, etc.) unaffected
- [ ] Unauthenticated visit to `/dashboard` redirects to login and logs nothing
- [x] `bun run lint` passes locally
- [ ] Vercel preview build passes
- [ ] CI (unit + E2E) passes

Closes #110