### PR TITLE
Phase 1: improve mobile dashboard layout

### DIFF
--- a/app/(dashboard)/dashboard/admin-settings/_components/helpme-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/helpme-visibility.tsx
@@ -39,8 +39,8 @@ export function HelpMeVisibilityPanel({ initialEnabled }: HelpMeVisibilityPanelP
 	}
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-			<div className="px-8 pt-8 pb-2">
+		<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+			<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
 					Help Me Module
 				</h3>
@@ -49,8 +49,8 @@ export function HelpMeVisibilityPanel({ initialEnabled }: HelpMeVisibilityPanelP
 				</p>
 			</div>
 
-			<div className="px-8 py-6">
-				<div className="flex items-center justify-between rounded-2xl border border-gray-200 dark:border-white/10 p-5 gap-4">
+			<div className="px-5 py-6 sm:px-8">
+				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
 					<div className="min-w-0">
 						<p className="text-sm font-medium text-foreground">Enable Help Me</p>
 						<p className="text-xs text-muted-foreground">

--- a/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
@@ -106,8 +106,8 @@ export function LeaderboardVisibilityPanel({
 	}
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-			<div className="px-8 pt-8 pb-2">
+		<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+			<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
 					Leaderboard Visibility
 				</h3>
@@ -118,8 +118,8 @@ export function LeaderboardVisibilityPanel({
 				</p>
 			</div>
 
-			<div className="px-8 py-6 space-y-4">
-				<div className="flex items-center justify-between rounded-2xl border border-gray-200 dark:border-white/10 p-5 gap-4">
+			<div className="space-y-4 px-5 py-6 sm:px-8">
+				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
 					<div className="min-w-0">
 						<p className="text-sm font-medium text-foreground">Visibility mode</p>
 						<p className="text-xs text-muted-foreground">{MODE_DESCRIPTIONS[mode]}</p>
@@ -129,7 +129,7 @@ export function LeaderboardVisibilityPanel({
 						onValueChange={(val) => handleModeChange(val as LeaderboardVisibilityMode)}
 						disabled={isPending}
 					>
-						<SelectTrigger className="w-56 shrink-0">
+						<SelectTrigger className="w-full shrink-0 rounded-full sm:w-56">
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>
@@ -143,7 +143,7 @@ export function LeaderboardVisibilityPanel({
 				</div>
 
 				{mode === "last_n_days_of_month" && (
-					<div className="flex items-center justify-between rounded-2xl border border-gray-200 dark:border-white/10 p-5 gap-4">
+					<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
 						<div className="min-w-0">
 							<p className="text-sm font-medium text-foreground">Reveal days</p>
 							<p className="text-xs text-muted-foreground">
@@ -158,14 +158,14 @@ export function LeaderboardVisibilityPanel({
 							onChange={(e) => setDays(Number.parseInt(e.target.value, 10))}
 							onBlur={handleDaysBlur}
 							disabled={isPending}
-							className="w-24 shrink-0"
+							className="w-full shrink-0 sm:w-24"
 						/>
 					</div>
 				)}
 
 				{mode === "custom_range" && (
-					<div className="rounded-2xl border border-gray-200 dark:border-white/10 p-5 space-y-4">
-						<div className="flex items-center justify-between gap-4">
+					<div className="space-y-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:p-5">
+						<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
 							<div>
 								<Label
 									htmlFor="leaderboard-custom-start"
@@ -182,10 +182,10 @@ export function LeaderboardVisibilityPanel({
 								onChange={(e) => setCustomStart(e.target.value)}
 								onBlur={handleCustomStartBlur}
 								disabled={isPending}
-								className="w-48 shrink-0"
+								className="w-full shrink-0 sm:w-48"
 							/>
 						</div>
-						<div className="flex items-center justify-between gap-4">
+						<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
 							<div>
 								<Label
 									htmlFor="leaderboard-custom-end"
@@ -202,7 +202,7 @@ export function LeaderboardVisibilityPanel({
 								onChange={(e) => setCustomEnd(e.target.value)}
 								onBlur={handleCustomEndBlur}
 								disabled={isPending}
-								className="w-48 shrink-0"
+								className="w-full shrink-0 sm:w-48"
 							/>
 						</div>
 					</div>

--- a/app/(dashboard)/dashboard/admin-settings/_components/recognition-settings.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/recognition-settings.tsx
@@ -41,8 +41,8 @@ export function RecognitionSettingsPanel({ initialLimit }: { initialLimit: numbe
 	}
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-			<div className="px-8 pt-8 pb-2">
+		<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+			<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
 					Recognition Settings
 				</h3>
@@ -51,9 +51,9 @@ export function RecognitionSettingsPanel({ initialLimit }: { initialLimit: numbe
 				</p>
 			</div>
 
-			<div className="px-8 py-6">
-				<div className="flex items-center justify-between rounded-2xl border border-gray-200 dark:border-white/10 p-5">
-					<div>
+			<div className="px-5 py-6 sm:px-8">
+				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+					<div className="min-w-0">
 						<p className="text-sm font-medium text-foreground">Most Recognized Limit</p>
 						<p className="text-xs text-muted-foreground">
 							Number of top recipients shown in the dashboard stats widget.
@@ -67,7 +67,7 @@ export function RecognitionSettingsPanel({ initialLimit }: { initialLimit: numbe
 						}}
 						disabled={isPending}
 					>
-						<SelectTrigger className="w-20">
+						<SelectTrigger className="w-full rounded-full sm:w-20">
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/loading.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/loading.tsx
@@ -11,15 +11,17 @@ import {
 export default function ActivityLogsLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-8 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse sm:space-y-8"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading activity logs"
 		>
-			{/* Page header */}
-			<div className="space-y-3">
-				<SkeletonLine className="h-10 w-48" />
-				<SkeletonLine className="h-5 w-96" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="space-y-3">
+					<SkeletonLine className="h-3 w-28" />
+					<SkeletonLine className="h-10 w-48" />
+					<SkeletonLine className="h-5 w-96" />
+				</div>
 			</div>
 
 			{/* Filters panel */}

--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import type { ActivityAction, Prisma } from "@/app/generated/prisma/client";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { pruneActivityLogsIfNeeded } from "@/lib/activity-log";
 import { requireRole } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
@@ -107,15 +108,12 @@ export default async function ActivityLogsPage({
 	});
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
-			<div>
-				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-					Activity Logs
-				</h1>
-				<p className="mt-2 text-base text-muted-foreground">
-					Audit trail of authentication and account events.
-				</p>
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+			<DashboardPageHeader
+				eyebrow="Administration"
+				title="Activity Logs"
+				description="Audit trail of authentication and account events."
+			/>
 
 			<ActivityLogFilters
 				users={users}

--- a/app/(dashboard)/dashboard/admin-settings/loading.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/loading.tsx
@@ -40,14 +40,17 @@ function SettingsPanelSkeleton({
 export default function AdminSettingsLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-8 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse sm:space-y-8"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading admin settings"
 		>
-			<div className="space-y-3">
-				<SkeletonLine className="h-10 w-52" />
-				<SkeletonLine className="h-5 w-80" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="space-y-3">
+					<SkeletonLine className="h-3 w-28" />
+					<SkeletonLine className="h-10 w-52" />
+					<SkeletonLine className="h-5 w-80" />
+				</div>
 			</div>
 
 			{/* Recognition Settings */}

--- a/app/(dashboard)/dashboard/admin-settings/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import {
 	getHelpMeEnabled,
 	getLeaderboardVisibilitySettings,
@@ -23,15 +24,12 @@ export default async function AdminSettingsPage() {
 	]);
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
-			<div>
-				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-					Admin Settings
-				</h1>
-				<p className="mt-2 text-base text-muted-foreground">
-					Manage application settings and configurations.
-				</p>
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+			<DashboardPageHeader
+				eyebrow="Administration"
+				title="Admin Settings"
+				description="Manage application settings and configurations."
+			/>
 
 			<RecognitionSettingsPanel initialLimit={topLimit} />
 

--- a/app/(dashboard)/dashboard/departments/_components/departments-client.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/departments-client.tsx
@@ -2,6 +2,7 @@
 
 import { Plus } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primitives";
 import { getDepartmentsAction } from "@/lib/actions/department-actions";
 import { DepartmentFormDialog } from "./department-form";
@@ -33,25 +34,22 @@ export function DepartmentsClient() {
 	}, [loadDepartments]);
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
-			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-				<div>
-					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-						Departments
-					</h1>
-					<p className="mt-2 text-base text-muted-foreground">
-						Manage organizational departments and team structure.
-					</p>
-				</div>
-				<button
-					type="button"
-					onClick={() => setShowCreate(true)}
-					className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-				>
-					<Plus className="-ml-1 h-5 w-5" />
-					Add Department
-				</button>
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+			<DashboardPageHeader
+				eyebrow="Operations"
+				title="Departments"
+				description="Manage organizational departments and team structure."
+				actions={
+					<button
+						type="button"
+						onClick={() => setShowCreate(true)}
+						className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm transition-all duration-200 hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30"
+					>
+						<Plus className="-ml-1 h-5 w-5" />
+						Add Department
+					</button>
+				}
+			/>
 
 			{isLoading ? (
 				<SkeletonCard

--- a/app/(dashboard)/dashboard/departments/loading.tsx
+++ b/app/(dashboard)/dashboard/departments/loading.tsx
@@ -3,18 +3,20 @@ import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primiti
 export default function DepartmentsLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-8 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse sm:space-y-8"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading departments"
 		>
-			{/* Page header + Add button */}
-			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-				<div className="space-y-3">
-					<SkeletonLine className="h-10 w-48" />
-					<SkeletonLine className="h-5 w-80" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="flex flex-col gap-5 sm:gap-6 lg:flex-row lg:items-end lg:justify-between">
+					<div className="space-y-3">
+						<SkeletonLine className="h-3 w-24" />
+						<SkeletonLine className="h-10 w-48" />
+						<SkeletonLine className="h-5 w-80" />
+					</div>
+					<SkeletonLine className="h-12 w-48 rounded-full" />
 				</div>
-				<SkeletonLine className="h-12 w-48 rounded-full" />
 			</div>
 
 			{/* Department table */}

--- a/app/(dashboard)/dashboard/helpme/[id]/loading.tsx
+++ b/app/(dashboard)/dashboard/helpme/[id]/loading.tsx
@@ -3,26 +3,28 @@ import { SkeletonLine } from "@/components/shared/skeleton-primitives";
 export default function TicketDetailLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-6 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading ticket"
 		>
-			<SkeletonLine className="h-4 w-32" />
+			<SkeletonLine className="h-10 w-36 rounded-full" />
+
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="space-y-3">
+					<SkeletonLine className="h-3 w-20" />
+					<SkeletonLine className="h-10 w-80 max-w-full" />
+					<SkeletonLine className="h-4 w-64" />
+				</div>
+				<div className="mt-3 flex items-center gap-2">
+					<SkeletonLine className="h-5 w-16 rounded-full" />
+					<SkeletonLine className="h-5 w-20 rounded-full" />
+				</div>
+			</div>
 
 			<div className="max-w-4xl space-y-6">
 				{/* Ticket header card */}
-				<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-8 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] space-y-5">
-					<div className="flex flex-wrap items-start justify-between gap-3">
-						<div className="space-y-2 flex-1 min-w-0">
-							<SkeletonLine className="h-7 w-80 max-w-full" />
-							<SkeletonLine className="h-4 w-64" />
-						</div>
-						<div className="flex items-center gap-2">
-							<SkeletonLine className="h-5 w-16 rounded-full" />
-							<SkeletonLine className="h-5 w-20 rounded-full" />
-						</div>
-					</div>
+				<div className="space-y-5 rounded-[2rem] border border-gray-200/60 bg-card p-8 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] dark:border-white/10">
 					<div className="space-y-2">
 						<SkeletonLine className="h-4 w-full" />
 						<SkeletonLine className="h-4 w-5/6" />
@@ -36,7 +38,7 @@ export default function TicketDetailLoading() {
 					{["r0", "r1"].map((key) => (
 						<div
 							key={key}
-							className="rounded-[1.5rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] space-y-3"
+							className="space-y-3 rounded-[1.5rem] border border-gray-200/60 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] dark:border-white/10"
 						>
 							<div className="flex items-center gap-3">
 								<SkeletonLine className="h-10 w-10 rounded-full shrink-0" />
@@ -54,7 +56,7 @@ export default function TicketDetailLoading() {
 				</div>
 
 				{/* Reply form */}
-				<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] space-y-4">
+				<div className="space-y-4 rounded-[2rem] border border-gray-200/60 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] dark:border-white/10">
 					<SkeletonLine className="h-4 w-32" />
 					<SkeletonLine className="h-32 w-full rounded-xl" />
 					<div className="flex justify-end">

--- a/app/(dashboard)/dashboard/helpme/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/[id]/page.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import type { Role } from "@/app/generated/prisma/client";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { Badge } from "@/components/ui/badge";
 import { getTicketByIdForCurrentUser } from "@/lib/actions/helpme-actions";
 import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
@@ -59,35 +60,32 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
 	const creatorDisplay = displayReplyAuthor(ticket.createdBy, viewerRole);
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-6 mt-2">
+		<div className="mx-auto max-w-7xl space-y-6">
 			<Link
 				href="/dashboard/helpme"
-				className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+				className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-gray-200/50 hover:text-foreground dark:hover:bg-white/5"
 			>
 				<ArrowLeft size={16} /> Back to tickets
 			</Link>
 
-			<div className="max-w-4xl space-y-6">
-				<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-8 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] space-y-5">
-					<div className="flex flex-wrap items-start justify-between gap-3">
-						<div>
-							<h1 className="text-[1.5rem] font-medium leading-tight text-foreground tracking-tight">
-								{ticket.subject}
-							</h1>
-							<p className="text-sm text-muted-foreground mt-1.5">
-								Raised by {creatorDisplay.displayName} · {formatDateTime(ticket.createdAt)}
-							</p>
-						</div>
-						<div className="flex items-center gap-2">
-							<span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs font-medium text-primary dark:bg-primary/10">
-								{CATEGORY_LABEL[ticket.category]}
-							</span>
-							<Badge variant="secondary" className={STATUS_STYLES[ticket.status]}>
-								{STATUS_LABEL[ticket.status]}
-							</Badge>
-						</div>
-					</div>
+			<DashboardPageHeader
+				eyebrow="Support"
+				title={ticket.subject}
+				description={`Raised by ${creatorDisplay.displayName} · ${formatDateTime(ticket.createdAt)}`}
+				meta={
+					<>
+						<span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-xs font-medium text-primary dark:bg-primary/10">
+							{CATEGORY_LABEL[ticket.category]}
+						</span>
+						<Badge variant="secondary" className={STATUS_STYLES[ticket.status]}>
+							{STATUS_LABEL[ticket.status]}
+						</Badge>
+					</>
+				}
+			/>
 
+			<div className="max-w-4xl space-y-6">
+				<div className="space-y-5 rounded-[2rem] border border-gray-200/60 bg-card p-8 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] dark:border-white/10">
 					<div
 						className="prose prose-sm dark:prose-invert max-w-none text-foreground/90"
 						// biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized here on read to protect against any pre-rich-text legacy rows
@@ -117,11 +115,11 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
 				</div>
 
 				{ticket.status === "CLOSED" ? (
-					<div className="rounded-[2rem] border border-dashed border-gray-200 dark:border-white/10 bg-card/50 p-6 text-center text-sm text-muted-foreground">
+					<div className="rounded-[2rem] border border-dashed border-gray-200 bg-card/50 p-6 text-center text-sm text-muted-foreground dark:border-white/10">
 						This ticket is closed. Create a new ticket if you need further help.
 					</div>
 				) : (
-					<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+					<div className="rounded-[2rem] border border-gray-200/60 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] dark:border-white/10">
 						<ReplyForm ticketId={ticket.id} />
 					</div>
 				)}

--- a/app/(dashboard)/dashboard/helpme/loading.tsx
+++ b/app/(dashboard)/dashboard/helpme/loading.tsx
@@ -11,18 +11,20 @@ import {
 export default function HelpMeLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-6 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading Help Me tickets"
 		>
-			{/* Page header + Add button */}
-			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-				<div className="space-y-3">
-					<SkeletonLine className="h-10 w-48" />
-					<SkeletonLine className="h-5 w-80" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="flex flex-col gap-5 sm:gap-6 lg:flex-row lg:items-end lg:justify-between">
+					<div className="space-y-3">
+						<SkeletonLine className="h-3 w-20" />
+						<SkeletonLine className="h-10 w-48" />
+						<SkeletonLine className="h-5 w-80" />
+					</div>
+					<SkeletonLine className="h-12 w-40 rounded-full" />
 				</div>
-				<SkeletonLine className="h-12 w-40 rounded-full" />
 			</div>
 
 			{/* Tickets table */}

--- a/app/(dashboard)/dashboard/helpme/new/loading.tsx
+++ b/app/(dashboard)/dashboard/helpme/new/loading.tsx
@@ -3,18 +3,20 @@ import { SkeletonLine } from "@/components/shared/skeleton-primitives";
 export default function NewTicketLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-6 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading new ticket form"
 		>
 			{/* Back link */}
-			<SkeletonLine className="h-4 w-32" />
+			<SkeletonLine className="h-10 w-36 rounded-full" />
 
-			{/* Page header */}
-			<div className="space-y-3">
-				<SkeletonLine className="h-10 w-56" />
-				<SkeletonLine className="h-5 w-96" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="space-y-3">
+					<SkeletonLine className="h-3 w-20" />
+					<SkeletonLine className="h-10 w-56" />
+					<SkeletonLine className="h-5 w-96" />
+				</div>
 			</div>
 
 			{/* Form card */}

--- a/app/(dashboard)/dashboard/helpme/new/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/new/page.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
 import { TicketForm } from "../_components/ticket-form";
@@ -12,22 +13,19 @@ export default async function NewTicketPage() {
 	if (!(await getHelpMeEnabled())) notFound();
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-6 mt-2">
+		<div className="mx-auto max-w-7xl space-y-6">
 			<Link
 				href="/dashboard/helpme"
-				className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+				className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-gray-200/50 hover:text-foreground dark:hover:bg-white/5"
 			>
 				<ArrowLeft size={16} /> Back to tickets
 			</Link>
 
-			<div>
-				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-					Raise a Ticket
-				</h1>
-				<p className="mt-2 text-base text-muted-foreground">
-					Describe your issue and the right team will respond as soon as possible.
-				</p>
-			</div>
+			<DashboardPageHeader
+				eyebrow="Support"
+				title="Raise a Ticket"
+				description="Describe your issue and the right team will respond as soon as possible."
+			/>
 
 			<div className="max-w-3xl">
 				<TicketForm />

--- a/app/(dashboard)/dashboard/helpme/page.tsx
+++ b/app/(dashboard)/dashboard/helpme/page.tsx
@@ -1,6 +1,7 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { listTicketsForCurrentUser } from "@/lib/actions/helpme-actions";
 import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
@@ -15,26 +16,25 @@ export default async function HelpMePage() {
 	const { tickets, isAdmin } = await listTicketsForCurrentUser();
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-6 mt-2">
-			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-				<div>
-					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-						{isAdmin ? "Help Me Tickets" : "My Tickets"}
-					</h1>
-					<p className="mt-2 text-base text-muted-foreground">
-						{isAdmin
-							? "Respond to tickets raised by staff."
-							: "Raise an issue or request help from HR/IT."}
-					</p>
-				</div>
-				<Link
-					href="/dashboard/helpme/new"
-					className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-				>
-					<Plus className="-ml-1 h-5 w-5" />
-					New Ticket
-				</Link>
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6">
+			<DashboardPageHeader
+				eyebrow="Support"
+				title={isAdmin ? "Help Me Tickets" : "My Tickets"}
+				description={
+					isAdmin
+						? "Respond to tickets raised by staff."
+						: "Raise an issue or request help from HR/IT."
+				}
+				actions={
+					<Link
+						href="/dashboard/helpme/new"
+						className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm transition-all duration-200 hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30"
+					>
+						<Plus className="-ml-1 h-5 w-5" />
+						New Ticket
+					</Link>
+				}
+			/>
 
 			<TicketList tickets={tickets} isAdmin={isAdmin} />
 		</div>

--- a/app/(dashboard)/dashboard/leaderboard/_components/month-picker.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/_components/month-picker.tsx
@@ -34,7 +34,7 @@ export function MonthPicker({ items, selected }: MonthPickerProps) {
 
 	return (
 		<Select value={selected} onValueChange={handleChange} disabled={isPending}>
-			<SelectTrigger className="w-64">
+			<SelectTrigger className="w-full rounded-full bg-card sm:w-64">
 				<SelectValue />
 			</SelectTrigger>
 			<SelectContent>

--- a/app/(dashboard)/dashboard/leaderboard/loading.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/loading.tsx
@@ -3,21 +3,23 @@ import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primiti
 export default function LeaderboardLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto mt-2 space-y-8 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse sm:space-y-8"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading leaderboard"
 		>
-			{/* Page header */}
-			<div className="space-y-3">
-				<SkeletonLine className="h-10 w-60" />
-				<SkeletonLine className="h-5 w-80" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="space-y-3">
+					<SkeletonLine className="h-3 w-24" />
+					<SkeletonLine className="h-10 w-60" />
+					<SkeletonLine className="h-5 w-80" />
+				</div>
 			</div>
 
 			{/* Month picker row */}
-			<div className="flex flex-wrap items-center gap-3">
-				<SkeletonLine className="h-4 w-16" />
-				<SkeletonLine className="h-9 w-44 rounded-md" />
+			<div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-3">
+				<SkeletonLine className="h-3 w-16" />
+				<SkeletonLine className="h-10 w-full rounded-full sm:w-44" />
 			</div>
 
 			{/* Podium panel */}

--- a/app/(dashboard)/dashboard/leaderboard/page.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import {
 	getLeaderboardVisibilitySettings,
 	getTopRecognizedLimit,
@@ -22,14 +23,11 @@ interface PageProps {
 
 function PageHeader() {
 	return (
-		<div>
-			<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-				Leaderboard
-			</h1>
-			<p className="mt-2 text-base text-muted-foreground">
-				Most Recognized rankings, preserved month by month.
-			</p>
-		</div>
+		<DashboardPageHeader
+			eyebrow="Recognition"
+			title="Leaderboard"
+			description="Most Recognized rankings, preserved month by month."
+		/>
 	);
 }
 
@@ -70,7 +68,7 @@ export default async function LeaderboardHistoryPage({ searchParams }: PageProps
 	// the first archive exists.
 	if (selectableKeys.length === 0 && !requested) {
 		return (
-			<div className="max-w-7xl mx-auto mt-2 space-y-8">
+			<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
 				<PageHeader />
 				<div className="rounded-[2rem] border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-8 py-16 text-center">
 					<p className="text-base font-medium text-foreground">No leaderboards to show yet</p>
@@ -102,10 +100,12 @@ export default async function LeaderboardHistoryPage({ searchParams }: PageProps
 	const data = await getMonthLeaderboard(selectedKey, now, topLimit);
 
 	return (
-		<div className="max-w-7xl mx-auto mt-2 space-y-8">
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
 			<PageHeader />
-			<div className="flex flex-wrap items-center gap-3">
-				<span className="text-sm text-muted-foreground">Showing:</span>
+			<div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-3">
+				<span className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+					Showing
+				</span>
 				<MonthPicker items={items} selected={selectedKey} />
 			</div>
 			<LeaderboardList data={data} />

--- a/app/(dashboard)/dashboard/loading.tsx
+++ b/app/(dashboard)/dashboard/loading.tsx
@@ -3,18 +3,20 @@ import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primiti
 export default function DashboardLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto mt-2 space-y-8 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse sm:space-y-8"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading dashboard"
 		>
-			{/* Welcome header + Send button */}
-			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-				<div className="space-y-3">
-					<SkeletonLine className="h-10 w-80" />
-					<SkeletonLine className="h-5 w-72" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="flex flex-col gap-5 sm:gap-6 lg:flex-row lg:items-end lg:justify-between">
+					<div className="space-y-3">
+						<SkeletonLine className="h-3 w-20" />
+						<SkeletonLine className="h-10 w-80" />
+						<SkeletonLine className="h-5 w-72" />
+					</div>
+					<SkeletonLine className="h-12 w-56 rounded-full" />
 				</div>
-				<SkeletonLine className="h-12 w-56 rounded-full" />
 			</div>
 
 			{/* Feed (left on lg) + Stats (right on lg). On mobile, stats comes first. */}
@@ -48,9 +50,9 @@ export default function DashboardLoading() {
 				</SkeletonCard>
 
 				{/* Stats widget skeleton */}
-				<SkeletonCard className="p-6 space-y-6 h-full order-1 lg:order-2">
+				<SkeletonCard className="order-1 h-full space-y-6 p-6 lg:order-2">
 					<SkeletonLine className="h-6 w-40" />
-					<div className="grid grid-cols-3 gap-4">
+					<div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
 						{["s0", "s1", "s2"].map((key) => (
 							<div key={key} className="flex items-center gap-3">
 								<SkeletonLine className="h-10 w-10 rounded-full" />

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { getServerSession } from "@/lib/auth-utils";
 import { getUserRole, hasMinRole } from "@/lib/permissions";
 import { RecognitionFeedWidget } from "./_components/recognition-feed-widget";
@@ -14,25 +15,21 @@ export default async function DashboardPage() {
 	const isAdmin = hasMinRole(getUserRole(session), "ADMIN");
 
 	return (
-		<div className="max-w-7xl mx-auto mt-2 space-y-8">
-			{/* Top Row: Welcome + Send Button */}
-			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-				<div>
-					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-						Welcome back, {(user.firstName as string) ?? user.name}!
-					</h1>
-					<p className="mt-2 text-base text-muted-foreground">
-						Here&apos;s what&apos;s happening at Access Group today.
-					</p>
-				</div>
-				<Link
-					href="/dashboard/recognition/create"
-					className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-				>
-					<Plus className="-ml-1 h-5 w-5" />
-					Send Recognition Card
-				</Link>
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+			<DashboardPageHeader
+				eyebrow="Dashboard"
+				title={<>Welcome back, {(user.firstName as string) ?? user.name}!</>}
+				description="Here’s what’s happening at Access Group today."
+				actions={
+					<Link
+						href="/dashboard/recognition/create"
+						className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm transition-all duration-200 hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30"
+					>
+						<Plus className="-ml-1 h-5 w-5" />
+						Send Recognition Card
+					</Link>
+				}
+			/>
 
 			{/* Widgets: Public Feed + Stats */}
 			<div className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-8">

--- a/app/(dashboard)/dashboard/profile/_components/change-password-form.tsx
+++ b/app/(dashboard)/dashboard/profile/_components/change-password-form.tsx
@@ -50,8 +50,8 @@ export function ChangePasswordForm() {
 	}
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-			<div className="px-8 pt-8 pb-2">
+		<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+			<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
 					Change Password
 				</h3>
@@ -61,7 +61,7 @@ export function ChangePasswordForm() {
 			</div>
 
 			<form onSubmit={handleSubmit(onSubmit)}>
-				<div className="px-8 py-6 space-y-5">
+				<div className="space-y-5 px-5 py-6 sm:px-8">
 					<div>
 						<label
 							htmlFor="currentPassword"
@@ -147,11 +147,11 @@ export function ChangePasswordForm() {
 					</div>
 				</div>
 
-				<div className="px-8 py-6 bg-gray-50/50 dark:bg-white/[0.02] border-t border-gray-200/60 dark:border-white/10 flex justify-end">
+				<div className="flex justify-end border-t border-gray-200/60 bg-gray-50/50 px-5 py-6 dark:border-white/10 dark:bg-white/[0.02] sm:px-8">
 					<button
 						type="submit"
 						disabled={isLoading}
-						className="inline-flex justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50"
+						className="inline-flex w-full justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground transition-all duration-200 hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 disabled:opacity-50 sm:w-auto"
 					>
 						{isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
 						Update Password

--- a/app/(dashboard)/dashboard/profile/_components/profile-nav.tsx
+++ b/app/(dashboard)/dashboard/profile/_components/profile-nav.tsx
@@ -32,7 +32,7 @@ export function ProfileNav() {
 	const pathname = usePathname();
 
 	return (
-		<nav className="flex flex-row gap-1 sm:flex-col sm:w-48 sm:shrink-0">
+		<nav className="flex gap-1 overflow-x-auto pb-1 sm:w-48 sm:shrink-0 sm:flex-col sm:overflow-visible sm:pb-0 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 			{NAV_ITEMS.map((item) => {
 				const isActive = pathname === item.href;
 				return (
@@ -40,7 +40,7 @@ export function ProfileNav() {
 						key={item.href}
 						href={item.href}
 						className={cn(
-							"flex items-center gap-2.5 rounded-full px-4 py-2.5 text-sm font-medium transition-all duration-200",
+							"flex shrink-0 items-center gap-2.5 rounded-full px-4 py-2.5 text-sm font-medium transition-all duration-200",
 							isActive
 								? "bg-[oklch(0.96_0.03_18)] text-primary dark:bg-primary/15 dark:text-primary"
 								: "text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5",

--- a/app/(dashboard)/dashboard/profile/connected-accounts/_components/connected-accounts-panel.tsx
+++ b/app/(dashboard)/dashboard/profile/connected-accounts/_components/connected-accounts-panel.tsx
@@ -75,8 +75,8 @@ export function ConnectedAccountsPanel({ providers, hasPassword }: ConnectedAcco
 	}
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-			<div className="px-8 pt-8 pb-2">
+		<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+			<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
 					Connected Accounts
 				</h3>
@@ -85,9 +85,9 @@ export function ConnectedAccountsPanel({ providers, hasPassword }: ConnectedAcco
 				</p>
 			</div>
 
-			<div className="px-8 py-6 space-y-3">
+			<div className="space-y-3 px-5 py-6 sm:px-8">
 				{hasPassword && (
-					<div className="flex items-center justify-between rounded-2xl border border-gray-200/60 dark:border-white/10 px-5 py-4">
+					<div className="flex flex-col gap-4 rounded-2xl border border-gray-200/60 px-4 py-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:px-5">
 						<div className="flex items-center gap-3">
 							<div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 dark:bg-white/10">
 								<svg
@@ -111,7 +111,7 @@ export function ConnectedAccountsPanel({ providers, hasPassword }: ConnectedAcco
 								</p>
 							</div>
 						</div>
-						<span className="inline-flex items-center rounded-full bg-emerald-50 dark:bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+						<span className="inline-flex items-center self-start rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400 sm:self-auto">
 							Active
 						</span>
 					</div>
@@ -120,7 +120,7 @@ export function ConnectedAccountsPanel({ providers, hasPassword }: ConnectedAcco
 				{providers.map((provider) => (
 					<div
 						key={provider.id}
-						className="flex items-center justify-between rounded-2xl border border-gray-200/60 dark:border-white/10 px-5 py-4"
+						className="flex flex-col gap-4 rounded-2xl border border-gray-200/60 px-4 py-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:px-5"
 					>
 						<div className="flex items-center gap-3">
 							<div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 dark:bg-white/10">
@@ -141,7 +141,7 @@ export function ConnectedAccountsPanel({ providers, hasPassword }: ConnectedAcco
 								type="button"
 								onClick={() => handleUnlink(provider.id, provider.name)}
 								disabled={loadingProvider !== null}
-								className="inline-flex items-center gap-1.5 rounded-full border border-gray-200 dark:border-white/10 px-4 py-2 text-xs font-medium text-muted-foreground hover:text-destructive hover:border-destructive/30 transition-all duration-200 disabled:opacity-50"
+								className="inline-flex items-center gap-1.5 self-start rounded-full border border-gray-200 px-4 py-2 text-xs font-medium text-muted-foreground transition-all duration-200 hover:border-destructive/30 hover:text-destructive disabled:opacity-50 dark:border-white/10 sm:self-auto"
 							>
 								{loadingProvider === provider.id ? (
 									<Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -155,7 +155,7 @@ export function ConnectedAccountsPanel({ providers, hasPassword }: ConnectedAcco
 								type="button"
 								onClick={() => handleLink(provider.id, provider.name)}
 								disabled={loadingProvider !== null}
-								className="inline-flex items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-all duration-200 disabled:opacity-50"
+								className="inline-flex items-center gap-1.5 self-start rounded-full bg-primary px-4 py-2 text-xs font-medium text-primary-foreground transition-all duration-200 hover:bg-primary/90 disabled:opacity-50 sm:self-auto"
 							>
 								{loadingProvider === provider.id ? (
 									<Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -165,7 +165,9 @@ export function ConnectedAccountsPanel({ providers, hasPassword }: ConnectedAcco
 								Connect
 							</button>
 						) : (
-							<span className="text-xs text-muted-foreground">Not available</span>
+							<span className="self-start text-xs text-muted-foreground sm:self-auto">
+								Not available
+							</span>
 						)}
 					</div>
 				))}

--- a/app/(dashboard)/dashboard/profile/connected-accounts/loading.tsx
+++ b/app/(dashboard)/dashboard/profile/connected-accounts/loading.tsx
@@ -9,15 +9,15 @@ export default function ConnectedAccountsLoading() {
 			aria-label="Loading connected accounts"
 		>
 			<SkeletonCard className="overflow-hidden">
-				<div className="px-8 pt-8 pb-2 space-y-2">
+				<div className="space-y-2 px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 					<SkeletonLine className="h-7 w-48" />
 					<SkeletonLine className="h-4 w-64" />
 				</div>
-				<div className="px-8 py-6 space-y-3">
+				<div className="space-y-3 px-5 py-6 sm:px-8">
 					{[1, 2, 3].map((i) => (
 						<div
 							key={`provider-${i}`}
-							className="flex items-center justify-between rounded-2xl border border-gray-200/60 dark:border-white/10 px-5 py-4"
+							className="flex flex-col gap-4 rounded-2xl border border-gray-200/60 px-4 py-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:px-5"
 						>
 							<div className="flex items-center gap-3">
 								<SkeletonLine className="h-10 w-10 rounded-full" />
@@ -26,7 +26,7 @@ export default function ConnectedAccountsLoading() {
 									<SkeletonLine className="h-3 w-48" />
 								</div>
 							</div>
-							<SkeletonLine className="h-8 w-20 rounded-full" />
+							<SkeletonLine className="h-8 w-20 self-start rounded-full sm:self-auto" />
 						</div>
 					))}
 				</div>

--- a/app/(dashboard)/dashboard/profile/layout.tsx
+++ b/app/(dashboard)/dashboard/profile/layout.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { Badge } from "@/components/ui/badge";
 import { getServerSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
@@ -14,17 +15,18 @@ export default async function ProfileLayout({ children }: { children: React.Reac
 	});
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
-			<div>
-				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-					My Profile
-				</h1>
-				<div className="mt-2 flex items-center gap-2">
-					<p className="text-base text-muted-foreground">{user.email}</p>
-					<Badge variant="outline">{user.role}</Badge>
-					{user.department && <Badge variant="secondary">{user.department.name}</Badge>}
-				</div>
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+			<DashboardPageHeader
+				eyebrow="Account"
+				title="My Profile"
+				description={user.email}
+				meta={
+					<>
+						<Badge variant="outline">{user.role}</Badge>
+						{user.department && <Badge variant="secondary">{user.department.name}</Badge>}
+					</>
+				}
+			/>
 
 			<div className="flex flex-col gap-8 sm:flex-row">
 				<ProfileNav />

--- a/app/(dashboard)/dashboard/profile/loading.tsx
+++ b/app/(dashboard)/dashboard/profile/loading.tsx
@@ -9,13 +9,13 @@ export default function ProfileLoading() {
 			aria-label="Loading profile"
 		>
 			{/* Avatar card */}
-			<SkeletonCard className="px-8 py-6">
-				<div className="flex items-center gap-6">
+			<SkeletonCard className="px-5 py-6 sm:px-8">
+				<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
 					<SkeletonLine className="h-20 w-20 rounded-full shrink-0" />
 					<div className="flex flex-col gap-2 flex-1">
 						<SkeletonLine className="h-4 w-32" />
 						<SkeletonLine className="h-3 w-64" />
-						<div className="flex gap-2 mt-1">
+						<div className="mt-1 flex flex-col gap-2 sm:flex-row">
 							<SkeletonLine className="h-7 w-32 rounded-full" />
 							<SkeletonLine className="h-7 w-24 rounded-full" />
 						</div>
@@ -25,11 +25,11 @@ export default function ProfileLoading() {
 
 			{/* Edit Profile form card */}
 			<SkeletonCard className="overflow-hidden">
-				<div className="px-8 pt-8 pb-2">
+				<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 					<SkeletonLine className="h-8 w-40" />
 				</div>
-				<div className="px-8 py-6 space-y-5">
-					<div className="grid grid-cols-2 gap-5">
+				<div className="space-y-5 px-5 py-6 sm:px-8">
+					<div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
 						{["first", "last"].map((key) => (
 							<div key={key} className="space-y-2">
 								<SkeletonLine className="h-4 w-24" />
@@ -41,7 +41,7 @@ export default function ProfileLoading() {
 						<SkeletonLine className="h-4 w-28" />
 						<SkeletonLine className="h-12 w-full rounded-xl" />
 					</div>
-					<div className="grid grid-cols-2 gap-5">
+					<div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
 						{["phone", "position"].map((key) => (
 							<div key={key} className="space-y-2">
 								<SkeletonLine className="h-4 w-20" />
@@ -54,16 +54,16 @@ export default function ProfileLoading() {
 						<SkeletonLine className="h-12 w-full rounded-xl" />
 					</div>
 				</div>
-				<div className="px-8 py-6 bg-gray-50/50 dark:bg-white/[0.02] border-t border-gray-200/60 dark:border-white/10 flex justify-end">
-					<SkeletonLine className="h-10 w-32 rounded-full" />
+				<div className="flex justify-end border-t border-gray-200/60 bg-gray-50/50 px-5 py-6 dark:border-white/10 dark:bg-white/[0.02] sm:px-8">
+					<SkeletonLine className="h-10 w-full rounded-full sm:w-32" />
 				</div>
 			</SkeletonCard>
 
 			{/* Recognition history card */}
-			<SkeletonCard className="px-8 py-6 space-y-2">
+			<SkeletonCard className="space-y-2 px-5 py-6 sm:px-8">
 				<SkeletonLine className="h-6 w-48" />
 				<SkeletonLine className="h-3 w-20" />
-				<div className="grid grid-cols-2 gap-4 mt-6">
+				<div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
 					{["sent", "received"].map((key) => (
 						<div key={key} className="flex items-center gap-3">
 							<SkeletonLine className="h-10 w-10 rounded-full" />

--- a/app/(dashboard)/dashboard/profile/page.tsx
+++ b/app/(dashboard)/dashboard/profile/page.tsx
@@ -29,7 +29,7 @@ export default async function ProfilePage() {
 
 	return (
 		<div className="space-y-6">
-			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card px-8 py-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)]">
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10 sm:px-8">
 				<AvatarUpload
 					firstName={user.firstName}
 					lastName={user.lastName}
@@ -38,12 +38,12 @@ export default async function ProfilePage() {
 				/>
 			</div>
 			<ProfileForm user={user} />
-			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card px-8 py-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)]">
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10 sm:px-8">
 				<h2 className="text-[1.25rem] font-medium text-foreground tracking-tight">
 					Recognition history
 				</h2>
 				<p className="text-xs uppercase tracking-wide text-muted-foreground mt-1">All time</p>
-				<div className="grid grid-cols-2 gap-4 mt-6">
+				<div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
 					<div className="flex items-center gap-3">
 						<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
 							<Send size={18} className="text-primary" />

--- a/app/(dashboard)/dashboard/profile/preferences/loading.tsx
+++ b/app/(dashboard)/dashboard/profile/preferences/loading.tsx
@@ -13,18 +13,18 @@ export default function PreferencesLoading() {
 	return (
 		<div className="animate-pulse" role="status" aria-busy="true" aria-label="Loading preferences">
 			<SkeletonCard className="overflow-hidden">
-				<div className="px-8 pt-8 pb-2">
+				<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 					<SkeletonLine className="h-7 w-40" />
 				</div>
 
-				<div className="px-8 py-6 space-y-8">
+				<div className="space-y-8 px-5 py-6 sm:px-8">
 					{/* Background Color */}
 					<div className="space-y-4">
 						<div className="space-y-2">
 							<SkeletonLine className="h-4 w-40" />
 							<SkeletonLine className="h-3 w-72" />
 						</div>
-						<div className="grid grid-cols-3 gap-3 sm:grid-cols-6">
+						<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
 							{["b0", "b1", "b2", "b3", "b4", "b5"].map((key) => (
 								<OptionButtonSkeleton key={key} />
 							))}
@@ -37,7 +37,7 @@ export default function PreferencesLoading() {
 							<SkeletonLine className="h-4 w-24" />
 							<SkeletonLine className="h-3 w-64" />
 						</div>
-						<div className="grid grid-cols-2 gap-3 max-w-xs">
+						<div className="grid max-w-xs grid-cols-2 gap-3">
 							{["v0", "v1"].map((key) => (
 								<div
 									key={key}
@@ -56,7 +56,7 @@ export default function PreferencesLoading() {
 							<SkeletonLine className="h-4 w-24" />
 							<SkeletonLine className="h-3 w-64" />
 						</div>
-						<div className="grid grid-cols-3 gap-3 max-w-sm">
+						<div className="grid max-w-sm grid-cols-2 gap-3 sm:grid-cols-3">
 							{["s0", "s1", "s2"].map((key) => (
 								<div
 									key={key}

--- a/app/(dashboard)/dashboard/profile/preferences/page.tsx
+++ b/app/(dashboard)/dashboard/profile/preferences/page.tsx
@@ -55,14 +55,14 @@ export default function PreferencesPage() {
 	}
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-			<div className="px-8 pt-8 pb-2">
+		<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+			<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
 					Preferences
 				</h3>
 			</div>
 
-			<div className="px-8 py-6 space-y-8">
+			<div className="space-y-8 px-5 py-6 sm:px-8">
 				{/* Background Color */}
 				<div className="space-y-4">
 					<div>
@@ -77,7 +77,7 @@ export default function PreferencesPage() {
 						)}
 					</div>
 
-					<div className="grid grid-cols-3 gap-3 sm:grid-cols-6">
+					<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
 						{BG_OPTIONS.map((option) => {
 							const isSelected = bgColorId === option.id;
 							return (
@@ -129,7 +129,7 @@ export default function PreferencesPage() {
 						</p>
 					</div>
 
-					<div className="grid grid-cols-2 gap-3 max-w-xs">
+					<div className="grid max-w-xs grid-cols-2 gap-3">
 						{CARD_VIEW_OPTIONS.map((option) => {
 							const isSelected = cardView === option.id;
 							const Icon = VIEW_ICONS[option.id];
@@ -178,7 +178,7 @@ export default function PreferencesPage() {
 						</p>
 					</div>
 
-					<div className="grid grid-cols-3 gap-3 max-w-sm">
+					<div className="grid max-w-sm grid-cols-2 gap-3 sm:grid-cols-3">
 						{CARD_SIZE_OPTIONS.map((option) => {
 							const isSelected = cardSize === option.id;
 							const Icon = SIZE_ICONS[option.id];

--- a/app/(dashboard)/dashboard/profile/security/loading.tsx
+++ b/app/(dashboard)/dashboard/profile/security/loading.tsx
@@ -9,12 +9,12 @@ export default function SecurityLoading() {
 			aria-label="Loading security settings"
 		>
 			<SkeletonCard className="overflow-hidden">
-				<div className="px-8 pt-8 pb-2 space-y-2">
+				<div className="space-y-2 px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 					<SkeletonLine className="h-7 w-48" />
 					<SkeletonLine className="h-4 w-72" />
 				</div>
 
-				<div className="px-8 py-6 space-y-5">
+				<div className="space-y-5 px-5 py-6 sm:px-8">
 					{["current", "new", "confirm"].map((key) => (
 						<div key={key} className="space-y-2">
 							<SkeletonLine className="h-4 w-40" />
@@ -23,8 +23,8 @@ export default function SecurityLoading() {
 					))}
 				</div>
 
-				<div className="px-8 py-6 bg-gray-50/50 dark:bg-white/[0.02] border-t border-gray-200/60 dark:border-white/10 flex justify-end">
-					<SkeletonLine className="h-10 w-40 rounded-full" />
+				<div className="flex justify-end border-t border-gray-200/60 bg-gray-50/50 px-5 py-6 dark:border-white/10 dark:bg-white/[0.02] sm:px-8">
+					<SkeletonLine className="h-10 w-full rounded-full sm:w-40" />
 				</div>
 			</SkeletonCard>
 		</div>

--- a/app/(dashboard)/dashboard/profile/security/page.tsx
+++ b/app/(dashboard)/dashboard/profile/security/page.tsx
@@ -16,8 +16,8 @@ export default async function SecurityPage() {
 
 	if (!credentialAccount) {
 		return (
-			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-				<div className="px-8 pt-8 pb-2">
+			<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+				<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 					<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
 						Change Password
 					</h3>
@@ -26,10 +26,10 @@ export default async function SecurityPage() {
 						account (Google or Microsoft). To set a password, contact an administrator.
 					</p>
 				</div>
-				<div className="px-8 py-6">
+				<div className="px-5 py-6 sm:px-8">
 					<Link
 						href="/dashboard/profile/connected-accounts"
-						className="inline-flex items-center gap-2 rounded-full border border-gray-200 dark:border-white/10 bg-card px-6 py-2.5 text-sm font-medium text-foreground hover:bg-gray-50 dark:hover:bg-white/5 transition-all duration-200"
+						className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-gray-200 bg-card px-6 py-2.5 text-sm font-medium text-foreground transition-all duration-200 hover:bg-gray-50 dark:border-white/10 dark:hover:bg-white/5 sm:w-auto"
 					>
 						<Link2 className="h-4 w-4" />
 						Manage Connected Accounts

--- a/app/(dashboard)/dashboard/recognition/(inbox)/layout.tsx
+++ b/app/(dashboard)/dashboard/recognition/(inbox)/layout.tsx
@@ -1,6 +1,7 @@
 import { Plus } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { getServerSession } from "@/lib/auth-utils";
 import { getUserRole, hasMinRole } from "@/lib/permissions";
 import { RecognitionTabs, type TabItem } from "../_components/recognition-tabs";
@@ -38,22 +39,21 @@ export default async function RecognitionInboxLayout({ children }: { children: R
 	);
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-6 mt-2">
-			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-				<div>
-					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-						Recognition Card
-					</h1>
-					<p className="mt-2 text-base text-muted-foreground">Your personal recognition inbox.</p>
-				</div>
-				<Link
-					href="/dashboard/recognition/create"
-					className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-				>
-					<Plus className="-ml-1 h-5 w-5" />
-					Send Recognition Card
-				</Link>
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6">
+			<DashboardPageHeader
+				eyebrow="Recognition"
+				title="Recognition Card"
+				description="Your personal recognition inbox."
+				actions={
+					<Link
+						href="/dashboard/recognition/create"
+						className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm transition-all duration-200 hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30"
+					>
+						<Plus className="-ml-1 h-5 w-5" />
+						Send Recognition Card
+					</Link>
+				}
+			/>
 
 			<RecognitionTabs tabs={tabs} />
 

--- a/app/(dashboard)/dashboard/recognition/[id]/edit/loading.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/edit/loading.tsx
@@ -3,66 +3,75 @@ import { SkeletonLine } from "@/components/shared/skeleton-primitives";
 export default function RecognitionEditLoading() {
 	return (
 		<div
-			className="max-w-5xl mx-auto py-4 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading recognition editor"
 		>
-			{/* Progress bar skeleton */}
-			<div className="flex items-center justify-center gap-3 mb-8">
-				<SkeletonLine className="h-8 w-8 rounded-full" />
-				<SkeletonLine className="h-1 w-16" />
-				<SkeletonLine className="h-8 w-8 rounded-full" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="space-y-3">
+					<SkeletonLine className="h-3 w-24" />
+					<SkeletonLine className="h-10 w-72" />
+					<SkeletonLine className="h-4 w-80" />
+				</div>
 			</div>
-
-			{/* Recognition card back skeleton */}
-			<div className="bg-[#e6e7e8] dark:bg-gray-800 p-4 md:p-8 shadow-2xl flex flex-col md:flex-row gap-4 md:gap-6">
-				{/* Left column */}
-				<div className="flex-1 flex flex-col gap-4">
-					<div className="bg-white dark:bg-white/10 p-3 md:p-4 rounded-sm h-20 space-y-2">
-						<SkeletonLine className="h-3 w-12" />
-						<SkeletonLine className="h-5 w-40" />
-					</div>
-					<div className="bg-white dark:bg-white/10 p-3 md:p-4 rounded-sm min-h-[300px] space-y-2">
-						<SkeletonLine className="h-3 w-28" />
-						<SkeletonLine className="h-4 w-full" />
-						<SkeletonLine className="h-4 w-3/4" />
-						<SkeletonLine className="h-4 w-1/2" />
-					</div>
-					<div className="flex gap-4">
-						<div className="bg-white dark:bg-white/10 p-3 md:p-4 rounded-sm flex-1 h-20 space-y-2">
-							<SkeletonLine className="h-3 w-16" />
-							<SkeletonLine className="h-5 w-32" />
-						</div>
-						<div className="bg-white dark:bg-white/10 p-3 md:p-4 rounded-sm flex-1 h-20 space-y-2">
-							<SkeletonLine className="h-3 w-12" />
-							<SkeletonLine className="h-5 w-28" />
-						</div>
-					</div>
+			<div className="mx-auto max-w-5xl py-2">
+				{/* Progress bar skeleton */}
+				<div className="mb-8 flex items-center justify-center gap-3">
+					<SkeletonLine className="h-8 w-8 rounded-full" />
+					<SkeletonLine className="h-1 w-16" />
+					<SkeletonLine className="h-8 w-8 rounded-full" />
 				</div>
 
-				{/* Right column */}
-				<div className="flex-1 flex flex-col gap-4">
-					<div className="h-24 flex items-center justify-between px-2">
-						<SkeletonLine className="h-10 w-32" />
-						<SkeletonLine className="h-10 w-32" />
-					</div>
-					<div className="bg-white dark:bg-white/10 p-6 md:p-8 rounded-sm flex-grow space-y-5">
-						<SkeletonLine className="h-4 w-64" />
-						{["v0", "v1", "v2", "v3", "v4"].map((key) => (
-							<div key={key} className="flex items-center gap-3">
-								<SkeletonLine className="h-6 w-6" />
+				{/* Recognition card back skeleton */}
+				<div className="flex flex-col gap-4 bg-[#e6e7e8] p-4 shadow-2xl dark:bg-gray-800 md:flex-row md:gap-6 md:p-8">
+					{/* Left column */}
+					<div className="flex flex-1 flex-col gap-4">
+						<div className="h-20 space-y-2 rounded-sm bg-white p-3 dark:bg-white/10 md:p-4">
+							<SkeletonLine className="h-3 w-12" />
+							<SkeletonLine className="h-5 w-40" />
+						</div>
+						<div className="min-h-[300px] space-y-2 rounded-sm bg-white p-3 dark:bg-white/10 md:p-4">
+							<SkeletonLine className="h-3 w-28" />
+							<SkeletonLine className="h-4 w-full" />
+							<SkeletonLine className="h-4 w-3/4" />
+							<SkeletonLine className="h-4 w-1/2" />
+						</div>
+						<div className="flex gap-4">
+							<div className="h-20 flex-1 space-y-2 rounded-sm bg-white p-3 dark:bg-white/10 md:p-4">
+								<SkeletonLine className="h-3 w-16" />
 								<SkeletonLine className="h-5 w-32" />
 							</div>
-						))}
+							<div className="h-20 flex-1 space-y-2 rounded-sm bg-white p-3 dark:bg-white/10 md:p-4">
+								<SkeletonLine className="h-3 w-12" />
+								<SkeletonLine className="h-5 w-28" />
+							</div>
+						</div>
+					</div>
+
+					{/* Right column */}
+					<div className="flex flex-1 flex-col gap-4">
+						<div className="flex h-24 items-center justify-between px-2">
+							<SkeletonLine className="h-10 w-32" />
+							<SkeletonLine className="h-10 w-32" />
+						</div>
+						<div className="flex-grow space-y-5 rounded-sm bg-white p-6 dark:bg-white/10 md:p-8">
+							<SkeletonLine className="h-4 w-64" />
+							{["v0", "v1", "v2", "v3", "v4"].map((key) => (
+								<div key={key} className="flex items-center gap-3">
+									<SkeletonLine className="h-6 w-6" />
+									<SkeletonLine className="h-5 w-32" />
+								</div>
+							))}
+						</div>
 					</div>
 				</div>
-			</div>
 
-			{/* Action buttons */}
-			<div className="flex justify-end gap-3 mt-6">
-				<SkeletonLine className="h-12 w-28 rounded-full" />
-				<SkeletonLine className="h-12 w-32 rounded-full" />
+				{/* Action buttons */}
+				<div className="mt-6 flex justify-end gap-3">
+					<SkeletonLine className="h-12 w-28 rounded-full" />
+					<SkeletonLine className="h-12 w-32 rounded-full" />
+				</div>
 			</div>
 		</div>
 	);

--- a/app/(dashboard)/dashboard/recognition/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 import { notFound, redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { getServerSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { RecognitionForm } from "../../_components/recognition-form";
@@ -28,28 +29,35 @@ export default async function EditRecognitionPage({ params }: { params: Promise<
 	const dateStr = card.date.toISOString().split("T")[0];
 
 	return (
-		<div className="max-w-5xl mx-auto py-4">
-			<RecognitionForm
-				mode="edit"
-				cardId={id}
-				defaultValues={{
-					recipientId: card.recipientId,
-					message: card.message,
-					date: dateStr,
-					valuesPeople: card.valuesPeople,
-					valuesSafety: card.valuesSafety,
-					valuesRespect: card.valuesRespect,
-					valuesCommunication: card.valuesCommunication,
-					valuesContinuousImprovement: card.valuesContinuousImprovement,
-				}}
-				defaultRecipient={{
-					id: card.recipient.id,
-					firstName: card.recipient.firstName,
-					lastName: card.recipient.lastName,
-					position: card.recipient.position,
-					department: card.recipient.department,
-				}}
+		<div className="mx-auto max-w-7xl space-y-6">
+			<DashboardPageHeader
+				eyebrow="Recognition"
+				title="Edit Recognition Card"
+				description={`Update the card for ${card.recipient.firstName} ${card.recipient.lastName} before sending it again.`}
 			/>
+			<div className="mx-auto max-w-5xl py-2">
+				<RecognitionForm
+					mode="edit"
+					cardId={id}
+					defaultValues={{
+						recipientId: card.recipientId,
+						message: card.message,
+						date: dateStr,
+						valuesPeople: card.valuesPeople,
+						valuesSafety: card.valuesSafety,
+						valuesRespect: card.valuesRespect,
+						valuesCommunication: card.valuesCommunication,
+						valuesContinuousImprovement: card.valuesContinuousImprovement,
+					}}
+					defaultRecipient={{
+						id: card.recipient.id,
+						firstName: card.recipient.firstName,
+						lastName: card.recipient.lastName,
+						position: card.recipient.position,
+						department: card.recipient.department,
+					}}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/recognition/[id]/loading.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/loading.tsx
@@ -3,22 +3,23 @@ import { SkeletonLine } from "@/components/shared/skeleton-primitives";
 export default function RecognitionDetailLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-6 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading recognition card"
 		>
-			{/* Header row */}
-			<div className="flex items-center gap-4">
-				<SkeletonLine className="h-10 w-10 rounded-full shrink-0" />
-				<div className="flex-1 min-w-0 space-y-2">
-					<SkeletonLine className="h-10 w-64" />
-					<SkeletonLine className="h-4 w-56" />
-				</div>
-				<div className="flex items-center gap-2 shrink-0">
-					<SkeletonLine className="h-10 w-10 rounded-full" />
-					<SkeletonLine className="h-10 w-10 rounded-full" />
-					<SkeletonLine className="h-10 w-10 rounded-full" />
+			<SkeletonLine className="h-10 w-36 rounded-full" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="flex flex-col gap-5 sm:gap-6 lg:flex-row lg:items-end lg:justify-between">
+					<div className="min-w-0 space-y-3">
+						<SkeletonLine className="h-3 w-24" />
+						<SkeletonLine className="h-10 w-64" />
+						<SkeletonLine className="h-4 w-56" />
+					</div>
+					<div className="flex gap-2">
+						<SkeletonLine className="h-10 w-24 rounded-full" />
+						<SkeletonLine className="h-10 w-24 rounded-full" />
+					</div>
 				</div>
 			</div>
 
@@ -58,7 +59,7 @@ export default function RecognitionDetailLoading() {
 			</div>
 
 			{/* Interaction bar */}
-			<div className="relative z-10 max-w-4xl mx-auto rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+			<div className="relative z-10 mx-auto max-w-4xl rounded-[2rem] border border-gray-200/60 bg-card px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] dark:border-white/10">
 				<div className="flex items-center gap-4">
 					<SkeletonLine className="h-8 w-20 rounded-full" />
 					<SkeletonLine className="h-8 w-20 rounded-full" />

--- a/app/(dashboard)/dashboard/recognition/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
 	AccessGroupLogo,
 	BackgroundGraphic,
 } from "@/components/shared/access-logos";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { FitText } from "@/components/shared/fit-text";
 import { PhysicalCardPerson } from "@/components/shared/physical-card-person";
 import { getServerSession } from "@/lib/auth-utils";
@@ -258,32 +259,28 @@ export default async function RecognitionDetailPage({
 	);
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-6 mt-2">
+		<div className="mx-auto max-w-7xl space-y-6">
 			{(isSender || isRecipient) && <MarkNotificationsRead cardId={id} />}
-			<div className="flex items-center gap-4">
-				<Link
-					href="/dashboard/recognition"
-					aria-label="Back to recognition inbox"
-					className="inline-flex items-center justify-center rounded-full p-2 text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5 transition-colors"
-				>
-					<ArrowLeft className="h-5 w-5" />
-				</Link>
-				<div className="flex-1">
-					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-						Recognition Card
-					</h1>
-					<p className="mt-1 text-base text-muted-foreground">
-						From {senderName} to {recipientName}
-					</p>
-				</div>
-				<CardDetailActions cardId={id} isSender={isSender} />
-			</div>
+			<Link
+				href="/dashboard/recognition"
+				aria-label="Back to recognition inbox"
+				className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-gray-200/50 hover:text-foreground dark:hover:bg-white/5"
+			>
+				<ArrowLeft className="h-4 w-4" />
+				Back to inbox
+			</Link>
+			<DashboardPageHeader
+				eyebrow="Recognition"
+				title="Recognition Card"
+				description={`From ${senderName} to ${recipientName}`}
+				actions={<CardDetailActions cardId={id} isSender={isSender} />}
+			/>
 
 			<div className="flex justify-center">
 				<FlipCard front={card1Front} back={card2Back} />
 			</div>
 
-			<div className="relative z-10 max-w-4xl mx-auto rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
+			<div className="relative z-10 mx-auto max-w-4xl rounded-[2rem] border border-gray-200/60 bg-card px-6 py-4 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] dark:border-white/10">
 				<CardInteractionBar
 					cardId={id}
 					currentUserId={session.user.id}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-tabs.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-tabs.tsx
@@ -27,32 +27,34 @@ export function RecognitionTabs({ tabs }: RecognitionTabsProps) {
 	const pathname = usePathname();
 
 	return (
-		<div
-			className="flex gap-1 rounded-full bg-gray-100 dark:bg-white/5 p-1 w-fit"
-			role="tablist"
-			aria-label="Recognition inbox"
-		>
-			{tabs.map((tab) => {
-				const isActive = pathname === tab.href;
-				const Icon = ICON_MAP[tab.icon];
-				return (
-					<Link
-						key={tab.key}
-						href={tab.href}
-						role="tab"
-						aria-selected={isActive}
-						className={cn(
-							"inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition-all duration-200",
-							isActive
-								? "bg-card text-foreground shadow-sm"
-								: "text-muted-foreground hover:text-foreground",
-						)}
-					>
-						{Icon && <Icon size={16} />}
-						{tab.label}
-					</Link>
-				);
-			})}
+		<div className="overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			<div
+				className="flex min-w-max gap-1 rounded-[1.6rem] border border-black/5 bg-gray-100/80 p-1.5 dark:border-white/10 dark:bg-white/5"
+				role="tablist"
+				aria-label="Recognition inbox"
+			>
+				{tabs.map((tab) => {
+					const isActive = pathname === tab.href;
+					const Icon = ICON_MAP[tab.icon];
+					return (
+						<Link
+							key={tab.key}
+							href={tab.href}
+							role="tab"
+							aria-selected={isActive}
+							className={cn(
+								"inline-flex min-h-11 items-center gap-2 rounded-[1.2rem] px-4 py-2.5 text-sm font-medium whitespace-nowrap transition-all duration-200",
+								isActive
+									? "bg-card text-foreground shadow-sm"
+									: "text-muted-foreground hover:text-foreground",
+							)}
+						>
+							{Icon && <Icon size={16} />}
+							{tab.label}
+						</Link>
+					);
+				})}
+			</div>
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/recognition/create/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/create/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { getServerSession } from "@/lib/auth-utils";
 import { RecognitionForm } from "../_components/recognition-form";
 
@@ -7,8 +8,15 @@ export default async function CreateRecognitionPage() {
 	if (!session) redirect("/login");
 
 	return (
-		<div className="max-w-5xl mx-auto py-4">
-			<RecognitionForm />
+		<div className="mx-auto max-w-7xl space-y-6">
+			<DashboardPageHeader
+				eyebrow="Recognition"
+				title="Send Recognition Card"
+				description="Create and review a recognition card before sending it to a colleague."
+			/>
+			<div className="mx-auto max-w-5xl py-2">
+				<RecognitionForm />
+			</div>
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/super-admin/_components/activity-log-retention.tsx
+++ b/app/(dashboard)/dashboard/super-admin/_components/activity-log-retention.tsx
@@ -38,8 +38,8 @@ export function ActivityLogRetentionPanel({ initialDays }: { initialDays: number
 	}
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-			<div className="px-8 pt-8 pb-2">
+		<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+			<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
 					Activity Log Retention
 				</h3>
@@ -48,8 +48,8 @@ export function ActivityLogRetentionPanel({ initialDays }: { initialDays: number
 				</p>
 			</div>
 
-			<div className="px-8 py-6">
-				<div className="flex items-center justify-between gap-4 rounded-2xl border border-gray-200 dark:border-white/10 p-5">
+			<div className="px-5 py-6 sm:px-8">
+				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
 					<div className="flex-1">
 						<p className="text-sm font-medium text-foreground">Retention period (days)</p>
 						<p className="text-xs text-muted-foreground">
@@ -57,17 +57,17 @@ export function ActivityLogRetentionPanel({ initialDays }: { initialDays: number
 						</p>
 					</div>
 
-					<div className="flex items-center gap-2">
+					<div className="flex w-full items-center gap-2 sm:w-auto">
 						<Input
 							type="number"
 							min={ACTIVITY_LOG_RETENTION_MIN}
 							max={ACTIVITY_LOG_RETENTION_MAX}
 							value={days}
 							onChange={(e) => setDays(e.target.value)}
-							className="w-28"
+							className="w-full sm:w-28"
 							disabled={isPending}
 						/>
-						<Button onClick={handleSave} disabled={isPending}>
+						<Button onClick={handleSave} disabled={isPending} className="shrink-0">
 							{isPending ? "Saving…" : "Save"}
 						</Button>
 					</div>

--- a/app/(dashboard)/dashboard/super-admin/_components/oauth-settings.tsx
+++ b/app/(dashboard)/dashboard/super-admin/_components/oauth-settings.tsx
@@ -89,8 +89,8 @@ export function OAuthSettingsPanel({
 	}
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-			<div className="px-8 pt-8 pb-2">
+		<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+			<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
 					OAuth Providers
 				</h3>
@@ -99,7 +99,7 @@ export function OAuthSettingsPanel({
 				</p>
 			</div>
 
-			<div className="px-8 py-6 space-y-4">
+			<div className="space-y-4 px-5 py-6 sm:px-8">
 				{PROVIDERS.map((provider) => {
 					const availabilityKey = AVAILABILITY_KEY_MAP[provider.key];
 					const isConfigured = providerAvailability[availabilityKey];
@@ -110,7 +110,7 @@ export function OAuthSettingsPanel({
 						<div
 							key={provider.key}
 							className={cn(
-								"flex items-center justify-between rounded-2xl border p-5 transition-all duration-200",
+								"flex flex-col gap-4 rounded-2xl border p-4 transition-all duration-200 sm:flex-row sm:items-center sm:justify-between sm:p-5",
 								!isConfigured && "opacity-60",
 								isEnabled
 									? "border-primary/20 bg-primary/5"
@@ -121,7 +121,7 @@ export function OAuthSettingsPanel({
 								<div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gray-100 dark:bg-white/10">
 									{provider.icon}
 								</div>
-								<div>
+								<div className="min-w-0">
 									<p className="text-sm font-medium text-foreground">{provider.name}</p>
 									<p className="text-xs text-muted-foreground">
 										{isConfigured
@@ -131,7 +131,7 @@ export function OAuthSettingsPanel({
 								</div>
 							</div>
 
-							<div className="flex items-center gap-3">
+							<div className="flex items-center gap-3 self-start sm:self-auto">
 								<span
 									className={cn(
 										"text-xs font-medium",

--- a/app/(dashboard)/dashboard/super-admin/loading.tsx
+++ b/app/(dashboard)/dashboard/super-admin/loading.tsx
@@ -3,15 +3,17 @@ import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primiti
 export default function SuperAdminLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-8 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse sm:space-y-8"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading super admin settings"
 		>
-			{/* Page header */}
-			<div className="space-y-3">
-				<SkeletonLine className="h-10 w-44" />
-				<SkeletonLine className="h-5 w-80" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="space-y-3">
+					<SkeletonLine className="h-3 w-28" />
+					<SkeletonLine className="h-10 w-44" />
+					<SkeletonLine className="h-5 w-80" />
+				</div>
 			</div>
 
 			{/* OAuth settings panel */}

--- a/app/(dashboard)/dashboard/super-admin/page.tsx
+++ b/app/(dashboard)/dashboard/super-admin/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import {
 	getActivityLogRetentionDays,
 	getOAuthProviderAvailability,
@@ -22,15 +23,12 @@ export default async function SuperAdminPage() {
 	]);
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
-			<div>
-				<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-					Super Admin
-				</h1>
-				<p className="mt-2 text-base text-muted-foreground">
-					System-level administration and advanced controls.
-				</p>
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+			<DashboardPageHeader
+				eyebrow="Administration"
+				title="Super Admin"
+				description="System-level administration and advanced controls."
+			/>
 
 			<OAuthSettingsPanel
 				initialSettings={oauthSettings}

--- a/app/(dashboard)/dashboard/users/(list)/layout.tsx
+++ b/app/(dashboard)/dashboard/users/(list)/layout.tsx
@@ -2,6 +2,7 @@ import { Plus } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { Role } from "@/app/generated/prisma/client";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { getServerSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { canManageUsers, canViewUsers } from "@/lib/permissions";
@@ -21,26 +22,23 @@ export default async function UsersListLayout({ children }: { children: React.Re
 	const canAdd = canManageUsers(session.user.role as Role);
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-6 mt-2">
-			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-				<div>
-					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight">
-						Staff Directory
-					</h1>
-					<p className="mt-2 text-base text-muted-foreground">
-						Manage staff accounts, roles, and department assignments.
-					</p>
-				</div>
-				{canAdd && (
-					<Link
-						href="/dashboard/users/new"
-						className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-					>
-						<Plus className="-ml-1 h-5 w-5" />
-						Add Staff Member
-					</Link>
-				)}
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6">
+			<DashboardPageHeader
+				eyebrow="Staff"
+				title="Staff Directory"
+				description="Manage staff accounts, roles, and department assignments."
+				actions={
+					canAdd ? (
+						<Link
+							href="/dashboard/users/new"
+							className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-3.5 text-sm font-medium text-primary-foreground shadow-sm transition-all duration-200 hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30"
+						>
+							<Plus className="-ml-1 h-5 w-5" />
+							Add Staff Member
+						</Link>
+					) : null
+				}
+			/>
 
 			<UsersTabs activeCount={activeCount} deletedCount={deletedCount} />
 

--- a/app/(dashboard)/dashboard/users/[id]/edit/loading.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/edit/loading.tsx
@@ -3,15 +3,15 @@ import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primiti
 export default function EditUserLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-8 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse sm:space-y-8"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading user editor"
 		>
-			{/* Header row */}
-			<div className="flex items-center gap-4">
-				<SkeletonLine className="h-10 w-10 rounded-full shrink-0" />
-				<div className="flex-1 min-w-0 space-y-2">
+			<SkeletonLine className="h-10 w-40 rounded-full" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="space-y-3">
+					<SkeletonLine className="h-3 w-20" />
 					<SkeletonLine className="h-10 w-72" />
 					<SkeletonLine className="h-4 w-48" />
 				</div>

--- a/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import type { Role } from "@/app/generated/prisma/client";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { getServerSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { canManageUsers } from "@/lib/permissions";
@@ -45,22 +46,20 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 		: null;
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
-			<div className="flex items-center gap-4">
-				<Link
-					href={`/dashboard/users/${user.id}`}
-					aria-label="Back to user details"
-					className="inline-flex items-center justify-center rounded-full p-2 text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5 transition-colors"
-				>
-					<ArrowLeft className="h-5 w-5" />
-				</Link>
-				<div className="flex-1 min-w-0">
-					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight truncate">
-						Edit {user.firstName} {user.lastName}
-					</h1>
-					<p className="mt-1 text-base text-muted-foreground truncate">{user.email}</p>
-				</div>
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+			<Link
+				href={`/dashboard/users/${user.id}`}
+				aria-label="Back to user details"
+				className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-gray-200/50 hover:text-foreground dark:hover:bg-white/5"
+			>
+				<ArrowLeft className="h-4 w-4" />
+				Back to user details
+			</Link>
+			<DashboardPageHeader
+				eyebrow="Staff"
+				title={`Edit ${user.firstName} ${user.lastName}`}
+				description={user.email}
+			/>
 
 			<UserForm
 				mode="edit"

--- a/app/(dashboard)/dashboard/users/[id]/loading.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/loading.tsx
@@ -12,19 +12,21 @@ function InfoRowSkeleton() {
 export default function UserDetailLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-8 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse sm:space-y-8"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading user details"
 		>
-			{/* Header row */}
-			<div className="flex items-center gap-4">
-				<SkeletonLine className="h-10 w-10 rounded-full shrink-0" />
-				<div className="flex-1 min-w-0 space-y-2">
-					<SkeletonLine className="h-10 w-64" />
-					<SkeletonLine className="h-4 w-48" />
+			<SkeletonLine className="h-10 w-40 rounded-full" />
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="flex flex-col gap-5 sm:gap-6 lg:flex-row lg:items-end lg:justify-between">
+					<div className="min-w-0 space-y-3">
+						<SkeletonLine className="h-3 w-20" />
+						<SkeletonLine className="h-10 w-64" />
+						<SkeletonLine className="h-4 w-48" />
+					</div>
+					<SkeletonLine className="h-10 w-32 rounded-full shrink-0" />
 				</div>
-				<SkeletonLine className="h-10 w-32 rounded-full shrink-0" />
 			</div>
 
 			{/* Info cards */}
@@ -59,7 +61,7 @@ export default function UserDetailLoading() {
 					</div>
 				</div>
 				<div className="px-8 pb-8">
-					<div className="grid grid-cols-7 gap-2">
+					<div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-7">
 						{["d0", "d1", "d2", "d3", "d4", "d5", "d6"].map((dayKey) => (
 							<div
 								key={dayKey}

--- a/app/(dashboard)/dashboard/users/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/page.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft, Clock, Pencil } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import type { Role } from "@/app/generated/prisma/client";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { Badge } from "@/components/ui/badge";
 import { getServerSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
@@ -60,36 +61,37 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 				user.shiftSchedule?.days.find((d) => d.dayOfWeek === dayOfWeek),
 			)
 		: null;
+	const userName = `${user.firstName} ${user.lastName}`;
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
-			<div className="flex items-center gap-4">
-				<Link
-					href="/dashboard/users"
-					aria-label="Back to staff directory"
-					className="inline-flex items-center justify-center rounded-full p-2 text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5 transition-colors"
-				>
-					<ArrowLeft className="h-5 w-5" />
-				</Link>
-				<div className="flex-1 min-w-0">
-					<h1 className="text-[2.25rem] leading-tight font-medium text-foreground tracking-tight truncate">
-						{user.firstName} {user.lastName}
-					</h1>
-					<p className="mt-1 text-base text-muted-foreground truncate">{user.email}</p>
-				</div>
-				{user.deletedAt === null && (
-					<Link
-						href={`/dashboard/users/${user.id}/edit`}
-						className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200"
-					>
-						<Pencil className="h-4 w-4" />
-						Edit User
-					</Link>
-				)}
-			</div>
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+			<Link
+				href="/dashboard/users"
+				aria-label="Back to staff directory"
+				className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-gray-200/50 hover:text-foreground dark:hover:bg-white/5"
+			>
+				<ArrowLeft className="h-4 w-4" />
+				Back to staff directory
+			</Link>
+			<DashboardPageHeader
+				eyebrow="Staff"
+				title={userName}
+				description={user.email}
+				actions={
+					user.deletedAt === null ? (
+						<Link
+							href={`/dashboard/users/${user.id}/edit`}
+							className="inline-flex items-center gap-2 rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground shadow-sm transition-all duration-200 hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30"
+						>
+							<Pencil className="h-4 w-4" />
+							Edit User
+						</Link>
+					) : null
+				}
+			/>
 
 			<div className="grid gap-6 md:grid-cols-2">
-				<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] overflow-hidden">
+				<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] dark:border-white/10">
 					<div className="px-8 pt-8 pb-2">
 						<h2 className="text-[1.25rem] font-medium text-foreground">Personal Info</h2>
 					</div>
@@ -137,8 +139,8 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 				</div>
 			</div>
 
-			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] overflow-hidden">
-				<div className="px-8 pt-8 pb-4 flex items-center justify-between gap-4">
+			<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] dark:border-white/10">
+				<div className="flex flex-col gap-4 px-8 pt-8 pb-4 sm:flex-row sm:items-center sm:justify-between">
 					<div className="flex items-center gap-3">
 						<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
 							<Clock className="h-5 w-5" />
@@ -182,7 +184,7 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 						</div>
 					)}
 					{orderedDays && (
-						<div className="grid grid-cols-7 gap-2">
+						<div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-7">
 							{DISPLAY_DAY_ORDER.map((dayOfWeek) => {
 								const day = orderedDays[dayOfWeek];
 								const isWorking = !!(day?.isWorking && day.startTime && day.endTime);

--- a/app/(dashboard)/dashboard/users/_components/reset-password-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/reset-password-form.tsx
@@ -52,8 +52,8 @@ export function ResetPasswordForm({ userId, userName }: ResetPasswordFormProps) 
 	}
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] overflow-hidden">
-			<div className="px-8 pt-8 pb-2">
+		<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+			<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
 				<h2 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
 					Reset Password
 				</h2>
@@ -64,7 +64,7 @@ export function ResetPasswordForm({ userId, userName }: ResetPasswordFormProps) 
 			</div>
 
 			<form onSubmit={handleSubmit(onSubmit)}>
-				<div className="px-8 py-6 space-y-5">
+				<div className="space-y-5 px-5 py-6 sm:px-8">
 					<div>
 						<label
 							htmlFor="newPassword"
@@ -122,11 +122,11 @@ export function ResetPasswordForm({ userId, userName }: ResetPasswordFormProps) 
 					</div>
 				</div>
 
-				<div className="px-8 py-6 bg-gray-50/50 dark:bg-white/[0.02] border-t border-gray-200/60 dark:border-white/10 flex justify-end">
+				<div className="flex justify-end border-t border-gray-200/60 bg-gray-50/50 px-5 py-6 dark:border-white/10 dark:bg-white/[0.02] sm:px-8">
 					<button
 						type="submit"
 						disabled={isLoading}
-						className="inline-flex justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50"
+						className="inline-flex w-full justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground transition-all duration-200 hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 disabled:opacity-50 sm:w-auto"
 					>
 						{isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
 						Reset Password

--- a/app/(dashboard)/dashboard/users/_components/users-tabs.tsx
+++ b/app/(dashboard)/dashboard/users/_components/users-tabs.tsx
@@ -53,42 +53,44 @@ export function UsersTabs({ activeCount, deletedCount }: UsersTabsProps) {
 	];
 
 	return (
-		<div
-			className="flex gap-1 rounded-full bg-gray-100 dark:bg-white/5 p-1 w-fit"
-			role="tablist"
-			aria-label="Staff directory"
-		>
-			{tabs.map((tab) => {
-				const isActive = pathname === tab.href;
-				const Icon = tab.icon;
-				return (
-					<Link
-						key={tab.key}
-						href={tab.href}
-						role="tab"
-						aria-selected={isActive}
-						className={cn(
-							"inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition-all duration-200",
-							isActive
-								? "bg-card text-foreground shadow-sm"
-								: "text-muted-foreground hover:text-foreground",
-						)}
-					>
-						<Icon size={16} />
-						{tab.label}
-						<span
+		<div className="overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			<div
+				className="flex min-w-max gap-1 rounded-[1.6rem] border border-black/5 bg-gray-100/80 p-1.5 dark:border-white/10 dark:bg-white/5"
+				role="tablist"
+				aria-label="Staff directory"
+			>
+				{tabs.map((tab) => {
+					const isActive = pathname === tab.href;
+					const Icon = tab.icon;
+					return (
+						<Link
+							key={tab.key}
+							href={tab.href}
+							role="tab"
+							aria-selected={isActive}
 							className={cn(
-								"inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 rounded-full text-xs font-medium",
+								"inline-flex min-h-11 items-center gap-2 rounded-[1.2rem] px-4 py-2.5 text-sm font-medium whitespace-nowrap transition-all duration-200",
 								isActive
-									? "bg-primary/10 text-primary"
-									: "bg-gray-200/70 dark:bg-white/10 text-muted-foreground",
+									? "bg-card text-foreground shadow-sm"
+									: "text-muted-foreground hover:text-foreground",
 							)}
 						>
-							{tab.count}
-						</span>
-					</Link>
-				);
-			})}
+							<Icon size={16} />
+							{tab.label}
+							<span
+								className={cn(
+									"inline-flex h-5 min-w-[1.5rem] items-center justify-center rounded-full px-1.5 text-xs font-medium",
+									isActive
+										? "bg-primary/10 text-primary"
+										: "bg-gray-200/70 text-muted-foreground dark:bg-white/10",
+								)}
+							>
+								{tab.count}
+							</span>
+						</Link>
+					);
+				})}
+			</div>
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/users/new/loading.tsx
+++ b/app/(dashboard)/dashboard/users/new/loading.tsx
@@ -3,11 +3,18 @@ import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primiti
 export default function NewUserLoading() {
 	return (
 		<div
-			className="max-w-7xl mx-auto space-y-8 mt-2 animate-pulse"
+			className="mx-auto max-w-7xl space-y-6 animate-pulse sm:space-y-8"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading new user form"
 		>
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="space-y-3">
+					<SkeletonLine className="h-3 w-20" />
+					<SkeletonLine className="h-10 w-64" />
+					<SkeletonLine className="h-4 w-96" />
+				</div>
+			</div>
 			<SkeletonCard className="overflow-hidden">
 				<div className="px-8 pt-8 pb-2 space-y-2">
 					<SkeletonLine className="h-8 w-56" />

--- a/app/(dashboard)/dashboard/users/new/page.tsx
+++ b/app/(dashboard)/dashboard/users/new/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import type { Role } from "@/app/generated/prisma/client";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { getServerSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { canManageUsers } from "@/lib/permissions";
@@ -14,7 +15,12 @@ export default async function NewUserPage() {
 	const departments = await prisma.department.findMany({ orderBy: { name: "asc" } });
 
 	return (
-		<div className="max-w-7xl mx-auto space-y-8 mt-2">
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+			<DashboardPageHeader
+				eyebrow="Staff"
+				title="Add Staff Member"
+				description="Create a new staff account, assign a role, and configure the initial work details."
+			/>
 			<UserForm
 				mode="create"
 				currentUserRole={session.user.role as string}

--- a/app/(dashboard)/layout.test.tsx
+++ b/app/(dashboard)/layout.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+	redirect: vi.fn(),
+}));
+
+vi.mock("@/components/shared/dashboard-header", () => ({
+	DashboardHeader: () => <div data-testid="dashboard-header" />,
+}));
+
+vi.mock("@/components/shared/dashboard-sidebar", () => ({
+	DashboardSidebar: () => <div data-testid="dashboard-sidebar" />,
+}));
+
+vi.mock("@/components/shared/help-fab", () => ({
+	HelpFab: () => <div data-testid="help-fab" />,
+}));
+
+vi.mock("@/lib/actions/settings-actions", () => ({
+	getHelpMeEnabled: vi.fn(async () => true),
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+	getServerSession: vi.fn(async () => ({
+		user: { role: "ADMIN" },
+	})),
+}));
+
+import DashboardLayout from "./layout";
+
+describe("DashboardLayout", () => {
+	it("keeps FAB-safe bottom padding until the desktop breakpoint", async () => {
+		render(await DashboardLayout({ children: <div>Dashboard content</div> }));
+
+		expect(screen.getByRole("main")).toHaveClass(
+			"pb-[calc(6.5rem+env(safe-area-inset-bottom))]",
+			"md:pb-8",
+		);
+		expect(screen.getByRole("main")).not.toHaveClass("sm:pb-8");
+	});
+});

--- a/app/(dashboard)/layout.test.tsx
+++ b/app/(dashboard)/layout.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
 	redirect: vi.fn(),
@@ -27,16 +27,37 @@ vi.mock("@/lib/auth-utils", () => ({
 	})),
 }));
 
+import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import DashboardLayout from "./layout";
 
+const mockedGetHelpMeEnabled = vi.mocked(getHelpMeEnabled);
+
 describe("DashboardLayout", () => {
-	it("keeps FAB-safe bottom padding until the desktop breakpoint", async () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("keeps FAB-safe bottom padding until the desktop breakpoint when Help Me is enabled", async () => {
+		mockedGetHelpMeEnabled.mockResolvedValue(true);
+
 		render(await DashboardLayout({ children: <div>Dashboard content</div> }));
 
 		expect(screen.getByRole("main")).toHaveClass(
-			"pb-[calc(6.5rem+env(safe-area-inset-bottom))]",
+			"pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]",
 			"md:pb-8",
 		);
 		expect(screen.getByRole("main")).not.toHaveClass("sm:pb-8");
+	});
+
+	it("does not reserve FAB space when Help Me is disabled", async () => {
+		mockedGetHelpMeEnabled.mockResolvedValue(false);
+
+		render(await DashboardLayout({ children: <div>Dashboard content</div> }));
+
+		expect(screen.getByRole("main")).toHaveClass("pb-8");
+		expect(screen.getByRole("main")).not.toHaveClass(
+			"pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]",
+		);
 	});
 });

--- a/app/(dashboard)/layout.test.tsx
+++ b/app/(dashboard)/layout.test.tsx
@@ -42,12 +42,13 @@ describe("DashboardLayout", () => {
 		mockedGetHelpMeEnabled.mockResolvedValue(true);
 
 		const { container } = render(await DashboardLayout({ children: <div>Dashboard content</div> }));
+		const main = screen.getByRole("main");
+		const styleAttr = main.getAttribute("style");
 
-		expect(screen.getByRole("main")).toHaveClass(
-			"pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]",
-			"md:pb-8",
-		);
-		expect(screen.getByRole("main")).not.toHaveClass("sm:pb-8");
+		expect(main).toHaveClass("pb-8", "md:pb-8");
+		expect(main).not.toHaveClass("sm:pb-8");
+		expect(styleAttr).toContain("padding-bottom:");
+		expect(styleAttr).toContain("6.5rem");
 		expect(container.firstChild).toHaveClass("bg-background");
 	});
 
@@ -55,10 +56,9 @@ describe("DashboardLayout", () => {
 		mockedGetHelpMeEnabled.mockResolvedValue(false);
 
 		render(await DashboardLayout({ children: <div>Dashboard content</div> }));
+		const main = screen.getByRole("main");
 
-		expect(screen.getByRole("main")).toHaveClass("pb-8");
-		expect(screen.getByRole("main")).not.toHaveClass(
-			"pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]",
-		);
+		expect(main).toHaveClass("pb-8");
+		expect(main.getAttribute("style")).toBeNull();
 	});
 });

--- a/app/(dashboard)/layout.test.tsx
+++ b/app/(dashboard)/layout.test.tsx
@@ -41,13 +41,14 @@ describe("DashboardLayout", () => {
 	it("keeps FAB-safe bottom padding until the desktop breakpoint when Help Me is enabled", async () => {
 		mockedGetHelpMeEnabled.mockResolvedValue(true);
 
-		render(await DashboardLayout({ children: <div>Dashboard content</div> }));
+		const { container } = render(await DashboardLayout({ children: <div>Dashboard content</div> }));
 
 		expect(screen.getByRole("main")).toHaveClass(
 			"pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]",
 			"md:pb-8",
 		);
 		expect(screen.getByRole("main")).not.toHaveClass("sm:pb-8");
+		expect(container.firstChild).toHaveClass("bg-background");
 	});
 
 	it("does not reserve FAB space when Help Me is disabled", async () => {

--- a/app/(dashboard)/layout.test.tsx
+++ b/app/(dashboard)/layout.test.tsx
@@ -38,21 +38,21 @@ describe("DashboardLayout", () => {
 		vi.clearAllMocks();
 	});
 
-	it("keeps FAB-safe bottom padding until the desktop breakpoint when Help Me is enabled", async () => {
+	it("reserves FAB-safe bottom padding via inline style when Help Me is enabled", async () => {
 		mockedGetHelpMeEnabled.mockResolvedValue(true);
 
 		const { container } = render(await DashboardLayout({ children: <div>Dashboard content</div> }));
 		const main = screen.getByRole("main");
-		const styleAttr = main.getAttribute("style");
 
-		expect(main).toHaveClass("pb-8", "md:pb-8");
-		expect(main).not.toHaveClass("sm:pb-8");
-		expect(styleAttr).toContain("padding-bottom:");
+		expect(main).toHaveClass("pb-8");
+		const styleAttr = main.getAttribute("style") ?? "";
+		expect(styleAttr).toMatch(/padding-bottom:\s*calc\(/);
 		expect(styleAttr).toContain("6.5rem");
+		expect(styleAttr).toContain("safe-area-inset-bottom");
 		expect(container.firstChild).toHaveClass("bg-background");
 	});
 
-	it("does not reserve FAB space when Help Me is disabled", async () => {
+	it("falls back to the Tailwind pb-8 utility when Help Me is disabled", async () => {
 		mockedGetHelpMeEnabled.mockResolvedValue(false);
 
 		render(await DashboardLayout({ children: <div>Dashboard content</div> }));

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -17,7 +17,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
 			<DashboardSidebar helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 			<div className="relative flex min-h-screen min-w-0 flex-1 flex-col bg-background/92 md:bg-card md:shadow-sm md:backdrop-blur-sm md:my-2 md:mr-2 md:rounded-l-[2rem] md:border md:border-gray-100 dark:md:border-white/5">
 				<DashboardHeader helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
-				<main className="flex-1 px-4 pb-[calc(6.5rem+env(safe-area-inset-bottom))] sm:px-8 sm:pb-8">
+				<main className="flex-1 px-4 pb-[calc(6.5rem+env(safe-area-inset-bottom))] sm:px-8 md:pb-8">
 					<div className="mx-auto min-w-0">{children}</div>
 				</main>
 			</div>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import { DashboardSidebar } from "@/components/shared/dashboard-sidebar";
 import { HelpFab } from "@/components/shared/help-fab";
 import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
+import { cn } from "@/lib/utils";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
 	const session = await getServerSession();
@@ -17,7 +18,12 @@ export default async function DashboardLayout({ children }: { children: React.Re
 			<DashboardSidebar helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 			<div className="relative flex min-h-screen min-w-0 flex-1 flex-col bg-background/92 md:bg-card md:shadow-sm md:backdrop-blur-sm md:my-2 md:mr-2 md:rounded-l-[2rem] md:border md:border-gray-100 dark:md:border-white/5">
 				<DashboardHeader helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
-				<main className="flex-1 px-4 pb-[calc(6.5rem+env(safe-area-inset-bottom))] sm:px-8 md:pb-8">
+				<main
+					className={cn(
+						"flex-1 px-4 sm:px-8 md:pb-8",
+						helpMeEnabled ? "pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]" : "pb-8",
+					)}
+				>
 					<div className="mx-auto min-w-0">{children}</div>
 				</main>
 			</div>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -14,7 +14,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
 	const initialUserRole = session.user.role as "STAFF" | "ADMIN" | "SUPERADMIN";
 
 	return (
-		<div className="flex min-h-screen bg-[radial-gradient(circle_at_top,oklch(0.985_0.012_18),transparent_36%),linear-gradient(to_bottom,oklch(0.992_0_0),oklch(0.97_0_0))] dark:bg-[linear-gradient(to_bottom,oklch(0.16_0.01_18),oklch(0.145_0_0))]">
+		<div className="flex min-h-screen bg-background [background-image:radial-gradient(circle_at_top,oklch(0.985_0.012_18/0.78),transparent_36%)] dark:[background-image:linear-gradient(to_bottom,oklch(0.16_0.01_18),transparent_45%)]">
 			<DashboardSidebar helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 			<div className="relative flex min-h-screen min-w-0 flex-1 flex-col bg-background/92 md:bg-card md:shadow-sm md:backdrop-blur-sm md:my-2 md:mr-2 md:rounded-l-[2rem] md:border md:border-gray-100 dark:md:border-white/5">
 				<DashboardHeader helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -4,7 +4,6 @@ import { DashboardSidebar } from "@/components/shared/dashboard-sidebar";
 import { HelpFab } from "@/components/shared/help-fab";
 import { getHelpMeEnabled } from "@/lib/actions/settings-actions";
 import { getServerSession } from "@/lib/auth-utils";
-import { cn } from "@/lib/utils";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
 	const session = await getServerSession();
@@ -19,14 +18,14 @@ export default async function DashboardLayout({ children }: { children: React.Re
 			<div className="relative flex min-h-screen min-w-0 flex-1 flex-col bg-background/92 md:bg-card md:shadow-sm md:backdrop-blur-sm md:my-2 md:mr-2 md:rounded-l-[2rem] md:border md:border-gray-100 dark:md:border-white/5">
 				<DashboardHeader helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 				<main
-					className={cn("flex-1 px-4 pb-8 sm:px-8 md:pb-8")}
+					className="flex-1 px-4 pb-8 sm:px-8"
 					style={
 						helpMeEnabled
 							? { paddingBottom: "calc(6.5rem + env(safe-area-inset-bottom, 0px))" }
 							: undefined
 					}
 				>
-					<div className="mx-auto min-w-0">{children}</div>
+					{children}
 				</main>
 			</div>
 			<HelpFab enabled={helpMeEnabled} />

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -13,11 +13,13 @@ export default async function DashboardLayout({ children }: { children: React.Re
 	const initialUserRole = session.user.role as "STAFF" | "ADMIN" | "SUPERADMIN";
 
 	return (
-		<div className="flex min-h-screen bg-background">
+		<div className="flex min-h-screen bg-[radial-gradient(circle_at_top,oklch(0.985_0.012_18),transparent_36%),linear-gradient(to_bottom,oklch(0.992_0_0),oklch(0.97_0_0))] dark:bg-[linear-gradient(to_bottom,oklch(0.16_0.01_18),oklch(0.145_0_0))]">
 			<DashboardSidebar helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
-			<div className="flex flex-1 flex-col bg-card sm:my-2 sm:mr-2 sm:rounded-l-[2rem] shadow-sm border border-gray-100 dark:border-white/5">
+			<div className="relative flex min-h-screen min-w-0 flex-1 flex-col bg-background/92 md:bg-card md:shadow-sm md:backdrop-blur-sm md:my-2 md:mr-2 md:rounded-l-[2rem] md:border md:border-gray-100 dark:md:border-white/5">
 				<DashboardHeader helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
-				<main className="flex-1 px-4 pb-8 sm:px-8">{children}</main>
+				<main className="flex-1 px-4 pb-[calc(6.5rem+env(safe-area-inset-bottom))] sm:px-8 sm:pb-8">
+					<div className="mx-auto min-w-0">{children}</div>
+				</main>
 			</div>
 			<HelpFab enabled={helpMeEnabled} />
 		</div>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -19,10 +19,12 @@ export default async function DashboardLayout({ children }: { children: React.Re
 			<div className="relative flex min-h-screen min-w-0 flex-1 flex-col bg-background/92 md:bg-card md:shadow-sm md:backdrop-blur-sm md:my-2 md:mr-2 md:rounded-l-[2rem] md:border md:border-gray-100 dark:md:border-white/5">
 				<DashboardHeader helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 				<main
-					className={cn(
-						"flex-1 px-4 sm:px-8 md:pb-8",
-						helpMeEnabled ? "pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]" : "pb-8",
-					)}
+					className={cn("flex-1 px-4 pb-8 sm:px-8 md:pb-8")}
+					style={
+						helpMeEnabled
+							? { paddingBottom: "calc(6.5rem + env(safe-area-inset-bottom, 0px))" }
+							: undefined
+					}
 				>
 					<div className="mx-auto min-w-0">{children}</div>
 				</main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -136,3 +136,22 @@
 		color: oklch(0.85 0.1 18);
 	}
 }
+
+@layer utilities {
+	.px-safe {
+		padding-left: env(safe-area-inset-left);
+		padding-right: env(safe-area-inset-right);
+	}
+
+	.pt-safe {
+		padding-top: env(safe-area-inset-top);
+	}
+
+	.pb-safe {
+		padding-bottom: env(safe-area-inset-bottom);
+	}
+
+	.bottom-safe-6 {
+		bottom: calc(env(safe-area-inset-bottom) + 1.5rem);
+	}
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -139,16 +139,16 @@
 
 @layer utilities {
 	.px-safe {
-		padding-left: env(safe-area-inset-left);
-		padding-right: env(safe-area-inset-right);
+		padding-left: calc(env(safe-area-inset-left, 0px) + 1rem);
+		padding-right: calc(env(safe-area-inset-right, 0px) + 1rem);
 	}
 
 	.pt-safe {
-		padding-top: env(safe-area-inset-top);
+		padding-top: calc(env(safe-area-inset-top, 0px) + 1rem);
 	}
 
 	.pb-safe {
-		padding-bottom: env(safe-area-inset-bottom);
+		padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem);
 	}
 
 	.bottom-safe-6 {

--- a/app/globals.css
+++ b/app/globals.css
@@ -152,6 +152,6 @@
 	}
 
 	.bottom-safe-6 {
-		bottom: calc(env(safe-area-inset-bottom) + 1.5rem);
+		bottom: calc(env(safe-area-inset-bottom, 0px) + 1.5rem);
 	}
 }

--- a/components/shared/dashboard-account-controls.tsx
+++ b/components/shared/dashboard-account-controls.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { ChevronDown, LogOut, UserCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { NotificationBell } from "@/components/shared/notification-bell";
+import { ThemeToggle } from "@/components/shared/theme-toggle";
+import { UserAvatar } from "@/components/shared/user-avatar";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { signOut, useSession } from "@/lib/auth-client";
+
+export function DashboardAccountControls({ className = "" }: { className?: string }) {
+	const router = useRouter();
+	const { data: session } = useSession();
+	const user = session?.user;
+
+	async function handleSignOut() {
+		try {
+			await signOut();
+			router.push("/login");
+			router.refresh();
+		} catch {
+			toast.error("Failed to sign out");
+		}
+	}
+
+	return (
+		<div className={`flex items-center gap-2 sm:gap-3 ${className}`.trim()}>
+			<div className="rounded-full border border-black/5 bg-card/80 p-1 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/5">
+				<ThemeToggle />
+			</div>
+			{user && (
+				<div className="rounded-full border border-black/5 bg-card/80 p-1 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/5">
+					<NotificationBell />
+				</div>
+			)}
+			{user && (
+				<DropdownMenu>
+					<DropdownMenuTrigger className="flex cursor-pointer items-center gap-2 rounded-full border border-black/5 bg-card/80 py-1 pr-1.5 pl-1 shadow-sm backdrop-blur-sm transition-all outline-none hover:border-gray-200 hover:bg-gray-50 dark:border-white/10 dark:bg-white/5 dark:hover:border-white/15 dark:hover:bg-white/8">
+						<UserAvatar
+							firstName={user.firstName ?? ""}
+							lastName={user.lastName ?? ""}
+							avatar={user.avatar}
+							image={user.image}
+							size="md"
+							className="bg-[oklch(0.96_0.03_18)] text-primary dark:bg-primary/15"
+						/>
+						<div className="hidden min-w-0 text-left sm:block">
+							<p className="truncate text-sm font-medium text-foreground">{user.name}</p>
+							<p className="truncate text-[11px] text-muted-foreground">Account</p>
+						</div>
+						<ChevronDown
+							size={16}
+							className="mr-1 hidden shrink-0 text-muted-foreground sm:block"
+						/>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end" sideOffset={8}>
+						<DropdownMenuItem
+							className="cursor-pointer"
+							onClick={() => router.push("/dashboard/profile")}
+						>
+							<UserCircle size={16} />
+							My Profile
+						</DropdownMenuItem>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem className="cursor-pointer" onClick={handleSignOut}>
+							<LogOut size={16} />
+							Sign Out
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			)}
+		</div>
+	);
+}

--- a/components/shared/dashboard-account-controls.tsx
+++ b/components/shared/dashboard-account-controls.tsx
@@ -14,8 +14,9 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { signOut, useSession } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
 
-export function DashboardAccountControls({ className = "" }: { className?: string }) {
+export function DashboardAccountControls({ className }: { className?: string }) {
 	const router = useRouter();
 	const { data: session } = useSession();
 	const user = session?.user;
@@ -31,7 +32,7 @@ export function DashboardAccountControls({ className = "" }: { className?: strin
 	}
 
 	return (
-		<div className={`flex items-center gap-2 sm:gap-3 ${className}`.trim()}>
+		<div className={cn("flex items-center gap-2 sm:gap-3", className)}>
 			<div className="rounded-full border border-black/5 bg-card/80 p-1 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/5">
 				<ThemeToggle />
 			</div>
@@ -42,7 +43,7 @@ export function DashboardAccountControls({ className = "" }: { className?: strin
 			)}
 			{user && (
 				<DropdownMenu>
-					<DropdownMenuTrigger className="flex cursor-pointer items-center gap-2 rounded-full border border-black/5 bg-card/80 py-1 pr-1.5 pl-1 shadow-sm backdrop-blur-sm transition-all outline-none hover:border-gray-200 hover:bg-gray-50 dark:border-white/10 dark:bg-white/5 dark:hover:border-white/15 dark:hover:bg-white/8">
+					<DropdownMenuTrigger className="flex cursor-pointer items-center gap-2 rounded-full border border-black/5 bg-card/80 py-1 pr-1.5 pl-1 shadow-sm backdrop-blur-sm transition-all outline-none hover:border-gray-200 hover:bg-gray-50 dark:border-white/10 dark:bg-white/5 dark:hover:border-white/15 dark:hover:bg-white/10">
 						<UserAvatar
 							firstName={user.firstName ?? ""}
 							lastName={user.lastName ?? ""}

--- a/components/shared/dashboard-account-controls.tsx
+++ b/components/shared/dashboard-account-controls.tsx
@@ -33,17 +33,17 @@ export function DashboardAccountControls({ className }: { className?: string }) 
 
 	return (
 		<div className={cn("flex items-center gap-2 sm:gap-3", className)}>
-			<div className="rounded-full border border-black/5 bg-card/80 p-1 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/5">
+			<div className="rounded-full border border-black/5 bg-card/80 p-1 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/5 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none md:backdrop-blur-none dark:md:border-0 dark:md:bg-transparent">
 				<ThemeToggle />
 			</div>
 			{user && (
-				<div className="rounded-full border border-black/5 bg-card/80 p-1 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/5">
+				<div className="rounded-full border border-black/5 bg-card/80 p-1 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/5 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none md:backdrop-blur-none dark:md:border-0 dark:md:bg-transparent">
 					<NotificationBell />
 				</div>
 			)}
 			{user && (
 				<DropdownMenu>
-					<DropdownMenuTrigger className="flex cursor-pointer items-center gap-2 rounded-full border border-black/5 bg-card/80 py-1 pr-1.5 pl-1 shadow-sm backdrop-blur-sm transition-all outline-none hover:border-gray-200 hover:bg-gray-50 dark:border-white/10 dark:bg-white/5 dark:hover:border-white/15 dark:hover:bg-white/10">
+					<DropdownMenuTrigger className="flex cursor-pointer items-center gap-2 rounded-full border border-black/5 bg-card/80 py-1 pr-1.5 pl-1 shadow-sm backdrop-blur-sm transition-all outline-none hover:border-gray-200 hover:bg-gray-50 dark:border-white/10 dark:bg-white/5 dark:hover:border-white/15 dark:hover:bg-white/10 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none md:backdrop-blur-none md:hover:border-transparent md:hover:bg-transparent dark:md:border-0 dark:md:bg-transparent dark:md:hover:border-transparent dark:md:hover:bg-transparent">
 						<UserAvatar
 							firstName={user.firstName ?? ""}
 							lastName={user.lastName ?? ""}

--- a/components/shared/dashboard-header.test.tsx
+++ b/components/shared/dashboard-header.test.tsx
@@ -37,6 +37,9 @@ describe("DashboardHeader", () => {
 		["/dashboard/recognition/create", "Recognition"],
 		["/dashboard/leaderboard", "Leaderboard"],
 		["/dashboard/users/new", "Staff"],
+		["/dashboard/departments", "Departments"],
+		["/dashboard/profile/security", "Profile"],
+		["/dashboard/helpme/new", "Help Me"],
 		["/dashboard/admin-settings/activity-logs", "Admin Settings"],
 		["/dashboard/super-admin", "Super Admin"],
 	])("shows the correct mobile section label for %s", (pathname, label) => {

--- a/components/shared/dashboard-header.test.tsx
+++ b/components/shared/dashboard-header.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+}));
+
+vi.mock("@/components/shared/access-logos", () => ({
+	AccessGroupLogo: (props: React.ComponentProps<"svg">) => (
+		<svg aria-label="Access Group" {...props} />
+	),
+}));
+
+vi.mock("@/components/shared/dashboard-sidebar", () => ({
+	MobileSidebarTrigger: () => <button type="button">Menu</button>,
+}));
+
+vi.mock("@/components/shared/dashboard-account-controls", () => ({
+	DashboardAccountControls: ({ className = "" }: { className?: string }) => (
+		<div data-testid="account-controls" className={className} />
+	),
+}));
+
+import { usePathname } from "next/navigation";
+import { DashboardHeader } from "./dashboard-header";
+
+const mockedUsePathname = vi.mocked(usePathname);
+
+describe("DashboardHeader", () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it.each([
+		["/dashboard", "Dashboard"],
+		["/dashboard/recognition/create", "Recognition"],
+		["/dashboard/leaderboard", "Leaderboard"],
+		["/dashboard/users/new", "Staff"],
+		["/dashboard/admin-settings/activity-logs", "Admin Settings"],
+		["/dashboard/super-admin", "Super Admin"],
+	])("shows the correct mobile section label for %s", (pathname, label) => {
+		mockedUsePathname.mockReturnValue(pathname);
+
+		render(<DashboardHeader helpMeEnabled initialUserRole="ADMIN" />);
+
+		expect(screen.getByText(label)).toBeInTheDocument();
+	});
+
+	it("renders the account controls inside the mobile-only sticky header", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
+
+		const { container } = render(<DashboardHeader helpMeEnabled initialUserRole="STAFF" />);
+
+		expect(screen.getByTestId("account-controls")).toBeInTheDocument();
+		expect(container.querySelector("header")).toHaveClass("md:hidden");
+	});
+});

--- a/components/shared/dashboard-header.tsx
+++ b/components/shared/dashboard-header.tsx
@@ -42,7 +42,7 @@ export function DashboardHeader({
 
 	return (
 		<header className="sticky top-0 z-20 px-safe pt-safe md:hidden">
-			<div className="flex h-[4.5rem] items-center justify-between border-b border-black/5 bg-background/88 px-4 backdrop-blur-xl dark:border-white/8">
+			<div className="flex h-[4.5rem] items-center justify-between border-b border-black/5 bg-background/88 backdrop-blur-xl dark:border-white/10">
 				<div className="flex min-w-0 items-center gap-3">
 					<MobileSidebarTrigger helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
 					<div className="min-w-0">

--- a/components/shared/dashboard-header.tsx
+++ b/components/shared/dashboard-header.tsx
@@ -1,20 +1,34 @@
 "use client";
 
-import { ChevronDown, LogOut, UserCircle } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { toast } from "sonner";
+import { usePathname } from "next/navigation";
+import { AccessGroupLogo } from "@/components/shared/access-logos";
+import { DashboardAccountControls } from "@/components/shared/dashboard-account-controls";
 import { MobileSidebarTrigger } from "@/components/shared/dashboard-sidebar";
-import { NotificationBell } from "@/components/shared/notification-bell";
-import { ThemeToggle } from "@/components/shared/theme-toggle";
-import { UserAvatar } from "@/components/shared/user-avatar";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { signOut, useSession } from "@/lib/auth-client";
+
+function getMobileSectionLabel(pathname: string) {
+	const segment = pathname.split("/")[2] ?? "";
+
+	switch (segment) {
+		case "recognition":
+			return "Recognition";
+		case "leaderboard":
+			return "Leaderboard";
+		case "users":
+			return "Staff";
+		case "departments":
+			return "Departments";
+		case "profile":
+			return "Profile";
+		case "helpme":
+			return "Help Me";
+		case "admin-settings":
+			return "Admin Settings";
+		case "super-admin":
+			return "Super Admin";
+		default:
+			return "Dashboard";
+	}
+}
 
 export function DashboardHeader({
 	helpMeEnabled,
@@ -23,63 +37,23 @@ export function DashboardHeader({
 	helpMeEnabled: boolean;
 	initialUserRole: "STAFF" | "ADMIN" | "SUPERADMIN";
 }) {
-	const router = useRouter();
-	const { data: session } = useSession();
-	const user = session?.user;
-
-	async function handleSignOut() {
-		try {
-			await signOut();
-			router.push("/login");
-			router.refresh();
-		} catch {
-			toast.error("Failed to sign out");
-		}
-	}
+	const pathname = usePathname();
+	const sectionLabel = getMobileSectionLabel(pathname);
 
 	return (
-		<header className="sticky top-0 z-10 flex h-20 items-center justify-between bg-card px-4 sm:px-8">
-			<div className="flex items-center md:hidden">
-				<MobileSidebarTrigger helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
-			</div>
+		<header className="sticky top-0 z-20 px-safe pt-safe md:hidden">
+			<div className="flex h-[4.5rem] items-center justify-between border-b border-black/5 bg-background/88 px-4 backdrop-blur-xl dark:border-white/8">
+				<div className="flex min-w-0 items-center gap-3">
+					<MobileSidebarTrigger helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
+					<div className="min-w-0">
+						<div className="flex items-center gap-2">
+							<AccessGroupLogo color="currentColor" className="h-5 w-auto text-primary" />
+						</div>
+						<p className="truncate text-sm font-semibold text-foreground">{sectionLabel}</p>
+					</div>
+				</div>
 
-			<div className="flex-1 md:flex-none" />
-
-			<div className="flex items-center gap-3">
-				<ThemeToggle />
-				{user && <NotificationBell />}
-				{user && (
-					<DropdownMenu>
-						<DropdownMenuTrigger className="flex items-center gap-2 rounded-full p-1.5 border border-transparent hover:border-gray-200 dark:hover:border-white/10 hover:bg-gray-50 dark:hover:bg-white/5 transition-all cursor-pointer outline-none">
-							<UserAvatar
-								firstName={user.firstName ?? ""}
-								lastName={user.lastName ?? ""}
-								avatar={user.avatar}
-								image={user.image}
-								size="md"
-								className="bg-[oklch(0.96_0.03_18)] text-primary dark:bg-primary/15"
-							/>
-							<span className="hidden text-sm font-medium text-foreground sm:block">
-								{user.name}
-							</span>
-							<ChevronDown size={16} className="mr-1 hidden text-muted-foreground sm:block" />
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end" sideOffset={8}>
-							<DropdownMenuItem
-								className="cursor-pointer"
-								onClick={() => router.push("/dashboard/profile")}
-							>
-								<UserCircle size={16} />
-								My Profile
-							</DropdownMenuItem>
-							<DropdownMenuSeparator />
-							<DropdownMenuItem className="cursor-pointer" onClick={handleSignOut}>
-								<LogOut size={16} />
-								Sign Out
-							</DropdownMenuItem>
-						</DropdownMenuContent>
-					</DropdownMenu>
-				)}
+				<DashboardAccountControls />
 			</div>
 		</header>
 	);

--- a/components/shared/dashboard-page-header.tsx
+++ b/components/shared/dashboard-page-header.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from "react";
+import { DashboardAccountControls } from "@/components/shared/dashboard-account-controls";
+import { cn } from "@/lib/utils";
+
+interface DashboardPageHeaderProps {
+	title: ReactNode;
+	description?: ReactNode;
+	eyebrow?: ReactNode;
+	meta?: ReactNode;
+	actions?: ReactNode;
+	className?: string;
+}
+
+export function DashboardPageHeader({
+	title,
+	description,
+	eyebrow = "Dashboard",
+	meta,
+	actions,
+	className,
+}: DashboardPageHeaderProps) {
+	return (
+		<section
+			className={cn(
+				"mt-2 overflow-hidden rounded-[2rem] border border-black/5 bg-[linear-gradient(180deg,rgba(255,255,255,0.95),rgba(252,248,247,0.98))] px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 dark:bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] sm:px-7 sm:py-6",
+				className,
+			)}
+		>
+			<div
+				className={cn(
+					"flex flex-col gap-5 sm:gap-6 lg:flex-row lg:justify-between",
+					actions ? "lg:items-end" : "lg:items-start",
+				)}
+			>
+				<div className="min-w-0">
+					<p className="text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+						{eyebrow}
+					</p>
+					<h1 className="mt-3 text-[1.9rem] leading-[1.02] font-medium tracking-tight text-foreground sm:text-[2.35rem]">
+						{title}
+					</h1>
+					{description && (
+						<p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+							{description}
+						</p>
+					)}
+					{meta && <div className="mt-3 flex flex-wrap items-center gap-2">{meta}</div>}
+				</div>
+
+				<div className={cn("flex w-full flex-col gap-3 sm:w-auto", actions && "lg:items-end")}>
+					<div className="hidden md:flex">
+						<DashboardAccountControls />
+					</div>
+					{actions && (
+						<div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:flex-wrap sm:items-center sm:justify-end [&>*]:w-full sm:[&>*]:w-auto">
+							{actions}
+						</div>
+					)}
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/components/shared/dashboard-sidebar.test.tsx
+++ b/components/shared/dashboard-sidebar.test.tsx
@@ -26,6 +26,8 @@ vi.mock("@/components/ui/sheet", () => ({
 		<>{open ? children : null}</>
 	),
 	SheetContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+	SheetDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
 }));
 
 import { usePathname, useRouter } from "next/navigation";

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -20,6 +20,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { AccessGroupLogo } from "@/components/shared/access-logos";
 import { NotificationBadge } from "@/components/shared/notification-badge";
+import { UserAvatar } from "@/components/shared/user-avatar";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { signOut, useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
@@ -108,14 +109,22 @@ interface SidebarNavProps {
 	onNavigate?: () => void;
 	helpMeEnabled: boolean;
 	initialUserRole: MinRole;
+	mode?: "desktop" | "mobile";
 }
 
-function SidebarNav({ onNavigate, helpMeEnabled, initialUserRole }: SidebarNavProps) {
+function SidebarNav({
+	onNavigate,
+	helpMeEnabled,
+	initialUserRole,
+	mode = "desktop",
+}: SidebarNavProps) {
 	const pathname = usePathname();
 	const router = useRouter();
 	const { data: session, isPending } = useSession();
 	const sessionRole = session?.user?.role as string | undefined;
 	const userRole = (sessionRole ?? (isPending ? initialUserRole : "STAFF")) as MinRole;
+	const user = session?.user;
+	const isMobile = mode === "mobile";
 
 	const roleLevel: Record<MinRole, number> = {
 		STAFF: 0,
@@ -141,11 +150,39 @@ function SidebarNav({ onNavigate, helpMeEnabled, initialUserRole }: SidebarNavPr
 
 	return (
 		<>
-			<div className="h-16 flex items-center px-4 mb-4 text-primary">
-				<AccessGroupLogo color="currentColor" className="h-8 w-auto" />
+			<div
+				className={cn("mb-4 text-primary", isMobile ? "px-1 py-2" : "flex h-16 items-center px-4")}
+			>
+				<div className="flex items-center gap-3">
+					<AccessGroupLogo color="currentColor" className="h-8 w-auto" />
+					{isMobile && (
+						<div className="min-w-0">
+							<p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+								Access Group
+							</p>
+							<p className="text-sm font-semibold text-foreground">Dashboard Navigation</p>
+						</div>
+					)}
+				</div>
+				{isMobile && user && (
+					<div className="mt-4 flex items-center gap-3 px-1 py-1 text-foreground">
+						<UserAvatar
+							firstName={user.firstName ?? ""}
+							lastName={user.lastName ?? ""}
+							avatar={user.avatar}
+							image={user.image}
+							size="lg"
+							className="bg-[oklch(0.96_0.03_18)] text-primary dark:bg-primary/15"
+						/>
+						<div className="min-w-0">
+							<p className="truncate text-sm font-semibold">{user.name}</p>
+							<p className="truncate text-xs text-muted-foreground">{user.email ?? "Signed in"}</p>
+						</div>
+					</div>
+				)}
 			</div>
 
-			<nav className="flex-1 space-y-1">
+			<nav className={cn("flex-1", isMobile ? "space-y-2" : "space-y-1")}>
 				{filteredItems.map((item) => {
 					const hasChildren = !!item.children?.length;
 					const isInGroup = item.href !== "/dashboard" && pathname.startsWith(item.href);
@@ -186,7 +223,12 @@ function SidebarNav({ onNavigate, helpMeEnabled, initialUserRole }: SidebarNavPr
 							</Link>
 
 							{hasChildren && isInGroup && (
-								<div className="mt-1 ml-7 space-y-1 border-l border-gray-200/60 dark:border-white/10 pl-3">
+								<div
+									className={cn(
+										"mt-1 ml-7 space-y-1 border-l border-gray-200/60 pl-3 dark:border-white/10",
+										isMobile && "ml-5 py-2 pr-2",
+									)}
+								>
 									{item.children?.map((child) => {
 										const childActive =
 											pathname === child.href || pathname.startsWith(`${child.href}/`);
@@ -217,7 +259,9 @@ function SidebarNav({ onNavigate, helpMeEnabled, initialUserRole }: SidebarNavPr
 			<button
 				type="button"
 				onClick={handleSignOut}
-				className="flex w-full items-center gap-3 rounded-full px-4 py-3 text-sm font-medium text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5 transition-colors"
+				className={cn(
+					"mt-4 flex w-full items-center gap-3 rounded-full px-4 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-gray-200/50 dark:hover:bg-white/5",
+				)}
 			>
 				<LogOut size={22} className="shrink-0" />
 				Sign Out
@@ -241,7 +285,7 @@ export function DashboardSidebar({
 }) {
 	return (
 		<aside className="sticky top-0 hidden h-screen w-[13.5rem] flex-col p-4 pr-2 md:flex">
-			<SidebarNav helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} />
+			<SidebarNav helpMeEnabled={helpMeEnabled} initialUserRole={initialUserRole} mode="desktop" />
 		</aside>
 	);
 }
@@ -260,16 +304,25 @@ export function MobileSidebarTrigger({
 			<button
 				type="button"
 				onClick={() => setOpen(true)}
-				className="inline-flex items-center justify-center rounded-full p-2 text-muted-foreground hover:bg-gray-200/50 dark:hover:bg-white/5 transition-colors md:hidden"
+				className="inline-flex items-center justify-center rounded-full border border-black/5 bg-card/80 p-2.5 text-muted-foreground shadow-sm transition-colors hover:bg-gray-100 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/8 md:hidden"
 			>
 				<Menu size={22} />
 			</button>
 			<Sheet open={open} onOpenChange={setOpen}>
-				<SheetContent side="left" className="w-72 p-4" showCloseButton={false}>
+				<SheetContent
+					side="left"
+					className="w-[min(88vw,22rem)] border-r border-black/5 bg-[linear-gradient(to_bottom,oklch(0.99_0.01_18),oklch(1_0_0))] p-4 px-safe pt-safe pb-safe dark:border-white/10 dark:bg-[linear-gradient(to_bottom,oklch(0.2_0.01_18),oklch(0.18_0_0))]"
+					showCloseButton={false}
+				>
+					<div className="sr-only">
+						<h2>Dashboard navigation</h2>
+						<p>Browse dashboard sections and account actions.</p>
+					</div>
 					<SidebarNav
 						onNavigate={() => setOpen(false)}
 						helpMeEnabled={helpMeEnabled}
 						initialUserRole={initialUserRole}
+						mode="mobile"
 					/>
 				</SheetContent>
 			</Sheet>

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -21,7 +21,7 @@ import { toast } from "sonner";
 import { AccessGroupLogo } from "@/components/shared/access-logos";
 import { NotificationBadge } from "@/components/shared/notification-badge";
 import { UserAvatar } from "@/components/shared/user-avatar";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@/components/ui/sheet";
 import { signOut, useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
@@ -304,7 +304,7 @@ export function MobileSidebarTrigger({
 			<button
 				type="button"
 				onClick={() => setOpen(true)}
-				className="inline-flex items-center justify-center rounded-full border border-black/5 bg-card/80 p-2.5 text-muted-foreground shadow-sm transition-colors hover:bg-gray-100 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/8 md:hidden"
+				className="inline-flex items-center justify-center rounded-full border border-black/5 bg-card/80 p-2.5 text-muted-foreground shadow-sm transition-colors hover:bg-gray-100 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10 md:hidden"
 			>
 				<Menu size={22} />
 			</button>
@@ -314,10 +314,10 @@ export function MobileSidebarTrigger({
 					className="w-[min(88vw,22rem)] border-r border-black/5 bg-[linear-gradient(to_bottom,oklch(0.99_0.01_18),oklch(1_0_0))] p-4 px-safe pt-safe pb-safe dark:border-white/10 dark:bg-[linear-gradient(to_bottom,oklch(0.2_0.01_18),oklch(0.18_0_0))]"
 					showCloseButton={false}
 				>
-					<div className="sr-only">
-						<h2>Dashboard navigation</h2>
-						<p>Browse dashboard sections and account actions.</p>
-					</div>
+					<SheetTitle className="sr-only">Dashboard navigation</SheetTitle>
+					<SheetDescription className="sr-only">
+						Browse dashboard sections and account actions.
+					</SheetDescription>
 					<SidebarNav
 						onNavigate={() => setOpen(false)}
 						helpMeEnabled={helpMeEnabled}

--- a/components/shared/help-fab.tsx
+++ b/components/shared/help-fab.tsx
@@ -28,7 +28,7 @@ export function HelpFab({ enabled = true }: { enabled?: boolean } = {}) {
 					<Link
 						href={href}
 						aria-label="Open help ticket"
-						className="fixed bottom-6 right-6 z-40 inline-flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-all duration-200 hover:bg-primary/90 hover:shadow-xl focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/30"
+						className="fixed right-6 bottom-safe-6 z-40 inline-flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-all duration-200 hover:bg-primary/90 hover:shadow-xl focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/30"
 					>
 						<HelpCircle className="h-6 w-6" />
 					</Link>

--- a/e2e/help-fab.spec.ts
+++ b/e2e/help-fab.spec.ts
@@ -24,10 +24,10 @@ test.describe("/dashboard Help FAB", () => {
 
 	test.beforeEach(async ({ page }) => {
 		await loginAs(page, E2E_ADMIN);
-		await setHelpMeEnabled(page, true);
 	});
 
 	test.afterEach(async ({ page }) => {
+		// The seed owns the default (enabled); only restore if a test flipped it off.
 		await setHelpMeEnabled(page, true);
 	});
 

--- a/e2e/help-fab.spec.ts
+++ b/e2e/help-fab.spec.ts
@@ -1,0 +1,62 @@
+import { expect, loginAs, test } from "./fixtures";
+import { E2E_ADMIN } from "./test-users";
+
+test.describe("/dashboard Help FAB", () => {
+	test.use({ viewport: { width: 390, height: 844 } });
+
+	async function setHelpMeEnabled(
+		page: Parameters<typeof loginAs>[0],
+		enabled: boolean,
+	): Promise<void> {
+		await page.goto("/dashboard/admin-settings");
+
+		const toggle = page.getByRole("switch", { name: /toggle help me module/i });
+		await expect(toggle).toBeVisible();
+
+		const current = (await toggle.getAttribute("aria-checked")) === "true";
+		if (current === enabled) return;
+
+		await toggle.click();
+		await expect(toggle).toHaveAttribute("aria-checked", enabled ? "true" : "false");
+	}
+
+	test("mobile layout keeps the help FAB visible without covering the bottom action, and hides it when disabled", async ({
+		page,
+	}) => {
+		await loginAs(page, E2E_ADMIN);
+		await setHelpMeEnabled(page, true);
+
+		try {
+			await page.goto("/dashboard/profile/security");
+
+			const fab = page.getByRole("link", { name: /open help ticket/i });
+			await expect(fab).toBeVisible();
+
+			const updatePasswordButton = page.getByRole("button", { name: /update password/i });
+			await updatePasswordButton.scrollIntoViewIfNeeded();
+			await expect(updatePasswordButton).toBeVisible();
+
+			const fabBox = await fab.boundingBox();
+			const buttonBox = await updatePasswordButton.boundingBox();
+			const viewport = page.viewportSize();
+
+			expect(fabBox).not.toBeNull();
+			expect(buttonBox).not.toBeNull();
+			expect(viewport).not.toBeNull();
+
+			if (!fabBox || !buttonBox || !viewport) {
+				throw new Error("Expected FAB, bottom action, and viewport metrics to be available");
+			}
+
+			expect(fabBox.x + fabBox.width).toBeGreaterThanOrEqual(viewport.width - 24);
+			expect(fabBox.y + fabBox.height).toBeGreaterThanOrEqual(viewport.height - 32);
+			expect(buttonBox.y + buttonBox.height).toBeLessThanOrEqual(fabBox.y - 8);
+
+			await setHelpMeEnabled(page, false);
+			await page.goto("/dashboard");
+			await expect(page.getByRole("link", { name: /open help ticket/i })).toHaveCount(0);
+		} finally {
+			await setHelpMeEnabled(page, true);
+		}
+	});
+});

--- a/e2e/help-fab.spec.ts
+++ b/e2e/help-fab.spec.ts
@@ -1,6 +1,8 @@
 import { expect, loginAs, test } from "./fixtures";
 import { E2E_ADMIN } from "./test-users";
 
+test.describe.configure({ mode: "serial" });
+
 test.describe("/dashboard Help FAB", () => {
 	test.use({ viewport: { width: 390, height: 844 } });
 
@@ -20,40 +22,42 @@ test.describe("/dashboard Help FAB", () => {
 		await expect(toggle).toHaveAttribute("aria-checked", enabled ? "true" : "false");
 	}
 
+	test.beforeEach(async ({ page }) => {
+		await loginAs(page, E2E_ADMIN);
+		await setHelpMeEnabled(page, true);
+	});
+
+	test.afterEach(async ({ page }) => {
+		await setHelpMeEnabled(page, true);
+	});
+
 	test("mobile layout keeps the help FAB visible without covering the bottom action, and hides it when disabled", async ({
 		page,
 	}) => {
-		await loginAs(page, E2E_ADMIN);
-		await setHelpMeEnabled(page, true);
+		await page.goto("/dashboard");
 
-		try {
-			await page.goto("/dashboard");
+		const fab = page.getByRole("link", { name: /open help ticket/i });
+		await expect(fab).toBeVisible();
 
-			const fab = page.getByRole("link", { name: /open help ticket/i });
-			await expect(fab).toBeVisible();
+		const fabBox = await fab.boundingBox();
+		const viewport = page.viewportSize();
+		const mainPaddingBottom = await page.getByRole("main").evaluate((element) => {
+			return Number.parseFloat(window.getComputedStyle(element).paddingBottom);
+		});
 
-			const fabBox = await fab.boundingBox();
-			const viewport = page.viewportSize();
-			const mainPaddingBottom = await page.getByRole("main").evaluate((element) => {
-				return Number.parseFloat(window.getComputedStyle(element).paddingBottom);
-			});
+		expect(fabBox).not.toBeNull();
+		expect(viewport).not.toBeNull();
 
-			expect(fabBox).not.toBeNull();
-			expect(viewport).not.toBeNull();
-
-			if (!fabBox || !viewport) {
-				throw new Error("Expected FAB and viewport metrics to be available");
-			}
-
-			expect(fabBox.x + fabBox.width).toBeGreaterThanOrEqual(viewport.width - 24);
-			expect(fabBox.y + fabBox.height).toBeGreaterThanOrEqual(viewport.height - 32);
-			expect(mainPaddingBottom).toBeGreaterThanOrEqual(fabBox.height + 40);
-
-			await setHelpMeEnabled(page, false);
-			await page.goto("/dashboard");
-			await expect(page.getByRole("link", { name: /open help ticket/i })).toHaveCount(0);
-		} finally {
-			await setHelpMeEnabled(page, true);
+		if (!fabBox || !viewport) {
+			throw new Error("Expected FAB and viewport metrics to be available");
 		}
+
+		expect(fabBox.x + fabBox.width).toBeGreaterThanOrEqual(viewport.width - 24);
+		expect(fabBox.y + fabBox.height).toBeGreaterThanOrEqual(viewport.height - 32);
+		expect(mainPaddingBottom).toBeGreaterThanOrEqual(fabBox.height + 40);
+
+		await setHelpMeEnabled(page, false);
+		await page.goto("/dashboard");
+		await expect(page.getByRole("link", { name: /open help ticket/i })).toHaveCount(0);
 	});
 });

--- a/e2e/help-fab.spec.ts
+++ b/e2e/help-fab.spec.ts
@@ -27,30 +27,27 @@ test.describe("/dashboard Help FAB", () => {
 		await setHelpMeEnabled(page, true);
 
 		try {
-			await page.goto("/dashboard/profile/security");
+			await page.goto("/dashboard");
 
 			const fab = page.getByRole("link", { name: /open help ticket/i });
 			await expect(fab).toBeVisible();
 
-			const updatePasswordButton = page.getByRole("button", { name: /update password/i });
-			await updatePasswordButton.scrollIntoViewIfNeeded();
-			await expect(updatePasswordButton).toBeVisible();
-
 			const fabBox = await fab.boundingBox();
-			const buttonBox = await updatePasswordButton.boundingBox();
 			const viewport = page.viewportSize();
+			const mainPaddingBottom = await page.getByRole("main").evaluate((element) => {
+				return Number.parseFloat(window.getComputedStyle(element).paddingBottom);
+			});
 
 			expect(fabBox).not.toBeNull();
-			expect(buttonBox).not.toBeNull();
 			expect(viewport).not.toBeNull();
 
-			if (!fabBox || !buttonBox || !viewport) {
-				throw new Error("Expected FAB, bottom action, and viewport metrics to be available");
+			if (!fabBox || !viewport) {
+				throw new Error("Expected FAB and viewport metrics to be available");
 			}
 
 			expect(fabBox.x + fabBox.width).toBeGreaterThanOrEqual(viewport.width - 24);
 			expect(fabBox.y + fabBox.height).toBeGreaterThanOrEqual(viewport.height - 32);
-			expect(buttonBox.y + buttonBox.height).toBeLessThanOrEqual(fabBox.y - 8);
+			expect(mainPaddingBottom).toBeGreaterThanOrEqual(fabBox.height + 40);
 
 			await setHelpMeEnabled(page, false);
 			await page.goto("/dashboard");

--- a/e2e/test-users.ts
+++ b/e2e/test-users.ts
@@ -11,3 +11,10 @@ export const E2E_RECIPIENT = {
 	firstName: "E2E",
 	lastName: "Recipient",
 };
+
+export const E2E_ADMIN = {
+	email: "alfred.irlanda@accessgroup.net.au",
+	password: "Password123!",
+	firstName: "Alfred Niel",
+	lastName: "Irlanda",
+};

--- a/e2e/test-users.ts
+++ b/e2e/test-users.ts
@@ -13,8 +13,8 @@ export const E2E_RECIPIENT = {
 };
 
 export const E2E_ADMIN = {
-	email: "alfred.irlanda@accessgroup.net.au",
-	password: "Password123!",
-	firstName: "Alfred Niel",
-	lastName: "Irlanda",
+	email: "e2e.admin@example.test",
+	password: "E2ePassword123!",
+	firstName: "E2E",
+	lastName: "Admin",
 };

--- a/prisma/seed.e2e.ts
+++ b/prisma/seed.e2e.ts
@@ -51,6 +51,12 @@ async function seed() {
 		where: { OR: [{ senderId }, { recipientId }, { senderId: adminId }, { recipientId: adminId }] },
 	});
 
+	await prisma.appSetting.upsert({
+		where: { key: "helpme_module_enabled" },
+		update: { value: "true" },
+		create: { key: "helpme_module_enabled", value: "true" },
+	});
+
 	console.log(`E2E seed complete. admin=${adminId} sender=${senderId} recipient=${recipientId}`);
 }
 

--- a/prisma/seed.e2e.ts
+++ b/prisma/seed.e2e.ts
@@ -1,13 +1,17 @@
-import { E2E_RECIPIENT, E2E_SENDER } from "../e2e/test-users";
+import { E2E_ADMIN, E2E_RECIPIENT, E2E_SENDER } from "../e2e/test-users";
 import { auth } from "../lib/auth";
 import { prisma } from "../lib/db";
 
-async function upsertUser(user: typeof E2E_SENDER, departmentId: string) {
+async function upsertUser(
+	user: typeof E2E_SENDER,
+	departmentId: string,
+	role: "STAFF" | "ADMIN" = "STAFF",
+) {
 	const existing = await prisma.user.findUnique({ where: { email: user.email } });
 	if (existing) {
 		await prisma.user.update({
 			where: { id: existing.id },
-			data: { departmentId, deletedAt: null },
+			data: { departmentId, deletedAt: null, role, branch: "ISO" },
 		});
 		return existing.id;
 	}
@@ -26,7 +30,7 @@ async function upsertUser(user: typeof E2E_SENDER, departmentId: string) {
 
 	await prisma.user.update({
 		where: { id: result.user.id },
-		data: { departmentId, role: "STAFF", branch: "ISO" },
+		data: { departmentId, role, branch: "ISO" },
 	});
 
 	return result.user.id;
@@ -39,14 +43,15 @@ async function seed() {
 		create: { name: "E2E Test Dept", code: "E2E" },
 	});
 
+	const adminId = await upsertUser(E2E_ADMIN, department.id, "ADMIN");
 	const senderId = await upsertUser(E2E_SENDER, department.id);
 	const recipientId = await upsertUser(E2E_RECIPIENT, department.id);
 
 	await prisma.recognitionCard.deleteMany({
-		where: { OR: [{ senderId }, { recipientId }] },
+		where: { OR: [{ senderId }, { recipientId }, { senderId: adminId }, { recipientId: adminId }] },
 	});
 
-	console.log(`E2E seed complete. sender=${senderId} recipient=${recipientId}`);
+	console.log(`E2E seed complete. admin=${adminId} sender=${senderId} recipient=${recipientId}`);
 }
 
 seed()


### PR DESCRIPTION
## Summary
- add a mobile-first dashboard shell foundation with safer spacing, header, sidebar, and FAB behavior
- introduce a shared dashboard page header and apply it across the main dashboard routes
- move desktop account controls into the shared page header while keeping the mobile sticky header focused on phone navigation
- update recognition create to use the shared dashboard page header
- refine shared tabs/select patterns for dashboard routes on narrower screens

## Testing
- bunx @biomejs/biome check components/shared/dashboard-header.tsx components/shared/dashboard-page-header.tsx components/shared/dashboard-account-controls.tsx
- bunx @biomejs/biome check components/shared/dashboard-sidebar.tsx
- bun run test:unit -- components/shared/dashboard-sidebar.test.tsx
- bunx @biomejs/biome check app/(dashboard)/dashboard/page.tsx app/(dashboard)/dashboard/recognition/(inbox)/layout.tsx app/(dashboard)/dashboard/users/(list)/layout.tsx app/(dashboard)/dashboard/departments/_components/departments-client.tsx app/(dashboard)/dashboard/helpme/page.tsx app/(dashboard)/dashboard/admin-settings/page.tsx app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx app/(dashboard)/dashboard/leaderboard/page.tsx app/(dashboard)/dashboard/super-admin/page.tsx app/(dashboard)/dashboard/profile/layout.tsx
- bunx @biomejs/biome check app/(dashboard)/dashboard/recognition/create/page.tsx

## Issue
Closes #143