### PR TITLE
Add avatars to read-only physical recognition cards

### DIFF
--- a/app/(dashboard)/dashboard/recognition/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
 	BackgroundGraphic,
 } from "@/components/shared/access-logos";
 import { FitText } from "@/components/shared/fit-text";
+import { PhysicalCardPerson } from "@/components/shared/physical-card-person";
 import { getServerSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { getCardReactionSummary } from "@/lib/interactions";
@@ -70,6 +71,7 @@ export default async function RecognitionDetailPage({
 					id: true,
 					firstName: true,
 					lastName: true,
+					avatar: true,
 					position: true,
 					department: { select: { name: true } },
 				},
@@ -79,6 +81,7 @@ export default async function RecognitionDetailPage({
 					id: true,
 					firstName: true,
 					lastName: true,
+					avatar: true,
 					position: true,
 					department: { select: { name: true } },
 				},
@@ -175,9 +178,16 @@ export default async function RecognitionDetailPage({
 				aria-hidden="true"
 			/>
 			<div className="flex-1 flex flex-col gap-4">
-				<div className="bg-white p-3 md:p-4 rounded-sm flex flex-col min-h-20 shadow-sm">
-					<span className="text-xs font-black text-black mb-1">TO</span>
-					<FitText className="text-lg text-[#222]">{recipientName}</FitText>
+				<div className="bg-white p-3 md:p-4 rounded-sm flex items-center gap-3 min-h-20 shadow-sm">
+					<span className="text-xs font-black text-black shrink-0">TO</span>
+					<PhysicalCardPerson
+						firstName={card.recipient.firstName}
+						lastName={card.recipient.lastName}
+						avatar={card.recipient.avatar}
+						avatarSize="lg"
+						className="flex-1"
+						textClassName="text-lg"
+					/>
 				</div>
 				<div className="bg-white p-3 md:p-4 rounded-sm flex flex-col flex-grow min-h-[300px] shadow-sm relative">
 					<span className="text-xs font-black text-black mb-2">WHAT YOU DID</span>

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-card-mini.test.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-card-mini.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { RecognitionCard } from "@/lib/recognition";
+import { RecognitionCardMini } from "./recognition-card-mini";
+
+class ResizeObserverMock {
+	observe() {}
+	disconnect() {}
+}
+
+beforeAll(() => {
+	Object.defineProperty(window, "ResizeObserver", {
+		writable: true,
+		configurable: true,
+		value: ResizeObserverMock,
+	});
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+const card: RecognitionCard = {
+	id: "card-1",
+	message: "Thanks for helping the team.",
+	date: "2026-04-22T00:00:00.000Z",
+	createdAt: "2026-04-22T00:00:00.000Z",
+	sender: {
+		id: "sender-1",
+		firstName: "Sam",
+		lastName: "Sender",
+		avatar: "https://example.com/sender.png",
+		position: "Coordinator",
+	},
+	recipient: {
+		id: "recipient-1",
+		firstName: "Riley",
+		lastName: "Recipient",
+		avatar: "https://example.com/recipient.png",
+		position: "Specialist",
+	},
+	valuesPeople: true,
+	valuesSafety: false,
+	valuesRespect: true,
+	valuesCommunication: false,
+	valuesContinuousImprovement: true,
+	interactionCounts: null,
+};
+
+describe("RecognitionCardMini", () => {
+	it("renders the recipient avatar and keeps the sender as plain text", () => {
+		render(<RecognitionCardMini card={card} />);
+
+		expect(screen.getByAltText("Riley Recipient")).toBeInTheDocument();
+		expect(screen.queryByAltText("Sam Sender")).not.toBeInTheDocument();
+		expect(screen.getByText("Sam Sender")).toBeInTheDocument();
+	});
+
+	it("still renders the recipient name when the recipient avatar is missing", () => {
+		render(
+			<RecognitionCardMini
+				card={{
+					...card,
+					recipient: {
+						...card.recipient,
+						avatar: null,
+					},
+				}}
+			/>,
+		);
+
+		expect(screen.queryByAltText("Riley Recipient")).not.toBeInTheDocument();
+		expect(screen.getByText("Riley Recipient")).toBeInTheDocument();
+		expect(screen.getByText("RR")).toBeInTheDocument();
+	});
+});

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-card-mini.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-card-mini.tsx
@@ -7,12 +7,38 @@ import {
 	BackgroundGraphic,
 } from "@/components/shared/access-logos";
 import { FitText } from "@/components/shared/fit-text";
+import { PhysicalCardPerson } from "@/components/shared/physical-card-person";
+import type { AvatarSize } from "@/components/shared/user-avatar";
 import { COMPANY_VALUES, formatRecognitionDate, type RecognitionCard } from "@/lib/recognition";
 import { cn } from "@/lib/utils";
 import type { CardSize } from "@/stores/use-preferences-store";
 
-const SIZE_CONFIG = {
+const SIZE_CONFIG: Record<
+	CardSize,
+	{
+		avatarSize: AvatarSize;
+		outer: string;
+		field: string;
+		labelText: string;
+		valueText: string;
+		messageMin: string;
+		messageText: string;
+		fromDateH: string;
+		logoH: string;
+		logoSize: string;
+		businessLogoSize: string;
+		valuesTitle: string;
+		lgCheckbox: string;
+		lgCheckIcon: number;
+		lgLabel: string;
+		smCheckbox: string;
+		smCheckIcon: number;
+		smLabel: string;
+		valuesPanel: string;
+	}
+> = {
 	compact: {
+		avatarSize: "xs",
 		outer: "p-2 md:p-3 gap-2 md:gap-3",
 		field: "p-1.5 md:p-2",
 		labelText: "text-[7px] md:text-[8px]",
@@ -33,6 +59,7 @@ const SIZE_CONFIG = {
 		valuesPanel: "p-3 md:p-4",
 	},
 	normal: {
+		avatarSize: "sm",
 		outer: "p-3 md:p-5 gap-3 md:gap-4",
 		field: "p-2 md:p-3",
 		labelText: "text-[8px] md:text-[9px]",
@@ -53,6 +80,7 @@ const SIZE_CONFIG = {
 		valuesPanel: "p-4 md:p-5",
 	},
 	expanded: {
+		avatarSize: "md",
 		outer: "p-4 md:p-6 gap-4 md:gap-5",
 		field: "p-2.5 md:p-3",
 		labelText: "text-[9px] md:text-[10px]",
@@ -149,11 +177,16 @@ export function RecognitionCardMini({
 			{/* Left Column */}
 			<div className="flex-1 flex flex-col gap-2">
 				{/* TO */}
-				<div className={cn("bg-white rounded-sm flex flex-col shadow-sm", s.field)}>
-					<span className={cn("font-black text-black mb-0.5", s.labelText)}>TO</span>
-					<FitText className={cn("text-[#222]", s.valueText)}>
-						{`${card.recipient.firstName} ${card.recipient.lastName}`}
-					</FitText>
+				<div className={cn("bg-white rounded-sm flex items-center gap-2 shadow-sm", s.field)}>
+					<span className={cn("font-black text-black shrink-0", s.labelText)}>TO</span>
+					<PhysicalCardPerson
+						firstName={card.recipient.firstName}
+						lastName={card.recipient.lastName}
+						avatar={card.recipient.avatar}
+						avatarSize={s.avatarSize}
+						className="flex-1"
+						textClassName={s.valueText}
+					/>
 				</div>
 
 				{/* WHAT YOU DID */}

--- a/app/recognition/[id]/page.tsx
+++ b/app/recognition/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
 	BackgroundGraphic,
 } from "@/components/shared/access-logos";
 import { FitText } from "@/components/shared/fit-text";
+import { PhysicalCardPerson } from "@/components/shared/physical-card-person";
 import { getServerSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { getCardReactionSummary } from "@/lib/interactions";
@@ -29,6 +30,7 @@ const getCard = cache(async function getCard(id: string) {
 					id: true,
 					firstName: true,
 					lastName: true,
+					avatar: true,
 					position: true,
 					department: { select: { name: true } },
 				},
@@ -38,6 +40,7 @@ const getCard = cache(async function getCard(id: string) {
 					id: true,
 					firstName: true,
 					lastName: true,
+					avatar: true,
 					position: true,
 					department: { select: { name: true } },
 				},
@@ -227,9 +230,16 @@ export default async function SharePage({ params }: { params: Promise<{ id: stri
 
 			{/* Left Column */}
 			<div className="flex-1 flex flex-col gap-4">
-				<div className="bg-white p-3 md:p-4 rounded-sm flex flex-col min-h-20 shadow-sm">
-					<span className="text-xs font-black text-black mb-1">TO</span>
-					<FitText className="text-lg text-[#222]">{recipientName}</FitText>
+				<div className="bg-white p-3 md:p-4 rounded-sm flex items-center gap-3 min-h-20 shadow-sm">
+					<span className="text-xs font-black text-black shrink-0">TO</span>
+					<PhysicalCardPerson
+						firstName={card.recipient.firstName}
+						lastName={card.recipient.lastName}
+						avatar={card.recipient.avatar}
+						avatarSize="lg"
+						className="flex-1"
+						textClassName="text-lg"
+					/>
 				</div>
 
 				<div className="bg-white p-3 md:p-4 rounded-sm flex flex-col flex-grow min-h-[300px] shadow-sm relative">

--- a/components/shared/physical-card-person.test.tsx
+++ b/components/shared/physical-card-person.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { PhysicalCardPerson } from "./physical-card-person";
+
+class ResizeObserverMock {
+	observe() {}
+	disconnect() {}
+}
+
+beforeAll(() => {
+	Object.defineProperty(window, "ResizeObserver", {
+		writable: true,
+		configurable: true,
+		value: ResizeObserverMock,
+	});
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+describe("PhysicalCardPerson", () => {
+	it("renders the avatar image when an avatar URL is present", () => {
+		render(
+			<PhysicalCardPerson
+				firstName="Riley"
+				lastName="Recipient"
+				avatar="https://example.com/riley.png"
+			/>,
+		);
+
+		expect(screen.getByAltText("Riley Recipient")).toBeInTheDocument();
+		expect(screen.getByText("Riley Recipient")).toBeInTheDocument();
+	});
+
+	it("falls back to initials when the avatar is missing or fails to load", () => {
+		const { rerender } = render(<PhysicalCardPerson firstName="Riley" lastName="Recipient" />);
+
+		expect(screen.getByText("RR")).toBeInTheDocument();
+		expect(screen.getByText("Riley Recipient")).toBeInTheDocument();
+
+		rerender(
+			<PhysicalCardPerson
+				firstName="Riley"
+				lastName="Recipient"
+				avatar="https://example.com/riley.png"
+			/>,
+		);
+
+		fireEvent.error(screen.getByAltText("Riley Recipient"));
+
+		expect(screen.queryByAltText("Riley Recipient")).not.toBeInTheDocument();
+		expect(screen.getByText("RR")).toBeInTheDocument();
+	});
+});

--- a/components/shared/physical-card-person.tsx
+++ b/components/shared/physical-card-person.tsx
@@ -1,0 +1,38 @@
+import { FitText } from "@/components/shared/fit-text";
+import { type AvatarSize, UserAvatar } from "@/components/shared/user-avatar";
+import { cn } from "@/lib/utils";
+
+interface PhysicalCardPersonProps {
+	firstName: string;
+	lastName: string;
+	avatar?: string | null;
+	avatarSize?: AvatarSize;
+	className?: string;
+	textClassName?: string;
+	avatarClassName?: string;
+}
+
+export function PhysicalCardPerson({
+	firstName,
+	lastName,
+	avatar,
+	avatarSize = "md",
+	className,
+	textClassName,
+	avatarClassName,
+}: PhysicalCardPersonProps) {
+	return (
+		<div className={cn("flex items-center gap-2 min-w-0", className)}>
+			<UserAvatar
+				firstName={firstName}
+				lastName={lastName}
+				avatar={avatar}
+				size={avatarSize}
+				className={cn("border border-black/10 bg-[#333] text-white shadow-sm", avatarClassName)}
+			/>
+			<div className="min-w-0 flex-1">
+				<FitText className={cn("text-[#222]", textClassName)}>{`${firstName} ${lastName}`}</FitText>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- add recipient avatar treatment to read-only physical recognition cards in the feed and detail views
- keep sender fields plain text so only the recipient side is visually highlighted
- align the read-only physical card TO layout across feed, dashboard detail, and shared detail pages

## Scope
Closes #133
Follow-up for deferred preview/edit work: #134

## Testing
- bun run lint
- bun run build
