### PR TITLE
feat(admin-settings): Help Me module visibility toggle

### DIFF
--- a/app/(dashboard)/dashboard/admin-settings/_components/helpme-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/helpme-visibility.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
@@ -12,6 +13,7 @@ export interface HelpMeVisibilityPanelProps {
 export function HelpMeVisibilityPanel({ initialEnabled }: HelpMeVisibilityPanelProps) {
 	const [enabled, setEnabled] = useState(initialEnabled);
 	const [isPending, startTransition] = useTransition();
+	const router = useRouter();
 
 	function handleChange(next: boolean) {
 		const previous = enabled;
@@ -26,6 +28,9 @@ export function HelpMeVisibilityPanel({ initialEnabled }: HelpMeVisibilityPanelP
 					return;
 				}
 				toast.success(next ? "Help Me module enabled" : "Help Me module hidden");
+				// Re-render the dashboard layout so the sidebar link and FAB reflect the new state
+				// without requiring a hard reload.
+				router.refresh();
 			} catch {
 				setEnabled(previous);
 				toast.error("Failed to update Help Me visibility");
@@ -40,18 +45,18 @@ export function HelpMeVisibilityPanel({ initialEnabled }: HelpMeVisibilityPanelP
 					Help Me Module
 				</h3>
 				<p className="mt-2 text-sm text-muted-foreground">
-					Control whether staff can access the Help Me Tickets module. Admins always retain access
-					so existing tickets stay reachable.
+					Control whether the Help Me Tickets module is available across the app.
 				</p>
 			</div>
 
 			<div className="px-8 py-6">
 				<div className="flex items-center justify-between rounded-2xl border border-gray-200 dark:border-white/10 p-5 gap-4">
 					<div className="min-w-0">
-						<p className="text-sm font-medium text-foreground">Show Help Me for staff</p>
+						<p className="text-sm font-medium text-foreground">Enable Help Me</p>
 						<p className="text-xs text-muted-foreground">
 							When off, the sidebar entry, floating help button, and `/dashboard/helpme` pages are
-							hidden from non-admin users.
+							hidden for everyone. Existing tickets stay in the database and become reachable again
+							when you turn this back on.
 						</p>
 					</div>
 					<Switch

--- a/app/(dashboard)/dashboard/admin-settings/_components/helpme-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/helpme-visibility.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Switch } from "@/components/ui/switch";
+import { updateHelpMeEnabled } from "@/lib/actions/settings-actions";
+
+export interface HelpMeVisibilityPanelProps {
+	initialEnabled: boolean;
+}
+
+export function HelpMeVisibilityPanel({ initialEnabled }: HelpMeVisibilityPanelProps) {
+	const [enabled, setEnabled] = useState(initialEnabled);
+	const [isPending, startTransition] = useTransition();
+
+	function handleChange(next: boolean) {
+		const previous = enabled;
+		setEnabled(next);
+
+		startTransition(async () => {
+			try {
+				const result = await updateHelpMeEnabled(next);
+				if (!result.success) {
+					setEnabled(previous);
+					toast.error(result.error ?? "Failed to update Help Me visibility");
+					return;
+				}
+				toast.success(next ? "Help Me module enabled" : "Help Me module hidden");
+			} catch {
+				setEnabled(previous);
+				toast.error("Failed to update Help Me visibility");
+			}
+		});
+	}
+
+	return (
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
+			<div className="px-8 pt-8 pb-2">
+				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
+					Help Me Module
+				</h3>
+				<p className="mt-2 text-sm text-muted-foreground">
+					Control whether staff can access the Help Me Tickets module. Admins always retain access
+					so existing tickets stay reachable.
+				</p>
+			</div>
+
+			<div className="px-8 py-6">
+				<div className="flex items-center justify-between rounded-2xl border border-gray-200 dark:border-white/10 p-5 gap-4">
+					<div className="min-w-0">
+						<p className="text-sm font-medium text-foreground">Show Help Me for staff</p>
+						<p className="text-xs text-muted-foreground">
+							When off, the sidebar entry, floating help button, and `/dashboard/helpme` pages are
+							hidden from non-admin users.
+						</p>
+					</div>
+					<Switch
+						checked={enabled}
+						onCheckedChange={handleChange}
+						disabled={isPending}
+						aria-label="Toggle Help Me module"
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/page.tsx
@@ -1,9 +1,11 @@
 import { redirect } from "next/navigation";
 import {
+	getHelpMeEnabled,
 	getLeaderboardVisibilitySettings,
 	getTopRecognizedLimit,
 } from "@/lib/actions/settings-actions";
 import { requireRole } from "@/lib/auth-utils";
+import { HelpMeVisibilityPanel } from "./_components/helpme-visibility";
 import { LeaderboardVisibilityPanel } from "./_components/leaderboard-visibility";
 import { RecognitionSettingsPanel } from "./_components/recognition-settings";
 
@@ -14,9 +16,10 @@ export default async function AdminSettingsPage() {
 		redirect("/dashboard");
 	}
 
-	const [topLimit, visibility] = await Promise.all([
+	const [topLimit, visibility, helpMeEnabled] = await Promise.all([
 		getTopRecognizedLimit(),
 		getLeaderboardVisibilitySettings(),
+		getHelpMeEnabled(),
 	]);
 
 	return (
@@ -38,6 +41,8 @@ export default async function AdminSettingsPage() {
 				initialCustomStart={visibility.customStart}
 				initialCustomEnd={visibility.customEnd}
 			/>
+
+			<HelpMeVisibilityPanel initialEnabled={helpMeEnabled} />
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/helpme/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/[id]/page.tsx
@@ -7,7 +7,6 @@ import { getTicketByIdForCurrentUser } from "@/lib/actions/helpme-actions";
 import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
 import { displayReplyAuthor } from "@/lib/helpme-display";
-import { hasMinRole } from "@/lib/permissions";
 import { sanitizeReplyHtml } from "@/lib/sanitize-html";
 import { ReplyForm } from "../_components/reply-form";
 import { ReplyItem } from "../_components/reply-item";
@@ -48,9 +47,9 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
 	const session = await getServerSession();
 	if (!session) redirect("/login");
 
+	if (!(await getHelpMeEnabled())) notFound();
+
 	const viewerRole = session.user.role as Role;
-	const viewerIsAdmin = hasMinRole(viewerRole, "ADMIN");
-	if (!viewerIsAdmin && !(await getHelpMeEnabled())) notFound();
 
 	const { id } = await params;
 	const ticket = await getTicketByIdForCurrentUser(id);

--- a/app/(dashboard)/dashboard/helpme/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/[id]/page.tsx
@@ -4,8 +4,10 @@ import { notFound, redirect } from "next/navigation";
 import type { Role } from "@/app/generated/prisma/client";
 import { Badge } from "@/components/ui/badge";
 import { getTicketByIdForCurrentUser } from "@/lib/actions/helpme-actions";
+import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
 import { displayReplyAuthor } from "@/lib/helpme-display";
+import { hasMinRole } from "@/lib/permissions";
 import { sanitizeReplyHtml } from "@/lib/sanitize-html";
 import { ReplyForm } from "../_components/reply-form";
 import { ReplyItem } from "../_components/reply-item";
@@ -46,11 +48,14 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
 	const session = await getServerSession();
 	if (!session) redirect("/login");
 
+	const viewerRole = session.user.role as Role;
+	const viewerIsAdmin = hasMinRole(viewerRole, "ADMIN");
+	if (!viewerIsAdmin && !(await getHelpMeEnabled())) notFound();
+
 	const { id } = await params;
 	const ticket = await getTicketByIdForCurrentUser(id);
 	if (!ticket) notFound();
 
-	const viewerRole = session.user.role as Role;
 	const viewerId = session.user.id;
 	const creatorDisplay = displayReplyAuthor(ticket.createdBy, viewerRole);
 

--- a/app/(dashboard)/dashboard/helpme/new/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/new/page.tsx
@@ -1,12 +1,18 @@
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
+import type { Role } from "@/app/generated/prisma/client";
+import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
+import { hasMinRole } from "@/lib/permissions";
 import { TicketForm } from "../_components/ticket-form";
 
 export default async function NewTicketPage() {
 	const session = await getServerSession();
 	if (!session) redirect("/login");
+
+	const viewerIsAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+	if (!viewerIsAdmin && !(await getHelpMeEnabled())) notFound();
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-6 mt-2">

--- a/app/(dashboard)/dashboard/helpme/new/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/new/page.tsx
@@ -1,18 +1,15 @@
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import type { Role } from "@/app/generated/prisma/client";
 import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
-import { hasMinRole } from "@/lib/permissions";
 import { TicketForm } from "../_components/ticket-form";
 
 export default async function NewTicketPage() {
 	const session = await getServerSession();
 	if (!session) redirect("/login");
 
-	const viewerIsAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-	if (!viewerIsAdmin && !(await getHelpMeEnabled())) notFound();
+	if (!(await getHelpMeEnabled())) notFound();
 
 	return (
 		<div className="max-w-7xl mx-auto space-y-6 mt-2">

--- a/app/(dashboard)/dashboard/helpme/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/page.tsx
@@ -1,13 +1,19 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
+import type { Role } from "@/app/generated/prisma/client";
 import { listTicketsForCurrentUser } from "@/lib/actions/helpme-actions";
+import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
+import { hasMinRole } from "@/lib/permissions";
 import { TicketList } from "./_components/ticket-list";
 
 export default async function HelpMePage() {
 	const session = await getServerSession();
 	if (!session) redirect("/login");
+
+	const viewerIsAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+	if (!viewerIsAdmin && !(await getHelpMeEnabled())) notFound();
 
 	const { tickets, isAdmin } = await listTicketsForCurrentUser();
 

--- a/app/(dashboard)/dashboard/helpme/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/page.tsx
@@ -1,19 +1,16 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
-import type { Role } from "@/app/generated/prisma/client";
 import { listTicketsForCurrentUser } from "@/lib/actions/helpme-actions";
 import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
-import { hasMinRole } from "@/lib/permissions";
 import { TicketList } from "./_components/ticket-list";
 
 export default async function HelpMePage() {
 	const session = await getServerSession();
 	if (!session) redirect("/login");
 
-	const viewerIsAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-	if (!viewerIsAdmin && !(await getHelpMeEnabled())) notFound();
+	if (!(await getHelpMeEnabled())) notFound();
 
 	const { tickets, isAdmin } = await listTicketsForCurrentUser();
 

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,19 +1,30 @@
 import { redirect } from "next/navigation";
+import type { Role } from "@/app/generated/prisma/client";
 import { DashboardHeader } from "@/components/shared/dashboard-header";
 import { DashboardSidebar } from "@/components/shared/dashboard-sidebar";
+import { HelpFab } from "@/components/shared/help-fab";
+import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
+import { hasMinRole } from "@/lib/permissions";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
 	const session = await getServerSession();
 	if (!session) redirect("/login");
 
+	const helpMeEnabled = await getHelpMeEnabled();
+	const viewerIsAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+	// Admins always see the Help Me surfaces so they can triage existing tickets
+	// and toggle the module back on.
+	const showHelpMe = helpMeEnabled || viewerIsAdmin;
+
 	return (
 		<div className="flex min-h-screen bg-background">
-			<DashboardSidebar />
+			<DashboardSidebar helpMeEnabled={showHelpMe} />
 			<div className="flex flex-1 flex-col bg-card sm:my-2 sm:mr-2 sm:rounded-l-[2rem] shadow-sm border border-gray-100 dark:border-white/5">
-				<DashboardHeader />
+				<DashboardHeader helpMeEnabled={showHelpMe} />
 				<main className="flex-1 px-4 pb-8 sm:px-8">{children}</main>
 			</div>
+			<HelpFab enabled={showHelpMe} />
 		</div>
 	);
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,30 +1,24 @@
 import { redirect } from "next/navigation";
-import type { Role } from "@/app/generated/prisma/client";
 import { DashboardHeader } from "@/components/shared/dashboard-header";
 import { DashboardSidebar } from "@/components/shared/dashboard-sidebar";
 import { HelpFab } from "@/components/shared/help-fab";
 import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
-import { hasMinRole } from "@/lib/permissions";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
 	const session = await getServerSession();
 	if (!session) redirect("/login");
 
 	const helpMeEnabled = await getHelpMeEnabled();
-	const viewerIsAdmin = hasMinRole(session.user.role as Role, "ADMIN");
-	// Admins always see the Help Me surfaces so they can triage existing tickets
-	// and toggle the module back on.
-	const showHelpMe = helpMeEnabled || viewerIsAdmin;
 
 	return (
 		<div className="flex min-h-screen bg-background">
-			<DashboardSidebar helpMeEnabled={showHelpMe} />
+			<DashboardSidebar helpMeEnabled={helpMeEnabled} />
 			<div className="flex flex-1 flex-col bg-card sm:my-2 sm:mr-2 sm:rounded-l-[2rem] shadow-sm border border-gray-100 dark:border-white/5">
-				<DashboardHeader helpMeEnabled={showHelpMe} />
+				<DashboardHeader helpMeEnabled={helpMeEnabled} />
 				<main className="flex-1 px-4 pb-8 sm:px-8">{children}</main>
 			</div>
-			<HelpFab enabled={showHelpMe} />
+			<HelpFab enabled={helpMeEnabled} />
 		</div>
 	);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Geist_Mono, Roboto } from "next/font/google";
-import { HelpFab } from "@/components/shared/help-fab";
 import { Providers } from "@/components/shared/providers";
 import { env } from "@/env";
 import "./globals.css";
@@ -34,10 +33,7 @@ export default function RootLayout({
 			className={`${roboto.variable} ${geistMono.variable} h-full antialiased`}
 		>
 			<body className="min-h-full font-sans">
-				<Providers>
-					{children}
-					<HelpFab />
-				</Providers>
+				<Providers>{children}</Providers>
 			</body>
 		</html>
 	);

--- a/components/shared/dashboard-header.tsx
+++ b/components/shared/dashboard-header.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { signOut, useSession } from "@/lib/auth-client";
 
-export function DashboardHeader() {
+export function DashboardHeader({ helpMeEnabled }: { helpMeEnabled: boolean }) {
 	const router = useRouter();
 	const { data: session } = useSession();
 	const user = session?.user;
@@ -34,7 +34,7 @@ export function DashboardHeader() {
 	return (
 		<header className="sticky top-0 z-10 flex h-20 items-center justify-between bg-card px-4 sm:px-8">
 			<div className="flex items-center md:hidden">
-				<MobileSidebarTrigger />
+				<MobileSidebarTrigger helpMeEnabled={helpMeEnabled} />
 			</div>
 
 			<div className="flex-1 md:flex-none" />

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -104,7 +104,12 @@ const NAV_ITEMS: NavItem[] = [
 	},
 ];
 
-function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
+interface SidebarNavProps {
+	onNavigate?: () => void;
+	helpMeEnabled: boolean;
+}
+
+function SidebarNav({ onNavigate, helpMeEnabled }: SidebarNavProps) {
 	const pathname = usePathname();
 	const router = useRouter();
 	const { data: session } = useSession();
@@ -116,7 +121,11 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
 		SUPERADMIN: 2,
 	};
 
-	const filteredItems = NAV_ITEMS.filter((item) => roleLevel[userRole] >= roleLevel[item.minRole]);
+	const filteredItems = NAV_ITEMS.filter((item) => {
+		if (roleLevel[userRole] < roleLevel[item.minRole]) return false;
+		if (item.href === "/dashboard/helpme" && !helpMeEnabled) return false;
+		return true;
+	});
 
 	async function handleSignOut() {
 		try {
@@ -217,15 +226,15 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
 	);
 }
 
-export function DashboardSidebar() {
+export function DashboardSidebar({ helpMeEnabled }: { helpMeEnabled: boolean }) {
 	return (
 		<aside className="hidden w-72 sticky top-0 h-screen flex-col p-4 pr-2 md:flex">
-			<SidebarNav />
+			<SidebarNav helpMeEnabled={helpMeEnabled} />
 		</aside>
 	);
 }
 
-export function MobileSidebarTrigger() {
+export function MobileSidebarTrigger({ helpMeEnabled }: { helpMeEnabled: boolean }) {
 	const [open, setOpen] = useState(false);
 
 	return (
@@ -239,7 +248,7 @@ export function MobileSidebarTrigger() {
 			</button>
 			<Sheet open={open} onOpenChange={setOpen}>
 				<SheetContent side="left" className="w-72 p-4" showCloseButton={false}>
-					<SidebarNav onNavigate={() => setOpen(false)} />
+					<SidebarNav onNavigate={() => setOpen(false)} helpMeEnabled={helpMeEnabled} />
 				</SheetContent>
 			</Sheet>
 		</>

--- a/components/shared/help-fab.test.tsx
+++ b/components/shared/help-fab.test.tsx
@@ -103,4 +103,12 @@ describe("HelpFab", () => {
 		const link = screen.getByRole("link", { name: /open help ticket/i });
 		expect(link).toHaveAttribute("href", "/dashboard/helpme/new");
 	});
+
+	it("renders nothing when the Help Me module is disabled for the viewer", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
+		setSession({ user: true, isPending: false });
+
+		const { container } = render(<HelpFab enabled={false} />);
+		expect(container).toBeEmptyDOMElement();
+	});
 });

--- a/components/shared/help-fab.tsx
+++ b/components/shared/help-fab.tsx
@@ -8,10 +8,11 @@ import { useSession } from "@/lib/auth-client";
 
 const TARGET_HREF = "/dashboard/helpme/new";
 
-export function HelpFab() {
+export function HelpFab({ enabled = true }: { enabled?: boolean } = {}) {
 	const pathname = usePathname();
 	const { data: session, isPending } = useSession();
 
+	if (!enabled) return null;
 	if (!pathname.startsWith("/dashboard")) return null;
 	if (pathname === "/dashboard/helpme" || pathname.startsWith("/dashboard/helpme/")) return null;
 

--- a/lib/actions/helpme-actions.test.ts
+++ b/lib/actions/helpme-actions.test.ts
@@ -8,6 +8,10 @@ vi.mock("@/lib/auth-utils", () => ({
 	requireSession: vi.fn(),
 }));
 
+vi.mock("@/lib/actions/settings-actions", () => ({
+	getHelpMeEnabled: vi.fn(),
+}));
+
 vi.mock("@/lib/db", () => ({
 	prisma: {
 		helpMeTicket: {
@@ -24,6 +28,7 @@ vi.mock("@/lib/db", () => ({
 	},
 }));
 
+import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import {
@@ -53,6 +58,8 @@ const validInput = (overrides: Partial<Record<string, unknown>> = {}) => ({
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	// Default to module-enabled; individual tests opt into disabled state.
+	vi.mocked(getHelpMeEnabled).mockResolvedValue(true);
 });
 
 describe("createTicketAction", () => {
@@ -338,5 +345,56 @@ describe("deleteReplyAction", () => {
 			error: "You can only delete your own replies",
 		});
 		expect(prisma.ticketReply.delete).not.toHaveBeenCalled();
+	});
+});
+
+describe("when Help Me module is disabled", () => {
+	beforeEach(() => {
+		vi.mocked(getHelpMeEnabled).mockResolvedValue(false);
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(STAFF_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+	});
+
+	test("createTicketAction rejects and does not write", async () => {
+		const result = await createTicketAction(validInput());
+
+		expect(result).toEqual({ success: false, error: "Help Me module is disabled" });
+		expect(prisma.helpMeTicket.create).not.toHaveBeenCalled();
+	});
+
+	test("replyToTicketAction rejects and does not write", async () => {
+		const result = await replyToTicketAction("t1", { bodyHtml: "<p>ok</p>" });
+
+		expect(result).toEqual({ success: false, error: "Help Me module is disabled" });
+		expect(prisma.ticketReply.create).not.toHaveBeenCalled();
+	});
+
+	test("editReplyAction rejects and does not write", async () => {
+		const result = await editReplyAction("r1", { bodyHtml: "<p>ok</p>" });
+
+		expect(result).toEqual({ success: false, error: "Help Me module is disabled" });
+		expect(prisma.ticketReply.update).not.toHaveBeenCalled();
+	});
+
+	test("deleteReplyAction rejects and does not delete", async () => {
+		const result = await deleteReplyAction("r1");
+
+		expect(result).toEqual({ success: false, error: "Help Me module is disabled" });
+		expect(prisma.ticketReply.delete).not.toHaveBeenCalled();
+	});
+
+	test("listTicketsForCurrentUser returns an empty list and does not query", async () => {
+		const result = await listTicketsForCurrentUser();
+
+		expect(result).toEqual({ tickets: [], isAdmin: false });
+		expect(prisma.helpMeTicket.findMany).not.toHaveBeenCalled();
+	});
+
+	test("getTicketByIdForCurrentUser returns null and does not query", async () => {
+		const result = await getTicketByIdForCurrentUser("t1");
+
+		expect(result).toBeNull();
+		expect(prisma.helpMeTicket.findFirst).not.toHaveBeenCalled();
 	});
 });

--- a/lib/actions/helpme-actions.ts
+++ b/lib/actions/helpme-actions.ts
@@ -2,14 +2,20 @@
 
 import { revalidatePath } from "next/cache";
 import type { Role } from "@/app/generated/prisma/client";
+import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { hasMinRole } from "@/lib/permissions";
 import { sanitizeReplyHtml } from "@/lib/sanitize-html";
 import { createTicketSchema, replySchema } from "@/lib/validations/helpme";
 
+const MODULE_DISABLED_ERROR = "Help Me module is disabled";
+
 export async function createTicketAction(formData: unknown) {
 	try {
+		if (!(await getHelpMeEnabled())) {
+			return { success: false as const, error: MODULE_DISABLED_ERROR };
+		}
 		const session = await requireSession();
 		const parsed = createTicketSchema.safeParse(formData);
 
@@ -48,6 +54,10 @@ export async function listTicketsForCurrentUser() {
 	const role = session.user.role as Role;
 	const isAdmin = hasMinRole(role, "ADMIN");
 
+	if (!(await getHelpMeEnabled())) {
+		return { tickets: [], isAdmin };
+	}
+
 	const tickets = await prisma.helpMeTicket.findMany({
 		where: isAdmin ? undefined : { createdById: session.user.id },
 		orderBy: { createdAt: "desc" },
@@ -77,6 +87,8 @@ export async function getTicketByIdForCurrentUser(id: string) {
 	const session = await requireSession();
 	const role = session.user.role as Role;
 	const isAdmin = hasMinRole(role, "ADMIN");
+
+	if (!(await getHelpMeEnabled())) return null;
 
 	const ticket = await prisma.helpMeTicket.findFirst({
 		where: isAdmin ? { id } : { id, createdById: session.user.id },
@@ -119,6 +131,9 @@ async function loadTicketForAccess(ticketId: string, userId: string, isAdmin: bo
 
 export async function replyToTicketAction(ticketId: string, formData: unknown) {
 	try {
+		if (!(await getHelpMeEnabled())) {
+			return { success: false as const, error: MODULE_DISABLED_ERROR };
+		}
 		const session = await requireSession();
 		const role = session.user.role as Role;
 		const isAdmin = hasMinRole(role, "ADMIN");
@@ -161,6 +176,9 @@ export async function replyToTicketAction(ticketId: string, formData: unknown) {
 
 export async function editReplyAction(replyId: string, formData: unknown) {
 	try {
+		if (!(await getHelpMeEnabled())) {
+			return { success: false as const, error: MODULE_DISABLED_ERROR };
+		}
 		const session = await requireSession();
 		const parsed = replySchema.safeParse(formData);
 		if (!parsed.success) {
@@ -196,6 +214,9 @@ export async function editReplyAction(replyId: string, formData: unknown) {
 
 export async function deleteReplyAction(replyId: string) {
 	try {
+		if (!(await getHelpMeEnabled())) {
+			return { success: false as const, error: MODULE_DISABLED_ERROR };
+		}
 		const session = await requireSession();
 		const existing = await prisma.ticketReply.findUnique({
 			where: { id: replyId },

--- a/lib/actions/settings-actions.test.ts
+++ b/lib/actions/settings-actions.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/env", () => ({
+	env: {},
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+	requireRole: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		appSetting: {
+			findUnique: vi.fn(),
+			upsert: vi.fn(),
+		},
+	},
+}));
+
+// Bypass the shared cache so tests don't leak state across cases. We only care
+// that the fetcher and the prisma writes run as expected.
+vi.mock("@/lib/cache/settings-cache", () => ({
+	getOrCreateGlobalEntry: () => ({ data: null, expiry: 0, generation: 0 }),
+	invalidateEntry: vi.fn(),
+	readThroughCache: async <T>(_entry: unknown, _ttl: number, fetcher: () => Promise<T>) =>
+		fetcher(),
+}));
+
+import { requireRole } from "@/lib/auth-utils";
+import { invalidateEntry } from "@/lib/cache/settings-cache";
+import { prisma } from "@/lib/db";
+import { getHelpMeEnabled, updateHelpMeEnabled } from "./settings-actions";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("getHelpMeEnabled", () => {
+	test("defaults to enabled when no row exists", async () => {
+		vi.mocked(prisma.appSetting.findUnique).mockResolvedValue(null);
+
+		await expect(getHelpMeEnabled()).resolves.toBe(true);
+		expect(prisma.appSetting.findUnique).toHaveBeenCalledWith({
+			where: { key: "helpme_module_enabled" },
+		});
+	});
+
+	test("returns false only when the row explicitly stores 'false'", async () => {
+		vi.mocked(prisma.appSetting.findUnique).mockResolvedValueOnce({
+			key: "helpme_module_enabled",
+			value: "false",
+			updatedAt: new Date(),
+		} as Awaited<ReturnType<typeof prisma.appSetting.findUnique>>);
+
+		await expect(getHelpMeEnabled()).resolves.toBe(false);
+	});
+
+	test("returns true when the row stores 'true'", async () => {
+		vi.mocked(prisma.appSetting.findUnique).mockResolvedValueOnce({
+			key: "helpme_module_enabled",
+			value: "true",
+			updatedAt: new Date(),
+		} as Awaited<ReturnType<typeof prisma.appSetting.findUnique>>);
+
+		await expect(getHelpMeEnabled()).resolves.toBe(true);
+	});
+});
+
+describe("updateHelpMeEnabled", () => {
+	test("rejects non-admins and does not write to the database", async () => {
+		vi.mocked(requireRole).mockRejectedValueOnce(new Error("Forbidden"));
+
+		const result = await updateHelpMeEnabled(false);
+
+		expect(result).toEqual({ success: false, error: "Unauthorized" });
+		expect(prisma.appSetting.upsert).not.toHaveBeenCalled();
+		expect(invalidateEntry).not.toHaveBeenCalled();
+	});
+
+	test("persists the new value and invalidates the cache for admins", async () => {
+		vi.mocked(requireRole).mockResolvedValueOnce({} as Awaited<ReturnType<typeof requireRole>>);
+		vi.mocked(prisma.appSetting.upsert).mockResolvedValueOnce(
+			{} as Awaited<ReturnType<typeof prisma.appSetting.upsert>>,
+		);
+
+		const result = await updateHelpMeEnabled(false);
+
+		expect(result).toEqual({ success: true });
+		expect(requireRole).toHaveBeenCalledWith("ADMIN");
+		expect(prisma.appSetting.upsert).toHaveBeenCalledWith({
+			where: { key: "helpme_module_enabled" },
+			update: { value: "false" },
+			create: { key: "helpme_module_enabled", value: "false" },
+		});
+		expect(invalidateEntry).toHaveBeenCalledTimes(1);
+	});
+});

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -36,6 +36,7 @@ export type OAuthSettings = Record<OAuthKey, boolean>;
 const CACHE_TTL_MS = 30_000;
 
 const TOP_RECOGNIZED_KEY = "top_recognized_limit";
+const HELPME_MODULE_KEY = "helpme_module_enabled";
 
 const oauthCache = getOrCreateGlobalEntry<OAuthSettings>("accessGroupStaff.settings.oauth");
 const topLimitCache = getOrCreateGlobalEntry<number>(
@@ -44,6 +45,7 @@ const topLimitCache = getOrCreateGlobalEntry<number>(
 const leaderboardCache = getOrCreateGlobalEntry<LeaderboardVisibilitySettings>(
 	"accessGroupStaff.settings.leaderboardVisibility",
 );
+const helpMeCache = getOrCreateGlobalEntry<boolean>("accessGroupStaff.settings.helpMeEnabled");
 
 export async function getOAuthSettings(): Promise<OAuthSettings> {
 	return readThroughCache(oauthCache, CACHE_TTL_MS, async () => {
@@ -178,6 +180,42 @@ export async function updateActivityLogRetentionDays(
 		update: { value: String(days) },
 		create: { key: ACTIVITY_LOG_RETENTION_KEY, value: String(days) },
 	});
+
+	return { success: true };
+}
+
+/* ── Help Me Module Toggle ───────────────────────────── */
+
+function invalidateHelpMeCache() {
+	invalidateEntry(helpMeCache);
+}
+
+export async function getHelpMeEnabled(): Promise<boolean> {
+	return readThroughCache(helpMeCache, CACHE_TTL_MS, async () => {
+		const row = await prisma.appSetting.findUnique({
+			where: { key: HELPME_MODULE_KEY },
+		});
+		// Default to enabled when the row is missing or holds an unexpected value.
+		return row?.value !== "false";
+	});
+}
+
+export async function updateHelpMeEnabled(
+	enabled: boolean,
+): Promise<{ success: boolean; error?: string }> {
+	try {
+		await requireRole("ADMIN");
+	} catch {
+		return { success: false, error: "Unauthorized" };
+	}
+
+	await prisma.appSetting.upsert({
+		where: { key: HELPME_MODULE_KEY },
+		update: { value: String(enabled) },
+		create: { key: HELPME_MODULE_KEY, value: String(enabled) },
+	});
+
+	invalidateHelpMeCache();
 
 	return { success: true };
 }


### PR DESCRIPTION
## Summary

- Admins can now hide/show the Help Me Tickets module from `/dashboard/admin-settings`.
- When disabled, non-admins get `notFound()` on `/dashboard/helpme*`, the sidebar entry is dropped, and the floating help button is suppressed.
- Admins always retain access so existing tickets stay triageable and the module can be re-enabled.

Closes #117.

## Approach

- Reused the existing `AppSetting` + cached server action pattern (same shape as Leaderboard Visibility).
  - `getHelpMeEnabled()` / `updateHelpMeEnabled()` in `lib/actions/settings-actions.ts`, gated by `requireRole(\"ADMIN\")`, read-through cached 30s.
  - New setting key `helpme_module_enabled`; default is enabled (no migration needed).
- `(dashboard)/layout.tsx` resolves `showHelpMe = helpMeEnabled || viewerIsAdmin` server-side and threads it to the sidebar, header, and FAB so the admin bypass is computed in one place.
- Moved `<HelpFab />` out of the root layout into the dashboard layout — the FAB is only meaningful inside `/dashboard`, and that's where the session/setting context lives.
- Page-level guards (`helpme`, `helpme/new`, `helpme/[id]`) are defence-in-depth: even a direct URL visit 404s for non-admins when off.

## Test plan

- [x] `bun run lint` (Biome)
- [x] `bun run test:unit` — 174 tests pass, including:
  - `lib/actions/settings-actions.test.ts` (new): default, read, ADMIN gate, cache invalidation on write
  - `components/shared/help-fab.test.tsx`: renders nothing when `enabled={false}`
- [x] `bunx tsc --noEmit`
- [ ] Manual: toggle from `/dashboard/admin-settings` as an admin; verify a STAFF user sees the sidebar entry + FAB disappear and direct `/dashboard/helpme` visits 404
- [ ] Manual: confirm admin still sees sidebar entry, FAB, and can reach tickets with the toggle off
- [ ] Manual: toggle back on and confirm STAFF regains access

## Notes / Risks

- Cache is process-local (matches existing settings pattern); on multi-instance serverless, a flip can take up to 30 s to propagate to every instance. Acceptable for an admin-only config.
- No schema change; `AppSetting` row is upserted lazily on first toggle.

## Revert

Revert the merge commit — no data to unwind since the setting row is additive and defaults-on behaviour matches pre-change.