### PR TITLE
Roll out canonical department list

### DIFF
--- a/prisma/migrations/0005_department_canonical_list/migration.sql
+++ b/prisma/migrations/0005_department_canonical_list/migration.sql
@@ -7,31 +7,56 @@
 DO $$
 DECLARE
   blocked_departments TEXT;
+  legacy_department_id TEXT;
+  canonical_department_id TEXT;
 BEGIN
-  -- Reuse the old Engineering and Safety rows when possible so any linked users
-  -- keep the same department_id through the rename.
-  IF EXISTS (
-    SELECT 1 FROM "departments" WHERE "code" = 'ENG'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM "departments" WHERE "code" = 'COE'
-  ) THEN
+  -- Merge or reuse the old Engineering and Safety rows so linked users land on
+  -- the canonical department even if both legacy and canonical rows already
+  -- coexist from a phased/manual rollout.
+  SELECT "id" INTO legacy_department_id
+  FROM "departments"
+  WHERE "code" = 'ENG';
+
+  SELECT "id" INTO canonical_department_id
+  FROM "departments"
+  WHERE "code" = 'COE';
+
+  IF legacy_department_id IS NOT NULL AND canonical_department_id IS NOT NULL THEN
+    UPDATE "users"
+    SET "department_id" = canonical_department_id
+    WHERE "department_id" = legacy_department_id;
+
+    DELETE FROM "departments"
+    WHERE "id" = legacy_department_id;
+  ELSIF legacy_department_id IS NOT NULL THEN
     UPDATE "departments"
     SET "name" = 'COE',
         "code" = 'COE',
         "updated_at" = NOW()
-    WHERE "code" = 'ENG';
+    WHERE "id" = legacy_department_id;
   END IF;
 
-  IF EXISTS (
-    SELECT 1 FROM "departments" WHERE "code" = 'SAF'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM "departments" WHERE "code" = 'TRN'
-  ) THEN
+  SELECT "id" INTO legacy_department_id
+  FROM "departments"
+  WHERE "code" = 'SAF';
+
+  SELECT "id" INTO canonical_department_id
+  FROM "departments"
+  WHERE "code" = 'TRN';
+
+  IF legacy_department_id IS NOT NULL AND canonical_department_id IS NOT NULL THEN
+    UPDATE "users"
+    SET "department_id" = canonical_department_id
+    WHERE "department_id" = legacy_department_id;
+
+    DELETE FROM "departments"
+    WHERE "id" = legacy_department_id;
+  ELSIF legacy_department_id IS NOT NULL THEN
     UPDATE "departments"
     SET "name" = 'Training',
         "code" = 'TRN',
         "updated_at" = NOW()
-    WHERE "code" = 'SAF';
+    WHERE "id" = legacy_department_id;
   END IF;
 
   INSERT INTO "departments" ("id", "name", "code", "updated_at")

