### PR TITLE
fix(users): sort list by newest and add joined date (#121)

### DIFF
--- a/app/(dashboard)/dashboard/users/(list)/loading.tsx
+++ b/app/(dashboard)/dashboard/users/(list)/loading.tsx
@@ -49,6 +49,9 @@ export default function UsersListLoading() {
 							<TableHead>
 								<SkeletonLine className="h-3 w-12" />
 							</TableHead>
+							<TableHead>
+								<SkeletonLine className="h-3 w-12" />
+							</TableHead>
 							<TableHead className="text-right">
 								<SkeletonLine className="h-3 w-14 ml-auto" />
 							</TableHead>
@@ -77,6 +80,9 @@ export default function UsersListLoading() {
 								</TableCell>
 								<TableCell>
 									<SkeletonLine className="h-5 w-16 rounded-full" />
+								</TableCell>
+								<TableCell>
+									<SkeletonLine className="h-4 w-20" />
 								</TableCell>
 								<TableCell className="text-right">
 									<div className="flex justify-end gap-1">

--- a/app/(dashboard)/dashboard/users/(list)/loading.tsx
+++ b/app/(dashboard)/dashboard/users/(list)/loading.tsx
@@ -79,10 +79,10 @@ export default function UsersListLoading() {
 									<SkeletonLine className="h-4 w-16" />
 								</TableCell>
 								<TableCell>
-									<SkeletonLine className="h-5 w-16 rounded-full" />
+									<SkeletonLine className="h-4 w-20" />
 								</TableCell>
 								<TableCell>
-									<SkeletonLine className="h-4 w-20" />
+									<SkeletonLine className="h-5 w-16 rounded-full" />
 								</TableCell>
 								<TableCell className="text-right">
 									<div className="flex justify-end gap-1">

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -54,6 +54,7 @@ interface User {
 	deletedAt: string | null;
 	position: string | null;
 	branch: string | null;
+	createdAt: string;
 	department: { id: string; name: string; code: string } | null;
 }
 
@@ -79,6 +80,18 @@ function roleBadgeVariant(role: string) {
 	}
 }
 
+const joinedDateFormatter = new Intl.DateTimeFormat("en-AU", {
+	day: "2-digit",
+	month: "short",
+	year: "numeric",
+});
+
+function formatJoinedDate(value: string) {
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return "—";
+	return joinedDateFormatter.format(parsed);
+}
+
 function TableSkeleton() {
 	return (
 		<div
@@ -95,6 +108,9 @@ function TableSkeleton() {
 						</TableHead>
 						<TableHead className="w-full">
 							<SkeletonLine className="h-3 w-28" />
+						</TableHead>
+						<TableHead>
+							<SkeletonLine className="h-3 w-14" />
 						</TableHead>
 						<TableHead>
 							<SkeletonLine className="h-3 w-14" />
@@ -130,6 +146,9 @@ function TableSkeleton() {
 							</TableCell>
 							<TableCell>
 								<SkeletonLine className="h-5 w-16 rounded-md" />
+							</TableCell>
+							<TableCell>
+								<SkeletonLine className="h-4 w-24" />
 							</TableCell>
 							<TableCell className="text-right">
 								<div className="flex justify-end gap-1">
@@ -371,6 +390,7 @@ export function UserListClient({ mode, currentUserRole, departments }: UserListC
 									<TableHead>Employee</TableHead>
 									<TableHead>Position / Dept</TableHead>
 									<TableHead>Branch</TableHead>
+									<TableHead>Joined</TableHead>
 									<TableHead>Status</TableHead>
 									<TableHead className="text-right">Actions</TableHead>
 								</TableRow>
@@ -408,6 +428,11 @@ export function UserListClient({ mode, currentUserRole, departments }: UserListC
 											</TableCell>
 											<TableCell>
 												<span className="text-sm text-foreground">{user.branch ?? "—"}</span>
+											</TableCell>
+											<TableCell>
+												<span className="text-sm text-foreground">
+													{formatJoinedDate(user.createdAt)}
+												</span>
 											</TableCell>
 											<TableCell>
 												<div className="flex flex-col gap-1.5">

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -145,10 +145,10 @@ function TableSkeleton() {
 								<SkeletonLine className="h-4 w-24" />
 							</TableCell>
 							<TableCell>
-								<SkeletonLine className="h-5 w-16 rounded-md" />
+								<SkeletonLine className="h-4 w-24" />
 							</TableCell>
 							<TableCell>
-								<SkeletonLine className="h-4 w-24" />
+								<SkeletonLine className="h-5 w-16 rounded-md" />
 							</TableCell>
 							<TableCell className="text-right">
 								<div className="flex justify-end gap-1">

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -127,7 +127,7 @@ export async function GET(request: NextRequest) {
 		prisma.user.findMany({
 			where,
 			include: { department: true },
-			orderBy: [{ firstName: "asc" }, { lastName: "asc" }, { id: "asc" }],
+			orderBy: [{ createdAt: "desc" }, { id: "desc" }],
 			skip: (page - 1) * pageSize,
 			take: pageSize,
 		}),

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -106,7 +106,7 @@ export async function GET(request: NextRequest) {
 			prisma.user.findMany({
 				where,
 				include: { department: { select: { name: true } } },
-				orderBy: [{ firstName: "asc" }, { lastName: "asc" }, { id: "asc" }],
+				orderBy: [{ createdAt: "desc" }, { id: "desc" }],
 				take: EXPORT_LIMIT,
 			}),
 			prisma.user.count({ where }),

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -5,6 +5,7 @@ export interface ExportUser {
 	role: string;
 	position: string | null;
 	branch: string | null;
+	createdAt: Date | string;
 	deletedAt: Date | string | null;
 	department: { name: string } | null;
 }
@@ -23,9 +24,20 @@ const CSV_HEADERS = [
 	"Role",
 	"Department",
 	"Branch",
+	"Joined",
 	"Position",
 	"Status",
 ];
+
+function formatCsvDate(value: Date | string): string {
+	const parsed = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(parsed.getTime())) return "";
+	return new Intl.DateTimeFormat("en-AU", {
+		day: "2-digit",
+		month: "short",
+		year: "numeric",
+	}).format(parsed);
+}
 
 export function generateUserCsv(users: ExportUser[]): string {
 	const rows = users.map((user) => [
@@ -35,6 +47,7 @@ export function generateUserCsv(users: ExportUser[]): string {
 		user.role,
 		user.department?.name ?? "",
 		user.branch ?? "",
+		formatCsvDate(user.createdAt),
 		user.position ?? "",
 		user.deletedAt ? "Deleted" : "Active",
 	]);


### PR DESCRIPTION
## Summary
- sort `/dashboard/users` paginated results by newest registration (`createdAt desc`) so recent joins appear first
- add a `Joined` column in the users table that displays each user’s creation date
- update the users loading skeleton to keep table column alignment with the new `Joined` column

## Test plan
- [x] Open `/dashboard/users` and confirm newest registered users appear first
- [x] Verify each row shows a joined date in the new `Joined` column
- [x] Verify loading state column alignment while data is fetching

Made with [Cursor](https://cursor.com)