### PR TITLE
Fix dashboard recognition feed scrolling

### DIFF
--- a/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
@@ -62,7 +62,7 @@ export function RecognitionFeedWidget({ currentUserId, isAdmin }: RecognitionFee
 					))}
 				</div>
 			</div>
-			<div className="px-6 pb-6 overflow-y-auto max-h-[calc(100vh-12rem)]" role="tabpanel">
+			<div className="px-6 pb-6" role="tabpanel">
 				<RecognitionFeed
 					filter={activeTab}
 					showTitle={false}

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Calendar, Heart, Inbox, Lock, Medal, Send, Trophy } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primitives";
 import { UserAvatar } from "@/components/shared/user-avatar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -207,7 +207,7 @@ function StatItem({
 function StatsWidgetSkeleton() {
 	return (
 		<SkeletonCard
-			className="p-6 animate-pulse flex flex-col gap-6 h-full"
+			className="p-6 animate-pulse flex flex-col gap-6"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading recognition stats"
@@ -328,7 +328,7 @@ export function StatsWidget() {
 
 	if (isError || !data?.data) {
 		return (
-			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] h-full">
+			<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]">
 				<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight mb-2">
 					Recognition Stats
 				</h3>
@@ -346,7 +346,7 @@ export function StatsWidget() {
 	const showEmpty = resolvedVisibility.visible && stats.topRecipients.length === 0;
 
 	return (
-		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] flex flex-col gap-6 h-full">
+		<div className="rounded-[2rem] border border-gray-200/60 dark:border-white/10 bg-card p-6 shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] flex flex-col gap-6">
 			<h3 className="text-[1.25rem] font-medium text-foreground tracking-tight shrink-0">
 				Recognition Stats
 			</h3>
@@ -470,6 +470,47 @@ export function StatsWidget() {
 					</div>
 				</div>
 			) : null}
+		</div>
+	);
+}
+
+export function StickyStatsWidget() {
+	const widgetRef = useRef<HTMLDivElement>(null);
+	const [stickyTop, setStickyTop] = useState(32);
+
+	useEffect(() => {
+		const widget = widgetRef.current;
+		if (!widget) return;
+
+		const updateStickyOffset = () => {
+			const viewportHeight = window.innerHeight;
+			const widgetHeight = widget.offsetHeight;
+			const offset = 32;
+			const nextTop =
+				widgetHeight + offset * 2 > viewportHeight
+					? viewportHeight - widgetHeight - offset
+					: offset;
+
+			setStickyTop(nextTop);
+		};
+
+		updateStickyOffset();
+
+		const resizeObserver =
+			typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updateStickyOffset);
+
+		resizeObserver?.observe(widget);
+		window.addEventListener("resize", updateStickyOffset);
+
+		return () => {
+			resizeObserver?.disconnect();
+			window.removeEventListener("resize", updateStickyOffset);
+		};
+	}, []);
+
+	return (
+		<div ref={widgetRef} className="lg:sticky" style={{ top: stickyTop }}>
+			<StatsWidget />
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -463,7 +463,7 @@ export function StatsWidget() {
 						<Trophy size={16} className="text-primary" />
 						<h4 className="text-sm font-medium text-foreground/70">Most Recognized</h4>
 					</div>
-					<div className="flex items-center justify-center rounded-2xl border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-6 py-8 text-center">
+					<div className="flex min-h-48 items-center justify-center rounded-2xl border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-6 py-8 text-center">
 						<p className="text-sm text-muted-foreground">
 							No recognitions yet this month — be the first!
 						</p>
@@ -483,7 +483,7 @@ export function StickyStatsWidget() {
 		if (!widget) return;
 
 		const updateStickyOffset = () => {
-			const viewportHeight = window.innerHeight;
+			const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
 			const widgetHeight = widget.offsetHeight;
 			const offset = 32;
 			// Negative top is intentional for tall cards: it lets the card scroll
@@ -502,11 +502,16 @@ export function StickyStatsWidget() {
 			typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updateStickyOffset);
 
 		resizeObserver?.observe(widget);
+		const viewport = window.visualViewport;
 		window.addEventListener("resize", updateStickyOffset);
+		viewport?.addEventListener("resize", updateStickyOffset);
+		viewport?.addEventListener("scroll", updateStickyOffset);
 
 		return () => {
 			resizeObserver?.disconnect();
 			window.removeEventListener("resize", updateStickyOffset);
+			viewport?.removeEventListener("resize", updateStickyOffset);
+			viewport?.removeEventListener("scroll", updateStickyOffset);
 		};
 	}, []);
 

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -32,6 +32,9 @@ const PODIUM_STYLES = [
 	},
 ] as const;
 
+const STATS_STICKY_OFFSET = 32;
+const STATS_STICKY_BREAKPOINT_QUERY = "(min-width: 1024px)";
+
 type LeaderboardVisibilityMode = "always" | "last_n_days_of_month" | "custom_range";
 
 interface LeaderboardVisibility {
@@ -476,42 +479,68 @@ export function StatsWidget() {
 
 export function StickyStatsWidget() {
 	const widgetRef = useRef<HTMLDivElement>(null);
-	const [stickyTop, setStickyTop] = useState(32);
+	const [stickyTop, setStickyTop] = useState(STATS_STICKY_OFFSET);
 
 	useEffect(() => {
 		const widget = widgetRef.current;
 		if (!widget) return;
 
+		const breakpoint = window.matchMedia(STATS_STICKY_BREAKPOINT_QUERY);
+		let resizeObserver: ResizeObserver | null = null;
+		let viewport: VisualViewport | null | undefined;
+
 		const updateStickyOffset = () => {
 			const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
 			const widgetHeight = widget.offsetHeight;
-			const offset = 32;
 			// Negative top is intentional for tall cards: it lets the card scroll
 			// until its bottom is visible, then stick while the feed continues.
 			const nextTop =
-				widgetHeight + offset * 2 > viewportHeight
-					? viewportHeight - widgetHeight - offset
-					: offset;
+				widgetHeight + STATS_STICKY_OFFSET * 2 > viewportHeight
+					? viewportHeight - widgetHeight - STATS_STICKY_OFFSET
+					: STATS_STICKY_OFFSET;
 
 			setStickyTop(nextTop);
 		};
 
-		updateStickyOffset();
-
-		const resizeObserver =
-			typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updateStickyOffset);
-
-		resizeObserver?.observe(widget);
-		const viewport = window.visualViewport;
-		window.addEventListener("resize", updateStickyOffset);
-		viewport?.addEventListener("resize", updateStickyOffset);
-		viewport?.addEventListener("scroll", updateStickyOffset);
-
-		return () => {
+		const teardownStickyMeasurement = () => {
 			resizeObserver?.disconnect();
+			resizeObserver = null;
 			window.removeEventListener("resize", updateStickyOffset);
 			viewport?.removeEventListener("resize", updateStickyOffset);
-			viewport?.removeEventListener("scroll", updateStickyOffset);
+			viewport = undefined;
+		};
+
+		const setupStickyMeasurement = () => {
+			updateStickyOffset();
+
+			resizeObserver =
+				typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updateStickyOffset);
+
+			resizeObserver?.observe(widget);
+			viewport = window.visualViewport;
+			window.addEventListener("resize", updateStickyOffset);
+			viewport?.addEventListener("resize", updateStickyOffset);
+		};
+
+		const handleBreakpointChange = (event: MediaQueryListEvent) => {
+			teardownStickyMeasurement();
+
+			if (event.matches) {
+				setupStickyMeasurement();
+			} else {
+				setStickyTop(STATS_STICKY_OFFSET);
+			}
+		};
+
+		if (breakpoint.matches) {
+			setupStickyMeasurement();
+		}
+
+		breakpoint.addEventListener("change", handleBreakpointChange);
+
+		return () => {
+			teardownStickyMeasurement();
+			breakpoint.removeEventListener("change", handleBreakpointChange);
 		};
 	}, []);
 

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -230,8 +230,8 @@ function StatsWidgetSkeleton() {
 					</div>
 				))}
 			</div>
-			<div className="flex flex-col min-h-0 flex-1">
-				<div className="flex items-center gap-2 mb-3 shrink-0">
+			<div>
+				<div className="flex items-center gap-2 mb-3">
 					<SkeletonLine className="h-4 w-4 rounded" />
 					<SkeletonLine className="h-4 w-32" />
 				</div>
@@ -267,12 +267,12 @@ function LockedLeaderboard({
 	const showCountdown = msRemaining !== null && msRemaining > 0;
 
 	return (
-		<div className="flex flex-col min-h-0 flex-1">
-			<div className="flex items-center gap-2 mb-3 shrink-0">
+		<div>
+			<div className="flex items-center gap-2 mb-3">
 				<Lock size={16} className="text-muted-foreground" />
 				<h4 className="text-sm font-medium text-foreground/70">Most Recognized</h4>
 			</div>
-			<div className="flex flex-1 flex-col items-center justify-center rounded-2xl border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-6 py-8 text-center">
+			<div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-6 py-8 text-center">
 				<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 mb-3">
 					<Lock size={18} className="text-primary" />
 				</div>
@@ -394,12 +394,12 @@ export function StatsWidget() {
 			</div>
 
 			{showList ? (
-				<div className="flex flex-col min-h-0 flex-1">
-					<div className="flex items-center gap-2 mb-3 shrink-0">
+				<div>
+					<div className="flex items-center gap-2 mb-3">
 						<Trophy size={16} className="text-primary" />
 						<h4 className="text-sm font-medium text-foreground/70">Most Recognized</h4>
 					</div>
-					<ol className="space-y-2 overflow-y-auto pr-1 flex-1 min-h-0">
+					<ol className="space-y-2">
 						{stats.topRecipients.map((person, index) => {
 							const isPodium = index < 3;
 							const style = isPodium ? PODIUM_STYLES[index] : null;
@@ -458,12 +458,12 @@ export function StatsWidget() {
 			) : showLocked ? (
 				<LockedLeaderboard visibility={resolvedVisibility} msRemaining={msRemaining} />
 			) : showEmpty ? (
-				<div className="flex flex-col min-h-0 flex-1">
-					<div className="flex items-center gap-2 mb-3 shrink-0">
+				<div>
+					<div className="flex items-center gap-2 mb-3">
 						<Trophy size={16} className="text-primary" />
 						<h4 className="text-sm font-medium text-foreground/70">Most Recognized</h4>
 					</div>
-					<div className="flex flex-1 items-center justify-center rounded-2xl border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-6 py-8 text-center">
+					<div className="flex items-center justify-center rounded-2xl border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-6 py-8 text-center">
 						<p className="text-sm text-muted-foreground">
 							No recognitions yet this month — be the first!
 						</p>
@@ -486,6 +486,8 @@ export function StickyStatsWidget() {
 			const viewportHeight = window.innerHeight;
 			const widgetHeight = widget.offsetHeight;
 			const offset = 32;
+			// Negative top is intentional for tall cards: it lets the card scroll
+			// until its bottom is visible, then stick while the feed continues.
 			const nextTop =
 				widgetHeight + offset * 2 > viewportHeight
 					? viewportHeight - widgetHeight - offset

--- a/app/(dashboard)/dashboard/loading.tsx
+++ b/app/(dashboard)/dashboard/loading.tsx
@@ -50,34 +50,36 @@ export default function DashboardLoading() {
 				</SkeletonCard>
 
 				{/* Stats widget skeleton */}
-				<SkeletonCard className="order-1 h-full space-y-6 p-6 lg:order-2">
-					<SkeletonLine className="h-6 w-40" />
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-						{["s0", "s1", "s2"].map((key) => (
-							<div key={key} className="flex items-center gap-3">
-								<SkeletonLine className="h-10 w-10 rounded-full" />
-								<div className="space-y-1">
-									<SkeletonLine className="h-6 w-8" />
-									<SkeletonLine className="h-3 w-16" />
+				<div className="order-1 lg:order-2">
+					<SkeletonCard className="space-y-6 p-6 lg:sticky lg:top-8">
+						<SkeletonLine className="h-6 w-40" />
+						<div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+							{["s0", "s1", "s2"].map((key) => (
+								<div key={key} className="flex items-center gap-3">
+									<SkeletonLine className="h-10 w-10 rounded-full" />
+									<div className="space-y-1">
+										<SkeletonLine className="h-6 w-8" />
+										<SkeletonLine className="h-3 w-16" />
+									</div>
 								</div>
-							</div>
-						))}
-					</div>
-					<div className="space-y-3">
-						<SkeletonLine className="h-4 w-36" />
-						{["u0", "u1", "u2"].map((key) => (
-							<div
-								key={key}
-								className="flex items-center gap-3 rounded-xl border border-gray-200/60 dark:border-white/10 px-3 py-2.5"
-							>
-								<SkeletonLine className="h-[18px] w-[18px] rounded-full" />
-								<SkeletonLine className="h-8 w-8 rounded-full" />
-								<SkeletonLine className="h-4 w-24 flex-1" />
-								<SkeletonLine className="h-5 w-8 rounded-full" />
-							</div>
-						))}
-					</div>
-				</SkeletonCard>
+							))}
+						</div>
+						<div className="space-y-3">
+							<SkeletonLine className="h-4 w-36" />
+							{["u0", "u1", "u2"].map((key) => (
+								<div
+									key={key}
+									className="flex items-center gap-3 rounded-xl border border-gray-200/60 dark:border-white/10 px-3 py-2.5"
+								>
+									<SkeletonLine className="h-[18px] w-[18px] rounded-full" />
+									<SkeletonLine className="h-8 w-8 rounded-full" />
+									<SkeletonLine className="h-4 w-24 flex-1" />
+									<SkeletonLine className="h-5 w-8 rounded-full" />
+								</div>
+							))}
+						</div>
+					</SkeletonCard>
+				</div>
 			</div>
 		</div>
 	);

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -5,7 +5,7 @@ import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { getServerSession } from "@/lib/auth-utils";
 import { getUserRole, hasMinRole } from "@/lib/permissions";
 import { RecognitionFeedWidget } from "./_components/recognition-feed-widget";
-import { StatsWidget } from "./_components/stats-widget";
+import { StickyStatsWidget } from "./_components/stats-widget";
 
 export default async function DashboardPage() {
 	const session = await getServerSession();
@@ -37,7 +37,7 @@ export default async function DashboardPage() {
 					<RecognitionFeedWidget currentUserId={user.id} isAdmin={isAdmin} />
 				</div>
 				<div className="order-1 lg:order-2">
-					<StatsWidget />
+					<StickyStatsWidget />
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- let the dashboard recognition feed use native browser/page scrolling
- keep Recognition Stats visible with a measured sticky offset after the widget bottom enters the viewport
- align the loading skeleton with the updated dashboard layout

## Verification
- bun run lint

Closes #145