### PR TITLE
Fix recognition recipient input contrast in dark mode

### DIFF
--- a/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
@@ -199,7 +199,7 @@ function RecipientCombobox({
 								setIsDropdownOpen(true);
 							}}
 							onFocus={() => setIsDropdownOpen(true)}
-							className="w-full pl-5 outline-none text-lg bg-transparent placeholder:text-gray-400"
+							className="w-full pl-5 outline-none text-lg bg-transparent text-[#222] caret-[#222] placeholder:text-gray-400"
 							spellCheck="false"
 						/>
 						<ChevronDown size={14} className="absolute right-0 text-gray-400 pointer-events-none" />


### PR DESCRIPTION
## Summary
- keep the recognition recipient search text readable on the white card in dark mode
- set an explicit dark text and caret color on the shared recipient combobox input
- confirm the other editable fields in the recognition create/review flow already force readable text colors

Closes #136