--- a/prisma/migrations/0005_department_canonical_list/migration.sql
+++ b/prisma/migrations/0005_department_canonical_list/migration.sql
@@ -1,0 +1,83 @@
+-- Align departments with the canonical production list.
+-- Safe to apply after a manual local reconcile: existing canonical rows are
+-- preserved, legacy rows are reused where possible to keep user assignments,
+-- and unexpected obsolete departments with assigned users abort the migration
+-- instead of silently rehoming people to the wrong team.
+
+DO $$
+DECLARE
+  blocked_departments TEXT;
+BEGIN
+  -- Reuse the old Engineering and Safety rows when possible so any linked users
+  -- keep the same department_id through the rename.
+  IF EXISTS (
+    SELECT 1 FROM "departments" WHERE "code" = 'ENG'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM "departments" WHERE "code" = 'COE'
+  ) THEN
+    UPDATE "departments"
+    SET "name" = 'COE',
+        "code" = 'COE',
+        "updated_at" = NOW()
+    WHERE "code" = 'ENG';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "departments" WHERE "code" = 'SAF'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM "departments" WHERE "code" = 'TRN'
+  ) THEN
+    UPDATE "departments"
+    SET "name" = 'Training',
+        "code" = 'TRN',
+        "updated_at" = NOW()
+    WHERE "code" = 'SAF';
+  END IF;
+
+  INSERT INTO "departments" ("id", "name", "code", "updated_at")
+  VALUES
+    ('department-coe', 'COE', 'COE', NOW()),
+    ('department-cm', 'Credit Management', 'CM', NOW()),
+    ('department-fin', 'Finance', 'FIN', NOW()),
+    ('department-flt', 'Fleet', 'FLT', NOW()),
+    ('department-hr', 'Human Resources', 'HR', NOW()),
+    ('department-it', 'IT', 'IT', NOW()),
+    ('department-its', 'IT Support', 'ITS', NOW()),
+    ('department-lg', 'Lead Generation', 'LG', NOW()),
+    ('department-mkt', 'Marketing', 'MKT', NOW()),
+    ('department-ops', 'Operations', 'OPS', NOW()),
+    ('department-trn', 'Training', 'TRN', NOW())
+  ON CONFLICT ("code") DO UPDATE
+  SET "name" = EXCLUDED."name",
+      "updated_at" = NOW();
+
+  SELECT string_agg(
+    format('%s (%s): %s users', department_name, department_code, user_count),
+    E'\n'
+  )
+  INTO blocked_departments
+  FROM (
+    SELECT
+      d."name" AS department_name,
+      d."code" AS department_code,
+      COUNT(u."id")::TEXT AS user_count
+    FROM "departments" d
+    LEFT JOIN "users" u ON u."department_id" = d."id"
+    WHERE d."code" NOT IN ('COE', 'CM', 'FIN', 'FLT', 'HR', 'IT', 'ITS', 'LG', 'MKT', 'OPS', 'TRN')
+    GROUP BY d."id", d."name", d."code"
+    HAVING COUNT(u."id") > 0
+  ) blocked;
+
+  IF blocked_departments IS NOT NULL THEN
+    RAISE EXCEPTION USING MESSAGE =
+      E'Cannot remove obsolete departments with assigned users.\n' || blocked_departments;
+  END IF;
+
+  DELETE FROM "departments" d
+  WHERE d."code" NOT IN ('COE', 'CM', 'FIN', 'FLT', 'HR', 'IT', 'ITS', 'LG', 'MKT', 'OPS', 'TRN')
+    AND NOT EXISTS (
+      SELECT 1
+      FROM "users" u
+      WHERE u."department_id" = d."id"
+    );
+END $$;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,42 +8,33 @@ const SHOWCASE_CARD_IDS = [
 	"showcase-popover-card-2",
 	"showcase-popover-card-3",
 ] as const;
