### PR TITLE
Narrow desktop dashboard sidebar

### DIFF
--- a/components/shared/dashboard-sidebar.test.tsx
+++ b/components/shared/dashboard-sidebar.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+	signOut: vi.fn(),
+	useSession: vi.fn(),
+}));
+
+vi.mock("@/components/shared/access-logos", () => ({
+	AccessGroupLogo: (props: React.ComponentProps<"svg">) => (
+		<svg aria-label="Access Group" {...props} />
+	),
+}));
+
+vi.mock("@/components/shared/notification-badge", () => ({
+	NotificationBadge: () => <span data-testid="notification-badge">3</span>,
+}));
+
+import { usePathname, useRouter } from "next/navigation";
+import { useSession } from "@/lib/auth-client";
+import { DashboardSidebar } from "./dashboard-sidebar";
+
+const mockedUsePathname = vi.mocked(usePathname);
+const mockedUseRouter = vi.mocked(useRouter);
+const mockedUseSession = vi.mocked(useSession);
+
+function setRole(role: "STAFF" | "ADMIN" | "SUPERADMIN") {
+	mockedUseSession.mockReturnValue({
+		data: { user: { id: "user-1", role } },
+		isPending: false,
+		error: null,
+		refetch: vi.fn(),
+	} as unknown as ReturnType<typeof useSession>);
+}
+
+describe("DashboardSidebar", () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("keeps the desktop rail width and exposes full nav labels via title", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
+		mockedUseRouter.mockReturnValue({
+			push: vi.fn(),
+			refresh: vi.fn(),
+		} as unknown as ReturnType<typeof useRouter>);
+		setRole("STAFF");
+
+		const { container } = render(<DashboardSidebar helpMeEnabled />);
+
+		const aside = container.querySelector("aside");
+		expect(aside).toHaveClass("w-[13.5rem]");
+
+		const dashboardLink = screen.getByRole("link", { name: "Dashboard" });
+		expect(dashboardLink).toHaveAttribute("title", "Dashboard");
+		expect(dashboardLink.querySelector("svg")).toHaveClass("shrink-0");
+	});
+
+	it("keeps admin nav affordances from shrinking and titles truncated child labels", () => {
+		mockedUsePathname.mockReturnValue("/dashboard/admin-settings");
+		mockedUseRouter.mockReturnValue({
+			push: vi.fn(),
+			refresh: vi.fn(),
+		} as unknown as ReturnType<typeof useRouter>);
+		setRole("ADMIN");
+
+		render(<DashboardSidebar helpMeEnabled />);
+
+		const adminSettingsLink = screen.getByRole("link", { name: "Admin Settings" });
+		expect(adminSettingsLink).toHaveAttribute("title", "Admin Settings");
+
+		const icons = adminSettingsLink.querySelectorAll("svg");
+		expect(icons[0]).toHaveClass("shrink-0");
+		expect(icons[1]).toHaveClass("shrink-0");
+
+		const childLink = screen.getByRole("link", { name: "Activity Logs" });
+		expect(childLink).toHaveAttribute("title", "Activity Logs");
+	});
+});

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -151,12 +151,17 @@ function SidebarNav({ onNavigate, helpMeEnabled }: SidebarNavProps) {
 						? pathname === item.href
 						: pathname === item.href ||
 							(item.href !== "/dashboard" && pathname.startsWith(item.href));
+					const resolvedLabel =
+						roleLevel[userRole] >= roleLevel.ADMIN && item.adminLabel
+							? item.adminLabel
+							: item.label;
 
 					return (
 						<div key={item.href}>
 							<Link
 								href={item.href}
 								onClick={onNavigate}
+								title={resolvedLabel}
 								className={cn(
 									"flex w-full items-center gap-3 rounded-full px-4 py-3 text-sm font-medium transition-all duration-200",
 									isActive
@@ -164,18 +169,14 @@ function SidebarNav({ onNavigate, helpMeEnabled }: SidebarNavProps) {
 										: "text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5",
 								)}
 							>
-								<item.icon size={22} />
-								<span className="min-w-0 flex-1 truncate">
-									{roleLevel[userRole] >= roleLevel.ADMIN && item.adminLabel
-										? item.adminLabel
-										: item.label}
-								</span>
+								<item.icon size={22} className="shrink-0" />
+								<span className="min-w-0 flex-1 truncate">{resolvedLabel}</span>
 								{item.href === "/dashboard/recognition" && <NotificationBadge />}
 								{hasChildren && (
 									<ChevronDown
 										size={16}
 										className={cn(
-											"transition-transform duration-200",
+											"shrink-0 transition-transform duration-200",
 											isInGroup ? "rotate-0" : "-rotate-90",
 										)}
 									/>
@@ -192,6 +193,7 @@ function SidebarNav({ onNavigate, helpMeEnabled }: SidebarNavProps) {
 												key={child.href}
 												href={child.href}
 												onClick={onNavigate}
+												title={child.label}
 												className={cn(
 													"flex w-full items-center rounded-full px-4 py-2 text-sm font-medium transition-all duration-200",
 													childActive
@@ -215,7 +217,7 @@ function SidebarNav({ onNavigate, helpMeEnabled }: SidebarNavProps) {
 				onClick={handleSignOut}
 				className="flex w-full items-center gap-3 rounded-full px-4 py-3 text-sm font-medium text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5 transition-colors"
 			>
-				<LogOut size={22} />
+				<LogOut size={22} className="shrink-0" />
 				Sign Out
 			</button>
 

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -35,7 +35,7 @@ interface NavItem {
 	label: string;
 	adminLabel?: string;
 	href: string;
-	icon: React.ComponentType<{ size?: number }>;
+	icon: React.ComponentType<{ size?: number; className?: string }>;
 	minRole: MinRole;
 	children?: NavChild[];
 }

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -165,7 +165,7 @@ function SidebarNav({ onNavigate, helpMeEnabled }: SidebarNavProps) {
 								)}
 							>
 								<item.icon size={22} />
-								<span className="flex-1">
+								<span className="min-w-0 flex-1 truncate">
 									{roleLevel[userRole] >= roleLevel.ADMIN && item.adminLabel
 										? item.adminLabel
 										: item.label}
@@ -199,7 +199,7 @@ function SidebarNav({ onNavigate, helpMeEnabled }: SidebarNavProps) {
 														: "text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5",
 												)}
 											>
-												{child.label}
+												<span className="block min-w-0 truncate">{child.label}</span>
 											</Link>
 										);
 									})}
@@ -230,7 +230,7 @@ function SidebarNav({ onNavigate, helpMeEnabled }: SidebarNavProps) {
 
 export function DashboardSidebar({ helpMeEnabled }: { helpMeEnabled: boolean }) {
 	return (
-		<aside className="hidden w-72 sticky top-0 h-screen flex-col p-4 pr-2 md:flex">
+		<aside className="sticky top-0 hidden h-screen w-[13.5rem] flex-col p-4 pr-2 md:flex">
 			<SidebarNav helpMeEnabled={helpMeEnabled} />
 		</aside>
 	);

--- a/components/shared/notification-badge.tsx
+++ b/components/shared/notification-badge.tsx
@@ -8,7 +8,7 @@ export function NotificationBadge() {
 	if (unreadCount === 0) return null;
 
 	return (
-		<span className="ml-auto flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[11px] font-medium text-primary-foreground tabular-nums">
+		<span className="ml-auto shrink-0 flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[11px] font-medium text-primary-foreground tabular-nums">
 			{unreadCount > 9 ? "9+" : unreadCount}
 		</span>
 	);


### PR DESCRIPTION
## Summary
- reduce the desktop dashboard sidebar width
- truncate primary and child nav labels to prevent overflow in the narrower layout

## Testing
- not run