### PR TITLE
fix: prevent sidebar nav flicker on reload

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -10,12 +10,13 @@ export default async function DashboardLayout({ children }: { children: React.Re
 	if (!session) redirect("/login");
 
 	const helpMeEnabled = await getHelpMeEnabled();
+	const initialUserRole = session.user.role as "STAFF" | "ADMIN" | "SUPERADMIN";
 
 	return (
 		<div className="flex min-h-screen bg-background">
-			<DashboardSidebar helpMeEnabled={helpMeEnabled} />
+			<DashboardSidebar helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 			<div className="flex flex-1 flex-col bg-card sm:my-2 sm:mr-2 sm:rounded-l-[2rem] shadow-sm border border-gray-100 dark:border-white/5">
-				<DashboardHeader helpMeEnabled={helpMeEnabled} />
+				<DashboardHeader helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 				<main className="flex-1 px-4 pb-8 sm:px-8">{children}</main>
 			</div>
 			<HelpFab enabled={helpMeEnabled} />

--- a/components/shared/dashboard-header.tsx
+++ b/components/shared/dashboard-header.tsx
@@ -16,7 +16,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { signOut, useSession } from "@/lib/auth-client";
 
-export function DashboardHeader({ helpMeEnabled }: { helpMeEnabled: boolean }) {
+export function DashboardHeader({
+	helpMeEnabled,
+	initialUserRole,
+}: {
+	helpMeEnabled: boolean;
+	initialUserRole: "STAFF" | "ADMIN" | "SUPERADMIN";
+}) {
 	const router = useRouter();
 	const { data: session } = useSession();
 	const user = session?.user;
@@ -34,7 +40,10 @@ export function DashboardHeader({ helpMeEnabled }: { helpMeEnabled: boolean }) {
 	return (
 		<header className="sticky top-0 z-10 flex h-20 items-center justify-between bg-card px-4 sm:px-8">
 			<div className="flex items-center md:hidden">
-				<MobileSidebarTrigger helpMeEnabled={helpMeEnabled} />
+				<MobileSidebarTrigger
+					helpMeEnabled={helpMeEnabled}
+					initialUserRole={initialUserRole}
+				/>
 			</div>
 
 			<div className="flex-1 md:flex-none" />

--- a/components/shared/dashboard-header.tsx
+++ b/components/shared/dashboard-header.tsx
@@ -40,10 +40,7 @@ export function DashboardHeader({
 	return (
 		<header className="sticky top-0 z-10 flex h-20 items-center justify-between bg-card px-4 sm:px-8">
 			<div className="flex items-center md:hidden">
-				<MobileSidebarTrigger
-					helpMeEnabled={helpMeEnabled}
-					initialUserRole={initialUserRole}
-				/>
+				<MobileSidebarTrigger helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 			</div>
 
 			<div className="flex-1 md:flex-none" />

--- a/components/shared/dashboard-sidebar.test.tsx
+++ b/components/shared/dashboard-sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
@@ -21,18 +21,31 @@ vi.mock("@/components/shared/notification-badge", () => ({
 	NotificationBadge: () => <span data-testid="notification-badge">3</span>,
 }));
 
+vi.mock("@/components/ui/sheet", () => ({
+	Sheet: ({ open, children }: { open: boolean; children: React.ReactNode }) => (
+		<>{open ? children : null}</>
+	),
+	SheetContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
 import { usePathname, useRouter } from "next/navigation";
 import { useSession } from "@/lib/auth-client";
-import { DashboardSidebar } from "./dashboard-sidebar";
+import { DashboardSidebar, MobileSidebarTrigger } from "./dashboard-sidebar";
 
 const mockedUsePathname = vi.mocked(usePathname);
 const mockedUseRouter = vi.mocked(useRouter);
 const mockedUseSession = vi.mocked(useSession);
 
-function setRole(role: "STAFF" | "ADMIN" | "SUPERADMIN") {
+function setSession({
+	role,
+	isPending = false,
+}: {
+	role?: "STAFF" | "ADMIN" | "SUPERADMIN";
+	isPending?: boolean;
+}) {
 	mockedUseSession.mockReturnValue({
-		data: { user: { id: "user-1", role } },
-		isPending: false,
+		data: role ? { user: { id: "user-1", role } } : null,
+		isPending,
 		error: null,
 		refetch: vi.fn(),
 	} as unknown as ReturnType<typeof useSession>);
@@ -50,9 +63,9 @@ describe("DashboardSidebar", () => {
 			push: vi.fn(),
 			refresh: vi.fn(),
 		} as unknown as ReturnType<typeof useRouter>);
-		setRole("STAFF");
+		setSession({ role: "STAFF" });
 
-		const { container } = render(<DashboardSidebar helpMeEnabled />);
+		const { container } = render(<DashboardSidebar helpMeEnabled initialUserRole="STAFF" />);
 
 		const aside = container.querySelector("aside");
 		expect(aside).toHaveClass("w-[13.5rem]");
@@ -68,9 +81,9 @@ describe("DashboardSidebar", () => {
 			push: vi.fn(),
 			refresh: vi.fn(),
 		} as unknown as ReturnType<typeof useRouter>);
-		setRole("ADMIN");
+		setSession({ role: "ADMIN" });
 
-		render(<DashboardSidebar helpMeEnabled />);
+		render(<DashboardSidebar helpMeEnabled initialUserRole="ADMIN" />);
 
 		const adminSettingsLink = screen.getByRole("link", { name: "Admin Settings" });
 		expect(adminSettingsLink).toHaveAttribute("title", "Admin Settings");
@@ -81,5 +94,47 @@ describe("DashboardSidebar", () => {
 
 		const childLink = screen.getByRole("link", { name: "Activity Logs" });
 		expect(childLink).toHaveAttribute("title", "Activity Logs");
+	});
+
+	it("uses the server role while the client session is still pending", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
+		mockedUseRouter.mockReturnValue({
+			push: vi.fn(),
+			refresh: vi.fn(),
+		} as unknown as ReturnType<typeof useRouter>);
+		setSession({ isPending: true });
+
+		render(<DashboardSidebar helpMeEnabled initialUserRole="ADMIN" />);
+
+		expect(screen.getByRole("link", { name: "Staff" })).toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: "Super Admin" })).not.toBeInTheDocument();
+	});
+
+	it("downgrades to staff links after hydration when the client session has no user", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
+		mockedUseRouter.mockReturnValue({
+			push: vi.fn(),
+			refresh: vi.fn(),
+		} as unknown as ReturnType<typeof useRouter>);
+		setSession({ isPending: false });
+
+		render(<DashboardSidebar helpMeEnabled initialUserRole="ADMIN" />);
+
+		expect(screen.queryByRole("link", { name: "Staff" })).not.toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Dashboard" })).toBeInTheDocument();
+	});
+
+	it("uses the same pending fallback role in the mobile sidebar", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
+		mockedUseRouter.mockReturnValue({
+			push: vi.fn(),
+			refresh: vi.fn(),
+		} as unknown as ReturnType<typeof useRouter>);
+		setSession({ isPending: true });
+
+		render(<MobileSidebarTrigger helpMeEnabled initialUserRole="ADMIN" />);
+		fireEvent.click(screen.getByRole("button"));
+
+		expect(screen.getByRole("link", { name: "Staff" })).toBeInTheDocument();
 	});
 });

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -107,13 +107,14 @@ const NAV_ITEMS: NavItem[] = [
 interface SidebarNavProps {
 	onNavigate?: () => void;
 	helpMeEnabled: boolean;
+	initialUserRole: MinRole;
 }
 
-function SidebarNav({ onNavigate, helpMeEnabled }: SidebarNavProps) {
+function SidebarNav({ onNavigate, helpMeEnabled, initialUserRole }: SidebarNavProps) {
 	const pathname = usePathname();
 	const router = useRouter();
 	const { data: session } = useSession();
-	const userRole = ((session?.user?.role as string) ?? "STAFF") as MinRole;
+	const userRole = ((session?.user?.role as string) ?? initialUserRole) as MinRole;
 
 	const roleLevel: Record<MinRole, number> = {
 		STAFF: 0,
@@ -230,15 +231,27 @@ function SidebarNav({ onNavigate, helpMeEnabled }: SidebarNavProps) {
 	);
 }
 
-export function DashboardSidebar({ helpMeEnabled }: { helpMeEnabled: boolean }) {
+export function DashboardSidebar({
+	helpMeEnabled,
+	initialUserRole,
+}: {
+	helpMeEnabled: boolean;
+	initialUserRole: MinRole;
+}) {
 	return (
-		<aside className="sticky top-0 hidden h-screen w-[13.5rem] flex-col p-4 pr-2 md:flex">
-			<SidebarNav helpMeEnabled={helpMeEnabled} />
+		<aside className="hidden w-72 sticky top-0 h-screen flex-col p-4 pr-2 md:flex">
+			<SidebarNav helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 		</aside>
 	);
 }
 
-export function MobileSidebarTrigger({ helpMeEnabled }: { helpMeEnabled: boolean }) {
+export function MobileSidebarTrigger({
+	helpMeEnabled,
+	initialUserRole,
+}: {
+	helpMeEnabled: boolean;
+	initialUserRole: MinRole;
+}) {
 	const [open, setOpen] = useState(false);
 
 	return (
@@ -252,7 +265,11 @@ export function MobileSidebarTrigger({ helpMeEnabled }: { helpMeEnabled: boolean
 			</button>
 			<Sheet open={open} onOpenChange={setOpen}>
 				<SheetContent side="left" className="w-72 p-4" showCloseButton={false}>
-					<SidebarNav onNavigate={() => setOpen(false)} helpMeEnabled={helpMeEnabled} />
+					<SidebarNav
+						onNavigate={() => setOpen(false)}
+						helpMeEnabled={helpMeEnabled}
+						initialUserRole={initialUserRole}
+					/>
 				</SheetContent>
 			</Sheet>
 		</>

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -113,8 +113,9 @@ interface SidebarNavProps {
 function SidebarNav({ onNavigate, helpMeEnabled, initialUserRole }: SidebarNavProps) {
 	const pathname = usePathname();
 	const router = useRouter();
-	const { data: session } = useSession();
-	const userRole = ((session?.user?.role as string) ?? initialUserRole) as MinRole;
+	const { data: session, isPending } = useSession();
+	const sessionRole = session?.user?.role as string | undefined;
+	const userRole = (sessionRole ?? (isPending ? initialUserRole : "STAFF")) as MinRole;
 
 	const roleLevel: Record<MinRole, number> = {
 		STAFF: 0,
@@ -239,7 +240,7 @@ export function DashboardSidebar({
 	initialUserRole: MinRole;
 }) {
 	return (
-		<aside className="hidden w-72 sticky top-0 h-screen flex-col p-4 pr-2 md:flex">
+		<aside className="sticky top-0 hidden h-screen w-[13.5rem] flex-col p-4 pr-2 md:flex">
 			<SidebarNav helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 		</aside>
 	);


### PR DESCRIPTION
## Summary
- pass the server-known user role from the dashboard layout into the header and sidebar
- use that role as the initial fallback before useSession() hydrates
- keep desktop and mobile sidebar role gating consistent on first render

## Testing
- bun x tsc --noEmit

Closes #141