+const DEPARTMENT_SEED = [
+	{ name: "COE", code: "COE" },
+	{ name: "Credit Management", code: "CM" },
+	{ name: "Finance", code: "FIN" },
+	{ name: "Fleet", code: "FLT" },
+	{ name: "Human Resources", code: "HR" },
+	{ name: "IT", code: "IT" },
+	{ name: "IT Support", code: "ITS" },
+	{ name: "Lead Generation", code: "LG" },
+	{ name: "Marketing", code: "MKT" },
+	{ name: "Operations", code: "OPS" },
+	{ name: "Training", code: "TRN" },
+] as const;
 
 async function seed() {
 	console.log("Seeding departments...");
 
-	const departments = await Promise.all([
-		prisma.department.upsert({
-			where: { code: "ENG" },
-			update: {},
-			create: { name: "Engineering", code: "ENG" },
-		}),
-		prisma.department.upsert({
-			where: { code: "HR" },
-			update: {},
-			create: { name: "Human Resources", code: "HR" },
-		}),
-		prisma.department.upsert({
-			where: { code: "OPS" },
-			update: {},
-			create: { name: "Operations", code: "OPS" },
-		}),
-		prisma.department.upsert({
-			where: { code: "FIN" },
-			update: {},
-			create: { name: "Finance", code: "FIN" },
-		}),
-		prisma.department.upsert({
-			where: { code: "SAF" },
-			update: {},
-			create: { name: "Safety", code: "SAF" },
-		}),
-		prisma.department.upsert({
-			where: { code: "MKT" },
-			update: {},
-			create: { name: "Marketing", code: "MKT" },
-		}),
-	]);
+	const departments = await Promise.all(
+		DEPARTMENT_SEED.map((department) =>
+			prisma.department.upsert({
+				where: { code: department.code },
+				update: { name: department.name },
+				create: department,
+			}),
+		),
+	);
+	const departmentByCode = new Map(departments.map((department) => [department.code, department]));
 
 	console.log(`Created ${departments.length} departments`);
 	console.log("Seeding users...");
@@ -63,7 +54,7 @@ async function seed() {
 			lastName: "Diomampo",
 			role: "SUPERADMIN",
 			branch: "ISO",
-			departmentId: departments[5].id,
+			departmentId: departmentByCode.get("MKT")?.id ?? null,
 		},
 		{
 			email: "alfred.irlanda@accessgroup.net.au",
@@ -71,7 +62,7 @@ async function seed() {
 			lastName: "Irlanda",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departments[1].id,
+			departmentId: departmentByCode.get("HR")?.id ?? null,
 			position: "HR Compliance Coordinator",
 		},
 		{
@@ -80,7 +71,7 @@ async function seed() {
 			lastName: "Mora",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departments[1].id,
+			departmentId: departmentByCode.get("HR")?.id ?? null,
 			position: "Office Manager",
 		},
 		{
@@ -89,7 +80,7 @@ async function seed() {
 			lastName: "Abdelatty",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departments[1].id,
+			departmentId: departmentByCode.get("HR")?.id ?? null,
 		},
 		{
 			email: "may.viduya@accessgroup.net.au",
@@ -97,7 +88,7 @@ async function seed() {
 			lastName: "Viduya",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departments[1].id,
+			departmentId: departmentByCode.get("HR")?.id ?? null,
 			position: "HR Systems Administrator",
 		},
 		{
@@ -106,7 +97,7 @@ async function seed() {
 			lastName: "Hortal",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departments[1].id,
+			departmentId: departmentByCode.get("HR")?.id ?? null,
 			position: "Recruitment and Onboarding Admin",
 		},
 		{
@@ -115,7 +106,7 @@ async function seed() {
 			lastName: "Raymundo",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departments[1].id,
+			departmentId: departmentByCode.get("HR")?.id ?? null,
 			position: "Offshore Sourcing Specialist",
 		},
 		{
@@ -124,7 +115,7 @@ async function seed() {
 			lastName: "Alonzo",
 			role: "STAFF",
 			branch: "ISO",
-			departmentId: departments[5].id,
+			departmentId: departmentByCode.get("MKT")?.id ?? null,
 		},
 		{
 			email: "grace.urmeneta@accessgroup.net.au",
@@ -132,7 +123,7 @@ async function seed() {
 			lastName: "Urmeneta",
 			role: "STAFF",
 			branch: "ISO",
-			departmentId: departments[5].id,
+			departmentId: departmentByCode.get("MKT")?.id ?? null,
 		},
 		{
 			email: "kate.bickley@accessgroup.net.au",
@@ -140,7 +131,7 @@ async function seed() {
 			lastName: "Bickley",
 			role: "ADMIN",
 			branch: "PERTH",
-			departmentId: departments[5].id,
+			departmentId: departmentByCode.get("MKT")?.id ?? null,
 			position: "CMO",
 		},
 	];

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -22,6 +22,18 @@ const DEPARTMENT_SEED = [
 	{ name: "Training", code: "TRN" },
 ] as const;
 
+function getDepartmentId(
+	departmentByCode: Map<string, { id: string; name: string; code: string }>,
+	code: string,
+) {
+	const department = departmentByCode.get(code);
+	if (!department) {
+		throw new Error(`Seed department not found for code: ${code}`);
+	}
+
+	return department.id;
+}
+
 async function seed() {
 	console.log("Seeding departments...");
 
@@ -54,7 +66,7 @@ async function seed() {
 			lastName: "Diomampo",
 			role: "SUPERADMIN",
 			branch: "ISO",
-			departmentId: departmentByCode.get("MKT")?.id ?? null,
+			departmentId: getDepartmentId(departmentByCode, "MKT"),
 		},
 		{
 			email: "alfred.irlanda@accessgroup.net.au",
@@ -62,7 +74,7 @@ async function seed() {
 			lastName: "Irlanda",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departmentByCode.get("HR")?.id ?? null,
+			departmentId: getDepartmentId(departmentByCode, "HR"),
 			position: "HR Compliance Coordinator",
 		},
 		{
@@ -71,7 +83,7 @@ async function seed() {
 			lastName: "Mora",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departmentByCode.get("HR")?.id ?? null,
+			departmentId: getDepartmentId(departmentByCode, "HR"),
 			position: "Office Manager",
 		},
 		{
@@ -80,7 +92,7 @@ async function seed() {
 			lastName: "Abdelatty",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departmentByCode.get("HR")?.id ?? null,
+			departmentId: getDepartmentId(departmentByCode, "HR"),
 		},
 		{
 			email: "may.viduya@accessgroup.net.au",
@@ -88,7 +100,7 @@ async function seed() {
 			lastName: "Viduya",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departmentByCode.get("HR")?.id ?? null,
+			departmentId: getDepartmentId(departmentByCode, "HR"),
 			position: "HR Systems Administrator",
 		},
 		{
@@ -97,7 +109,7 @@ async function seed() {
 			lastName: "Hortal",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departmentByCode.get("HR")?.id ?? null,
+			departmentId: getDepartmentId(departmentByCode, "HR"),
 			position: "Recruitment and Onboarding Admin",
 		},
 		{
@@ -106,7 +118,7 @@ async function seed() {
 			lastName: "Raymundo",
 			role: "ADMIN",
 			branch: "ISO",
-			departmentId: departmentByCode.get("HR")?.id ?? null,
+			departmentId: getDepartmentId(departmentByCode, "HR"),
 			position: "Offshore Sourcing Specialist",
 		},
 		{
@@ -115,7 +127,7 @@ async function seed() {
 			lastName: "Alonzo",
 			role: "STAFF",
 			branch: "ISO",
-			departmentId: departmentByCode.get("MKT")?.id ?? null,
+			departmentId: getDepartmentId(departmentByCode, "MKT"),
 		},
 		{
 			email: "grace.urmeneta@accessgroup.net.au",
@@ -123,7 +135,7 @@ async function seed() {
 			lastName: "Urmeneta",
 			role: "STAFF",
 			branch: "ISO",
-			departmentId: departmentByCode.get("MKT")?.id ?? null,
+			departmentId: getDepartmentId(departmentByCode, "MKT"),
 		},
 		{
 			email: "kate.bickley@accessgroup.net.au",
@@ -131,7 +143,7 @@ async function seed() {
 			lastName: "Bickley",
 			role: "ADMIN",
 			branch: "PERTH",
-			departmentId: departmentByCode.get("MKT")?.id ?? null,
+			departmentId: getDepartmentId(departmentByCode, "MKT"),
 			position: "CMO",
 		},
 	];

--- a/scripts/reconcile-departments.ts
+++ b/scripts/reconcile-departments.ts
@@ -30,7 +30,17 @@ async function reconcileDepartments() {
 			const target = await tx.department.findUnique({
 				where: { code: mapping.to.code },
 			});
-			if (target) continue;
+			if (target) {
+				await tx.user.updateMany({
+					where: { departmentId: existing.id },
+					data: { departmentId: target.id },
+				});
+
+				await tx.department.delete({
+					where: { id: existing.id },
+				});
+				continue;
+			}
 
 			await tx.department.update({
 				where: { id: existing.id },

--- a/scripts/reconcile-departments.ts
+++ b/scripts/reconcile-departments.ts
@@ -1,0 +1,110 @@
+import { prisma } from "../lib/db";
+
+const CANONICAL_DEPARTMENTS = [
+	{ name: "COE", code: "COE" },
+	{ name: "Credit Management", code: "CM" },
+	{ name: "Finance", code: "FIN" },
+	{ name: "Fleet", code: "FLT" },
+	{ name: "Human Resources", code: "HR" },
+	{ name: "IT", code: "IT" },
+	{ name: "IT Support", code: "ITS" },
+	{ name: "Lead Generation", code: "LG" },
+	{ name: "Marketing", code: "MKT" },
+	{ name: "Operations", code: "OPS" },
+	{ name: "Training", code: "TRN" },
+] as const;
+
+const REUSE_MAPPINGS = [
+	{ fromCode: "ENG", to: { name: "COE", code: "COE" } },
+	{ fromCode: "SAF", to: { name: "Training", code: "TRN" } },
+] as const;
+
+async function reconcileDepartments() {
+	await prisma.$transaction(async (tx) => {
+		for (const mapping of REUSE_MAPPINGS) {
+			const existing = await tx.department.findUnique({
+				where: { code: mapping.fromCode },
+			});
+			if (!existing) continue;
+
+			const target = await tx.department.findUnique({
+				where: { code: mapping.to.code },
+			});
+			if (target) continue;
+
+			await tx.department.update({
+				where: { id: existing.id },
+				data: mapping.to,
+			});
+		}
+
+		for (const department of CANONICAL_DEPARTMENTS) {
+			await tx.department.upsert({
+				where: { code: department.code },
+				update: { name: department.name },
+				create: department,
+			});
+		}
+
+		const obsoleteDepartments = await tx.department.findMany({
+			where: {
+				code: {
+					notIn: CANONICAL_DEPARTMENTS.map((department) => department.code),
+				},
+			},
+			include: {
+				_count: {
+					select: { users: true },
+				},
+			},
+			orderBy: { name: "asc" },
+		});
+
+		const blockedDepartments = obsoleteDepartments.filter(
+			(department) => department._count.users > 0,
+		);
+		if (blockedDepartments.length > 0) {
+			throw new Error(
+				[
+					"Cannot remove obsolete departments with assigned users.",
+					...blockedDepartments.map(
+						(department) =>
+							`- ${department.name} (${department.code}): ${department._count.users} users`,
+					),
+				].join("\n"),
+			);
+		}
+
+		if (obsoleteDepartments.length > 0) {
+			await tx.department.deleteMany({
+				where: { id: { in: obsoleteDepartments.map((department) => department.id) } },
+			});
+		}
+	});
+
+	const finalDepartments = await prisma.department.findMany({
+		include: { _count: { select: { users: true } } },
+		orderBy: { name: "asc" },
+	});
+
+	console.log(
+		JSON.stringify(
+			finalDepartments.map(({ name, code, _count }) => ({
+				name,
+				code,
+				users: _count.users,
+			})),
+			null,
+			2,
+		),
+	);
+}
+
+reconcileDepartments()
+	.catch((error) => {
+		console.error(error);
+		process.exit(1);
+	})
+	.finally(async () => {
+		await prisma.$disconnect();
+	});


### PR DESCRIPTION
## Summary
- add a production migration that aligns department data during `prisma migrate deploy`
- update the seed data to the canonical department list and stop relying on fragile array indexes
- add a one-off reconciliation script for local/admin use

## Verification
- ran `bun scripts/reconcile-departments.ts`
- verified the final Prisma department list matches the target names and preserves existing linked users
- `bunx prisma migrate deploy` could not be verified in this shell because the Prisma CLI could not reach `localhost:5432`

Closes #127