### PR TITLE
Optimise recognition feed: limit + cursor pagination (closes #147)

### DIFF
--- a/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
@@ -71,6 +71,7 @@ export function RecognitionFeedWidget({ currentUserId, isAdmin }: RecognitionFee
 					emptyTitle={currentTab.emptyTitle}
 					emptyDescription={currentTab.emptyDescription}
 					limit={10}
+					infinite
 				/>
 			</div>
 		</div>

--- a/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/recognition-feed-widget.tsx
@@ -70,6 +70,7 @@ export function RecognitionFeedWidget({ currentUserId, isAdmin }: RecognitionFee
 					isAdmin={isAdmin}
 					emptyTitle={currentTab.emptyTitle}
 					emptyDescription={currentTab.emptyDescription}
+					limit={10}
 				/>
 			</div>
 		</div>

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed-client.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed-client.tsx
@@ -33,6 +33,8 @@ export function RecognitionFeedClient({
 				emptyTitle={emptyTitle}
 				emptyDescription={emptyDescription}
 				onShare={setShareCardId}
+				limit={10}
+				infinite
 			/>
 			<ShareDialog
 				open={!!shareCardId}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.test.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.test.tsx
@@ -21,8 +21,9 @@ vi.mock("./recognition-card-mini", () => ({
 	RecognitionCardMini: () => <div />,
 }));
 
+const intersectingState = { current: false };
 vi.mock("@/hooks/use-intersection-observer", () => ({
-	useIntersectionObserver: () => ({ ref: () => {}, isIntersecting: false }),
+	useIntersectionObserver: () => ({ ref: () => {}, isIntersecting: intersectingState.current }),
 }));
 
 import { RecognitionFeed } from "./recognition-feed";
@@ -50,6 +51,7 @@ const fetchMock = vi.fn();
 
 beforeEach(() => {
 	fetchMock.mockReset();
+	intersectingState.current = false;
 	vi.stubGlobal("fetch", fetchMock);
 });
 
@@ -154,6 +156,46 @@ describe("RecognitionFeed (infinite)", () => {
 					?.status,
 			).toBe("error"),
 		);
+	});
+
+	test("auto-fetches next page when sentinel intersects after a user scroll", async () => {
+		fetchMock
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					data: [makeCard("a"), makeCard("b")],
+					nextCursor: "b",
+				}),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					data: [makeCard("c")],
+					nextCursor: null,
+				}),
+			});
+
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(<RecognitionFeed filter="received" limit={2} infinite />, { wrapper: wrapper(client) });
+		await waitFor(() => expect(screen.getByText("message a")).toBeInTheDocument());
+
+		// Sentinel is in view but user hasn't scrolled yet — no second fetch.
+		await act(async () => {
+			intersectingState.current = true;
+			window.dispatchEvent(new Event("resize"));
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		// First user scroll flips the gate; sentinel still intersecting → fetch fires.
+		await act(async () => {
+			window.dispatchEvent(new Event("scroll"));
+		});
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+		const secondCall = fetchMock.mock.calls[1]?.[0] as string;
+		expect(secondCall).toContain("cursor=b");
 	});
 
 	test("hides Load more when nextCursor is null on first page", async () => {

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.test.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.test.tsx
@@ -1,0 +1,133 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/hooks/use-unread-card-ids", () => ({
+	useUnreadCardIds: () => ({ unreadCardIds: new Set<string>() }),
+}));
+
+vi.mock("@/stores/use-preferences-store", () => ({
+	usePreferencesStore: (selector: (s: { cardView: string; cardSize: string }) => unknown) =>
+		selector({ cardView: "list", cardSize: "md" }),
+}));
+
+vi.mock("./card-interaction-bar", () => ({
+	CardInteractionBar: () => <div data-testid="interaction-bar" />,
+}));
+
+vi.mock("./recognition-card-mini", () => ({
+	RecognitionCardMini: () => <div />,
+}));
+
+vi.mock("@/hooks/use-intersection-observer", () => ({
+	useIntersectionObserver: () => ({ ref: () => {}, isIntersecting: false }),
+}));
+
+import { RecognitionFeed } from "./recognition-feed";
+
+function makeCard(id: string) {
+	return {
+		id,
+		message: `message ${id}`,
+		date: "2026-04-22T00:00:00.000Z",
+		createdAt: "2026-04-22T00:00:00.000Z",
+		sender: { id: "s", firstName: "Sa", lastName: "Se", avatar: null, position: null },
+		recipient: { id: "r", firstName: "Re", lastName: "Ri", avatar: null, position: null },
+		interactionCounts: { reactions: 0, comments: 0 },
+		reactionSummary: [],
+	};
+}
+
+function wrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+	fetchMock.mockReset();
+	vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+});
+
+describe("RecognitionFeed (infinite)", () => {
+	test("loads first page and renders Load more when nextCursor present", async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				success: true,
+				data: [makeCard("a"), makeCard("b")],
+				nextCursor: "b",
+			}),
+		});
+
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(<RecognitionFeed filter="received" limit={2} infinite />, { wrapper: wrapper(client) });
+
+		await waitFor(() => expect(screen.getByText("message a")).toBeInTheDocument());
+		expect(screen.getByRole("button", { name: /load more/i })).toBeInTheDocument();
+
+		const call = fetchMock.mock.calls[0]?.[0] as string;
+		expect(call).toContain("filter=received");
+		expect(call).toContain("limit=2");
+		expect(call).not.toContain("cursor=");
+	});
+
+	test("clicking Load more appends next page with cursor", async () => {
+		fetchMock
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					data: [makeCard("a"), makeCard("b")],
+					nextCursor: "b",
+				}),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({
+					success: true,
+					data: [makeCard("c")],
+					nextCursor: null,
+				}),
+			});
+
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(<RecognitionFeed filter="received" limit={2} infinite />, { wrapper: wrapper(client) });
+
+		await waitFor(() => expect(screen.getByText("message a")).toBeInTheDocument());
+		await act(async () => {
+			await userEvent.click(screen.getByRole("button", { name: /load more/i }));
+		});
+		await waitFor(() => expect(screen.getByText("message c")).toBeInTheDocument());
+
+		expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+		const secondCall = fetchMock.mock.calls[1]?.[0] as string;
+		expect(secondCall).toContain("cursor=b");
+	});
+
+	test("hides Load more when nextCursor is null on first page", async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				success: true,
+				data: [makeCard("a")],
+				nextCursor: null,
+			}),
+		});
+
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(<RecognitionFeed filter="sent" limit={10} infinite />, { wrapper: wrapper(client) });
+
+		await waitFor(() => expect(screen.getByText("message a")).toBeInTheDocument());
+		expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+	});
+});

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.test.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.test.tsx
@@ -58,6 +58,30 @@ afterEach(() => {
 	vi.unstubAllGlobals();
 });
 
+describe("RecognitionFeed (static)", () => {
+	test("fetches once, forwards limit, and renders no Load more", async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				success: true,
+				data: [makeCard("a")],
+				nextCursor: null,
+			}),
+		});
+
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(<RecognitionFeed filter="all" limit={25} />, { wrapper: wrapper(client) });
+
+		await waitFor(() => expect(screen.getByText("message a")).toBeInTheDocument());
+		expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+
+		const call = fetchMock.mock.calls[0]?.[0] as string;
+		expect(call).toContain("limit=25");
+		expect(call).not.toContain("filter=all");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});
+
 describe("RecognitionFeed (infinite)", () => {
 	test("loads first page and renders Load more when nextCursor present", async () => {
 		fetchMock.mockResolvedValueOnce({
@@ -112,6 +136,24 @@ describe("RecognitionFeed (infinite)", () => {
 		expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
 		const secondCall = fetchMock.mock.calls[1]?.[0] as string;
 		expect(secondCall).toContain("cursor=b");
+	});
+
+	test("throws when body.success is false (consistent error envelope)", async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ success: false, error: "nope" }),
+		});
+
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(<RecognitionFeed filter="received" limit={5} infinite />, { wrapper: wrapper(client) });
+
+		// Query errors cause isPending to finish without populating data; skeletons linger on error.
+		await waitFor(() =>
+			expect(
+				client.getQueryState(["recognition-cards", "received", { limit: 5, infinite: true }])
+					?.status,
+			).toBe("error"),
+		);
 	});
 
 	test("hides Load more when nextCursor is null on first page", async () => {

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { type InfiniteData, useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { ArrowRight, Eye, Heart, Pencil, Share2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
@@ -21,6 +21,14 @@ interface FeedPage {
 	success: boolean;
 	data: RecognitionCard[];
 	nextCursor: string | null;
+}
+
+async function fetchFeedPage(url: string): Promise<FeedPage> {
+	const res = await fetch(url);
+	if (!res.ok) throw new Error("Failed to fetch recognition cards");
+	const body = (await res.json()) as FeedPage;
+	if (!body.success) throw new Error("Failed to fetch recognition cards");
+	return body;
 }
 
 function buildFeedUrl(filter: FeedFilter, limit: number, cursor?: string | null) {
@@ -152,11 +160,7 @@ function RecognitionFeedStatic({
 }: RecognitionFeedProps) {
 	const { data, isPending } = useQuery<FeedPage>({
 		queryKey: ["recognition-cards", filter, { limit, infinite: false }],
-		queryFn: async () => {
-			const res = await fetch(buildFeedUrl(filter, limit));
-			if (!res.ok) throw new Error("Failed to fetch recognition cards");
-			return res.json();
-		},
+		queryFn: () => fetchFeedPage(buildFeedUrl(filter, limit)),
 		staleTime: 30_000,
 	});
 
@@ -194,17 +198,13 @@ function RecognitionFeedInfinite({
 	const { data, isPending, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery<
 		FeedPage,
 		Error,
-		{ pages: FeedPage[] },
+		InfiniteData<FeedPage>,
 		readonly unknown[],
 		string | null
 	>({
 		queryKey: ["recognition-cards", filter, { limit, infinite: true }],
 		initialPageParam: null,
-		queryFn: async ({ pageParam }) => {
-			const res = await fetch(buildFeedUrl(filter, limit, pageParam));
-			if (!res.ok) throw new Error("Failed to fetch recognition cards");
-			return res.json();
-		},
+		queryFn: ({ pageParam }) => fetchFeedPage(buildFeedUrl(filter, limit, pageParam)),
 		getNextPageParam: (last) => last.nextCursor ?? undefined,
 		staleTime: 30_000,
 	});

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -1,16 +1,36 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { ArrowRight, Eye, Heart, Pencil, Share2 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primitives";
 import { UserAvatar } from "@/components/shared/user-avatar";
+import { Button } from "@/components/ui/button";
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useUnreadCardIds } from "@/hooks/use-unread-card-ids";
 import { formatRecognitionDate, getSelectedValues, type RecognitionCard } from "@/lib/recognition";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/stores/use-preferences-store";
 import { CardInteractionBar } from "./card-interaction-bar";
 import { RecognitionCardMini } from "./recognition-card-mini";
+
+type FeedFilter = "all" | "received" | "sent" | "department";
+
+interface FeedPage {
+	success: boolean;
+	data: RecognitionCard[];
+	nextCursor: string | null;
+}
+
+function buildFeedUrl(filter: FeedFilter, limit: number, cursor?: string | null) {
+	const params = new URLSearchParams();
+	if (filter !== "all") params.set("filter", filter);
+	params.set("limit", String(limit));
+	if (cursor) params.set("cursor", cursor);
+	const query = params.toString();
+	return `/api/recognition${query ? `?${query}` : ""}`;
+}
 
 function CardSkeleton() {
 	return (
@@ -100,7 +120,7 @@ function CardActions({
 }
 
 interface RecognitionFeedProps {
-	filter?: "all" | "received" | "sent" | "department";
+	filter?: FeedFilter;
 	showTitle?: boolean;
 	showActions?: boolean;
 	currentUserId?: string;
@@ -109,9 +129,16 @@ interface RecognitionFeedProps {
 	emptyTitle?: string;
 	emptyDescription?: string;
 	onShare?: (cardId: string) => void;
+	limit?: number;
+	infinite?: boolean;
 }
 
-export function RecognitionFeed({
+export function RecognitionFeed(props: RecognitionFeedProps) {
+	if (props.infinite) return <RecognitionFeedInfinite {...props} />;
+	return <RecognitionFeedStatic {...props} />;
+}
+
+function RecognitionFeedStatic({
 	filter = "all",
 	showTitle = true,
 	showActions = false,
@@ -121,19 +148,12 @@ export function RecognitionFeed({
 	emptyTitle = "No recognition cards yet",
 	emptyDescription = "Be the first to recognize a colleague!",
 	onShare,
+	limit = 50,
 }: RecognitionFeedProps) {
-	const cardView = usePreferencesStore((s) => s.cardView);
-	const cardSize = usePreferencesStore((s) => s.cardSize);
-	const { unreadCardIds } = useUnreadCardIds(filter === "received");
-	const queryParam = filter !== "all" ? `?filter=${filter}` : "";
-
-	const { data, isPending } = useQuery<{
-		success: boolean;
-		data: RecognitionCard[];
-	}>({
-		queryKey: ["recognition-cards", filter],
+	const { data, isPending } = useQuery<FeedPage>({
+		queryKey: ["recognition-cards", filter, { limit, infinite: false }],
 		queryFn: async () => {
-			const res = await fetch(`/api/recognition${queryParam}`);
+			const res = await fetch(buildFeedUrl(filter, limit));
 			if (!res.ok) throw new Error("Failed to fetch recognition cards");
 			return res.json();
 		},
@@ -141,6 +161,136 @@ export function RecognitionFeed({
 	});
 
 	const cards = data?.data ?? [];
+
+	return (
+		<FeedLayout
+			filter={filter}
+			showTitle={showTitle}
+			showActions={showActions}
+			currentUserId={currentUserId}
+			isAdmin={isAdmin}
+			cardMaxWidth={cardMaxWidth}
+			emptyTitle={emptyTitle}
+			emptyDescription={emptyDescription}
+			onShare={onShare}
+			cards={cards}
+			isPending={isPending}
+		/>
+	);
+}
+
+function RecognitionFeedInfinite({
+	filter = "all",
+	showTitle = true,
+	showActions = false,
+	currentUserId = "",
+	isAdmin = false,
+	cardMaxWidth,
+	emptyTitle = "No recognition cards yet",
+	emptyDescription = "Be the first to recognize a colleague!",
+	onShare,
+	limit = 10,
+}: RecognitionFeedProps) {
+	const { data, isPending, hasNextPage, isFetchingNextPage, fetchNextPage } = useInfiniteQuery<
+		FeedPage,
+		Error,
+		{ pages: FeedPage[] },
+		readonly unknown[],
+		string | null
+	>({
+		queryKey: ["recognition-cards", filter, { limit, infinite: true }],
+		initialPageParam: null,
+		queryFn: async ({ pageParam }) => {
+			const res = await fetch(buildFeedUrl(filter, limit, pageParam));
+			if (!res.ok) throw new Error("Failed to fetch recognition cards");
+			return res.json();
+		},
+		getNextPageParam: (last) => last.nextCursor ?? undefined,
+		staleTime: 30_000,
+	});
+
+	const cards = data?.pages.flatMap((p) => p.data) ?? [];
+
+	const { ref: sentinelRef, isIntersecting } = useIntersectionObserver({
+		enabled: !!hasNextPage && !isFetchingNextPage,
+	});
+
+	useEffect(() => {
+		if (isIntersecting && hasNextPage && !isFetchingNextPage) {
+			fetchNextPage();
+		}
+	}, [isIntersecting, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+	return (
+		<FeedLayout
+			filter={filter}
+			showTitle={showTitle}
+			showActions={showActions}
+			currentUserId={currentUserId}
+			isAdmin={isAdmin}
+			cardMaxWidth={cardMaxWidth}
+			emptyTitle={emptyTitle}
+			emptyDescription={emptyDescription}
+			onShare={onShare}
+			cards={cards}
+			isPending={isPending}
+			footer={
+				hasNextPage ? (
+					<>
+						<div ref={sentinelRef} aria-hidden className="h-px w-full" />
+						{isFetchingNextPage ? (
+							<CardSkeleton />
+						) : (
+							<div className="flex justify-center pt-2">
+								<Button
+									type="button"
+									variant="outline"
+									onClick={() => fetchNextPage()}
+									disabled={isFetchingNextPage}
+								>
+									Load more
+								</Button>
+							</div>
+						)}
+					</>
+				) : null
+			}
+		/>
+	);
+}
+
+interface FeedLayoutProps {
+	filter: FeedFilter;
+	showTitle: boolean;
+	showActions: boolean;
+	currentUserId: string;
+	isAdmin: boolean;
+	cardMaxWidth?: string;
+	emptyTitle: string;
+	emptyDescription: string;
+	onShare?: (cardId: string) => void;
+	cards: RecognitionCard[];
+	isPending: boolean;
+	footer?: React.ReactNode;
+}
+
+function FeedLayout({
+	filter,
+	showTitle,
+	showActions,
+	currentUserId,
+	isAdmin,
+	cardMaxWidth,
+	emptyTitle,
+	emptyDescription,
+	onShare,
+	cards,
+	isPending,
+	footer,
+}: FeedLayoutProps) {
+	const cardView = usePreferencesStore((s) => s.cardView);
+	const cardSize = usePreferencesStore((s) => s.cardSize);
+	const { unreadCardIds } = useUnreadCardIds(filter === "received");
 
 	const handleShare = (cardId: string) => {
 		onShare?.(cardId);
@@ -295,6 +445,7 @@ export function RecognitionFeed({
 					</div>
 				);
 			})}
+			{footer}
 		</div>
 	);
 }

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -211,9 +211,7 @@ function RecognitionFeedInfinite({
 
 	const cards = data?.pages.flatMap((p) => p.data) ?? [];
 
-	const { ref: sentinelRef, isIntersecting } = useIntersectionObserver({
-		enabled: !!hasNextPage && !isFetchingNextPage,
-	});
+	const { ref: sentinelRef, isIntersecting } = useIntersectionObserver();
 
 	useEffect(() => {
 		if (isIntersecting && hasNextPage && !isFetchingNextPage) {
@@ -237,7 +235,7 @@ function RecognitionFeedInfinite({
 			footer={
 				hasNextPage ? (
 					<>
-						<div ref={sentinelRef} aria-hidden className="h-px w-full" />
+						<div ref={sentinelRef} aria-hidden className="h-10 w-full" />
 						{isFetchingNextPage ? (
 							<CardSkeleton />
 						) : (

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -40,15 +40,19 @@ function buildFeedUrl(filter: FeedFilter, limit: number, cursor?: string | null)
 	return `/api/recognition${query ? `?${query}` : ""}`;
 }
 
-function AutoCardSkeleton() {
+function AutoCardSkeleton({ cardMaxWidth }: { cardMaxWidth?: string }) {
 	const cardView = usePreferencesStore((s) => s.cardView);
-	return cardView === "physical" ? <PhysicalCardSkeleton /> : <ListCardSkeleton />;
+	return cardView === "physical" ? (
+		<PhysicalCardSkeleton cardMaxWidth={cardMaxWidth} />
+	) : (
+		<ListCardSkeleton cardMaxWidth={cardMaxWidth} />
+	);
 }
 
-function PhysicalCardSkeleton() {
+function PhysicalCardSkeleton({ cardMaxWidth }: { cardMaxWidth?: string }) {
 	return (
 		<SkeletonCard
-			className="p-0 overflow-hidden animate-pulse"
+			className={cn("p-0 overflow-hidden animate-pulse", cardMaxWidth)}
 			role="status"
 			aria-busy="true"
 			aria-label="Loading recognition card"
@@ -88,10 +92,10 @@ function PhysicalCardSkeleton() {
 	);
 }
 
-function ListCardSkeleton() {
+function ListCardSkeleton({ cardMaxWidth }: { cardMaxWidth?: string }) {
 	return (
 		<SkeletonCard
-			className="p-6 animate-pulse"
+			className={cn("p-6 animate-pulse", cardMaxWidth)}
 			role="status"
 			aria-busy="true"
 			aria-label="Loading recognition card"
@@ -295,7 +299,7 @@ function RecognitionFeedInfinite({
 					<>
 						<div ref={sentinelRef} aria-hidden className="h-10 w-full" />
 						{isFetchingNextPage ? (
-							<AutoCardSkeleton />
+							<AutoCardSkeleton cardMaxWidth={cardMaxWidth} />
 						) : (
 							<div className="flex justify-center pt-2">
 								<Button
@@ -362,9 +366,9 @@ function FeedLayout({
 						Recent Recognitions
 					</h3>
 				)}
-				<Skeleton />
-				<Skeleton />
-				<Skeleton />
+				<Skeleton cardMaxWidth={cardMaxWidth} />
+				<Skeleton cardMaxWidth={cardMaxWidth} />
+				<Skeleton cardMaxWidth={cardMaxWidth} />
 			</div>
 		);
 	}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -3,7 +3,7 @@
 import { type InfiniteData, useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { ArrowRight, Eye, Heart, Pencil, Share2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primitives";
 import { UserAvatar } from "@/components/shared/user-avatar";
 import { Button } from "@/components/ui/button";
@@ -40,7 +40,55 @@ function buildFeedUrl(filter: FeedFilter, limit: number, cursor?: string | null)
 	return `/api/recognition${query ? `?${query}` : ""}`;
 }
 
-function CardSkeleton() {
+function AutoCardSkeleton() {
+	const cardView = usePreferencesStore((s) => s.cardView);
+	return cardView === "physical" ? <PhysicalCardSkeleton /> : <ListCardSkeleton />;
+}
+
+function PhysicalCardSkeleton() {
+	return (
+		<SkeletonCard
+			className="p-0 overflow-hidden animate-pulse"
+			role="status"
+			aria-busy="true"
+			aria-label="Loading recognition card"
+		>
+			<div className="bg-[#e6e7e8] dark:bg-white/5 flex flex-col md:flex-row gap-3 md:gap-4 p-3 md:p-5">
+				<div className="flex-1 flex flex-col gap-2">
+					<SkeletonLine className="h-12 w-full rounded-sm" />
+					<SkeletonLine className="h-24 md:h-28 w-full rounded-sm" />
+					<SkeletonLine className="h-12 w-full rounded-sm" />
+				</div>
+				<div className="flex-1 flex flex-col gap-2">
+					<div className="flex items-center justify-between h-14 md:h-16 px-1">
+						<SkeletonLine className="h-5 md:h-7 w-16" />
+						<SkeletonLine className="h-8 md:h-10 w-20" />
+					</div>
+					<div className="bg-white/70 dark:bg-white/5 rounded-sm p-4 md:p-5 flex flex-col gap-2 flex-grow">
+						<SkeletonLine className="h-3 w-40" />
+						{Array.from({ length: 5 }).map((_, i) => (
+							<div
+								// biome-ignore lint/suspicious/noArrayIndexKey: skeleton only
+								key={i}
+								className="flex items-center gap-1.5"
+							>
+								<SkeletonLine className="h-5 w-5 md:h-6 md:w-6 rounded-sm" />
+								<SkeletonLine className="h-4 w-24" />
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+			<div className="px-5 py-3 flex items-center gap-4">
+				<SkeletonLine className="h-6 w-14 rounded-full" />
+				<SkeletonLine className="h-6 w-14 rounded-full" />
+				<SkeletonLine className="h-6 w-20 rounded-full ml-auto" />
+			</div>
+		</SkeletonCard>
+	);
+}
+
+function ListCardSkeleton() {
 	return (
 		<SkeletonCard
 			className="p-6 animate-pulse"
@@ -213,11 +261,21 @@ function RecognitionFeedInfinite({
 
 	const { ref: sentinelRef, isIntersecting } = useIntersectionObserver();
 
+	// Gate auto-fetch on the first user scroll. Prevents a cascade when the
+	// first page's rendered height is shorter than the viewport + rootMargin,
+	// which would otherwise chain through many pages at mount time.
+	const [hasScrolled, setHasScrolled] = useState(false);
 	useEffect(() => {
-		if (isIntersecting && hasNextPage && !isFetchingNextPage) {
+		const onScroll = () => setHasScrolled(true);
+		window.addEventListener("scroll", onScroll, { once: true, passive: true });
+		return () => window.removeEventListener("scroll", onScroll);
+	}, []);
+
+	useEffect(() => {
+		if (hasScrolled && isIntersecting && hasNextPage && !isFetchingNextPage) {
 			fetchNextPage();
 		}
-	}, [isIntersecting, hasNextPage, isFetchingNextPage, fetchNextPage]);
+	}, [hasScrolled, isIntersecting, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
 	return (
 		<FeedLayout
@@ -237,7 +295,7 @@ function RecognitionFeedInfinite({
 					<>
 						<div ref={sentinelRef} aria-hidden className="h-10 w-full" />
 						{isFetchingNextPage ? (
-							<CardSkeleton />
+							<AutoCardSkeleton />
 						) : (
 							<div className="flex justify-center pt-2">
 								<Button
@@ -294,6 +352,8 @@ function FeedLayout({
 		onShare?.(cardId);
 	};
 
+	const Skeleton = cardView === "physical" ? PhysicalCardSkeleton : ListCardSkeleton;
+
 	if (isPending) {
 		return (
 			<div className="space-y-4">
@@ -302,9 +362,9 @@ function FeedLayout({
 						Recent Recognitions
 					</h3>
 				)}
-				<CardSkeleton />
-				<CardSkeleton />
-				<CardSkeleton />
+				<Skeleton />
+				<Skeleton />
+				<Skeleton />
 			</div>
 		);
 	}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/actions/recognition-actions";
 import { useSession } from "@/lib/auth-client";
 import { formatLocalDate } from "@/lib/date-utils";
+import { invalidateRecognitionFeed } from "@/lib/recognition-cache";
 import {
 	type CreateRecognitionCardInput,
 	createRecognitionCardSchema,
@@ -373,9 +374,7 @@ export function RecognitionForm({
 			}
 
 			await Promise.all([
-				queryClient.invalidateQueries({
-					queryKey: ["recognition-cards"],
-				}),
+				invalidateRecognitionFeed(queryClient),
 				queryClient.invalidateQueries({
 					queryKey: ["recognition-stats"],
 				}),

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
@@ -44,6 +44,7 @@ import {
 	getSelectedValues,
 	type RecognitionCard,
 } from "@/lib/recognition";
+import { invalidateRecognitionFeed } from "@/lib/recognition-cache";
 import { RecognitionFilterBar } from "./recognition-filter-bar";
 import { ShareDialog } from "./share-dialog";
 
@@ -270,7 +271,7 @@ export function RecognitionTable() {
 			const result = await deleteRecognitionCardAction(deleteCardId);
 			if (result.success) {
 				toast.success("Recognition card deleted");
-				queryClient.invalidateQueries({ queryKey: ["recognition-cards"] });
+				await invalidateRecognitionFeed(queryClient);
 			} else {
 				toast.error(result.error);
 			}

--- a/app/api/recognition/route.test.ts
+++ b/app/api/recognition/route.test.ts
@@ -135,7 +135,7 @@ describe("GET /api/recognition (cursor pagination)", () => {
 		expect(call?.skip).toBeUndefined();
 	});
 
-	test("maps Prisma findMany errors (e.g. bad cursor) to 400", async () => {
+	test("maps Prisma findMany errors to 400 only when a cursor was supplied", async () => {
 		vi.mocked(prisma.recognitionCard.findMany).mockRejectedValueOnce(new Error("bad cursor"));
 
 		const res = await GET(makeRequest("http://x/api/recognition?cursor=abc"));
@@ -143,6 +143,16 @@ describe("GET /api/recognition (cursor pagination)", () => {
 
 		expect(res.status).toBe(400);
 		expect(body).toEqual({ success: false, error: "Invalid cursor" });
+	});
+
+	test("surfaces findMany failures without a cursor as 500 (infra error)", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockRejectedValueOnce(new Error("db down"));
+
+		const res = await GET(makeRequest("http://x/api/recognition"));
+		const body = await res.json();
+
+		expect(res.status).toBe(500);
+		expect(body).toEqual({ success: false, error: "Internal server error" });
 	});
 
 	test("empty result returns empty data + null nextCursor", async () => {

--- a/app/api/recognition/route.test.ts
+++ b/app/api/recognition/route.test.ts
@@ -1,0 +1,137 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/auth-utils", () => ({
+	requireSession: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		recognitionCard: { findMany: vi.fn(), count: vi.fn() },
+		cardReaction: { findMany: vi.fn() },
+	},
+}));
+
+vi.mock("@/lib/permissions", () => ({
+	getUserRole: vi.fn(() => "MEMBER"),
+	hasMinRole: vi.fn(() => false),
+}));
+
+import { requireSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+import { GET } from "./route";
+
+const USER_ID = "user_123";
+
+function makeRequest(url: string): NextRequest {
+	return { nextUrl: new URL(url) } as unknown as NextRequest;
+}
+
+function makeCards(count: number, prefix = "card") {
+	return Array.from({ length: count }, (_, i) => ({
+		id: `${prefix}_${i}`,
+		message: "msg",
+		date: new Date(),
+		createdAt: new Date(Date.now() - i * 1000),
+		senderId: "s",
+		recipientId: "r",
+		sender: { id: "s", firstName: "S", lastName: "S", avatar: null, position: null },
+		recipient: { id: "r", firstName: "R", lastName: "R", avatar: null, position: null },
+		_count: { reactions: 0, comments: 0 },
+	}));
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(requireSession).mockResolvedValue({
+		user: { id: USER_ID, departmentId: null },
+		session: { id: "sess_1" },
+	} as unknown as Awaited<ReturnType<typeof requireSession>>);
+	vi.mocked(prisma.cardReaction.findMany).mockResolvedValue([] as never);
+});
+
+describe("GET /api/recognition (cursor pagination)", () => {
+	test("returns 401 when unauthenticated", async () => {
+		vi.mocked(requireSession).mockRejectedValueOnce(new Error("nope"));
+
+		const res = await GET(makeRequest("http://x/api/recognition"));
+
+		expect(res.status).toBe(401);
+	});
+
+	test("defaults to limit 50, no cursor, nextCursor null when under limit", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue(makeCards(3) as never);
+
+		const res = await GET(makeRequest("http://x/api/recognition"));
+		const body = await res.json();
+
+		expect(body.success).toBe(true);
+		expect(body.data).toHaveLength(3);
+		expect(body.nextCursor).toBeNull();
+
+		const call = vi.mocked(prisma.recognitionCard.findMany).mock.calls[0]?.[0];
+		expect(call?.take).toBe(51);
+		expect(call?.cursor).toBeUndefined();
+		expect(call?.skip).toBeUndefined();
+		expect(call?.orderBy).toEqual([{ createdAt: "desc" }, { id: "desc" }]);
+	});
+
+	test("returns nextCursor when more rows exist (limit+1 overfetch)", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue(makeCards(11) as never);
+
+		const res = await GET(makeRequest("http://x/api/recognition?limit=10"));
+		const body = await res.json();
+
+		expect(body.data).toHaveLength(10);
+		expect(body.nextCursor).toBe("card_9");
+	});
+
+	test("forwards cursor + skip to Prisma when ?cursor is provided", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue(makeCards(5) as never);
+
+		await GET(makeRequest("http://x/api/recognition?limit=10&cursor=abc"));
+
+		const call = vi.mocked(prisma.recognitionCard.findMany).mock.calls[0]?.[0];
+		expect(call?.cursor).toEqual({ id: "abc" });
+		expect(call?.skip).toBe(1);
+	});
+
+	test("clamps limit above 50 to 50", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([] as never);
+
+		await GET(makeRequest("http://x/api/recognition?limit=999"));
+
+		const call = vi.mocked(prisma.recognitionCard.findMany).mock.calls[0]?.[0];
+		expect(call?.take).toBe(51);
+	});
+
+	test("clamps limit below 1 to default", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([] as never);
+
+		await GET(makeRequest("http://x/api/recognition?limit=0"));
+
+		const call = vi.mocked(prisma.recognitionCard.findMany).mock.calls[0]?.[0];
+		expect(call?.take).toBe(51);
+	});
+
+	test("empty result returns empty data + null nextCursor", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([] as never);
+
+		const res = await GET(makeRequest("http://x/api/recognition?limit=10"));
+		const body = await res.json();
+
+		expect(body.data).toEqual([]);
+		expect(body.nextCursor).toBeNull();
+	});
+
+	test("does not fetch reactions for the overfetched +1 row", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue(makeCards(11) as never);
+
+		await GET(makeRequest("http://x/api/recognition?limit=10"));
+
+		const reactionCall = vi.mocked(prisma.cardReaction.findMany).mock.calls[0]?.[0];
+		const cardIds = (reactionCall?.where as { cardId: { in: string[] } } | undefined)?.cardId.in;
+		expect(cardIds).toHaveLength(10);
+		expect(cardIds).not.toContain("card_10");
+	});
+});

--- a/app/api/recognition/route.test.ts
+++ b/app/api/recognition/route.test.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { Prisma } from "@/app/generated/prisma/client";
 
 vi.mock("@/lib/auth-utils", () => ({
 	requireSession: vi.fn(),
@@ -135,8 +136,10 @@ describe("GET /api/recognition (cursor pagination)", () => {
 		expect(call?.skip).toBeUndefined();
 	});
 
-	test("maps Prisma findMany errors to 400 only when a cursor was supplied", async () => {
-		vi.mocked(prisma.recognitionCard.findMany).mockRejectedValueOnce(new Error("bad cursor"));
+	test("maps Prisma validation errors with a cursor to 400 Invalid cursor", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockRejectedValueOnce(
+			new Prisma.PrismaClientValidationError("bad cursor", { clientVersion: "x" }),
+		);
 
 		const res = await GET(makeRequest("http://x/api/recognition?cursor=abc"));
 		const body = await res.json();
@@ -145,8 +148,20 @@ describe("GET /api/recognition (cursor pagination)", () => {
 		expect(body).toEqual({ success: false, error: "Invalid cursor" });
 	});
 
-	test("surfaces findMany failures without a cursor as 500 (infra error)", async () => {
+	test("surfaces infra errors (e.g. DB down) with a cursor as 500, not 400", async () => {
 		vi.mocked(prisma.recognitionCard.findMany).mockRejectedValueOnce(new Error("db down"));
+
+		const res = await GET(makeRequest("http://x/api/recognition?cursor=abc"));
+		const body = await res.json();
+
+		expect(res.status).toBe(500);
+		expect(body).toEqual({ success: false, error: "Internal server error" });
+	});
+
+	test("surfaces findMany failures without a cursor as 500", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockRejectedValueOnce(
+			new Prisma.PrismaClientValidationError("db down", { clientVersion: "x" }),
+		);
 
 		const res = await GET(makeRequest("http://x/api/recognition"));
 		const body = await res.json();

--- a/app/api/recognition/route.test.ts
+++ b/app/api/recognition/route.test.ts
@@ -114,6 +114,37 @@ describe("GET /api/recognition (cursor pagination)", () => {
 		expect(call?.take).toBe(51);
 	});
 
+	test("floors fractional limit to an integer", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([] as never);
+
+		await GET(makeRequest("http://x/api/recognition?limit=10.7"));
+
+		const call = vi.mocked(prisma.recognitionCard.findMany).mock.calls[0]?.[0];
+		expect(call?.take).toBe(11);
+		expect(Number.isInteger(call?.take)).toBe(true);
+	});
+
+	test("ignores oversized cursor (>64 chars) and returns first page", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([] as never);
+		const huge = "x".repeat(200);
+
+		await GET(makeRequest(`http://x/api/recognition?cursor=${huge}`));
+
+		const call = vi.mocked(prisma.recognitionCard.findMany).mock.calls[0]?.[0];
+		expect(call?.cursor).toBeUndefined();
+		expect(call?.skip).toBeUndefined();
+	});
+
+	test("maps Prisma findMany errors (e.g. bad cursor) to 400", async () => {
+		vi.mocked(prisma.recognitionCard.findMany).mockRejectedValueOnce(new Error("bad cursor"));
+
+		const res = await GET(makeRequest("http://x/api/recognition?cursor=abc"));
+		const body = await res.json();
+
+		expect(res.status).toBe(400);
+		expect(body).toEqual({ success: false, error: "Invalid cursor" });
+	});
+
 	test("empty result returns empty data + null nextCursor", async () => {
 		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([] as never);
 

--- a/app/api/recognition/route.test.ts
+++ b/app/api/recognition/route.test.ts
@@ -1,6 +1,11 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { Prisma } from "@/app/generated/prisma/client";
+
+function prismaValidationError(message = "invalid"): Error {
+	const err = new Error(message);
+	err.name = "PrismaClientValidationError";
+	return err;
+}
 
 vi.mock("@/lib/auth-utils", () => ({
 	requireSession: vi.fn(),
@@ -138,7 +143,7 @@ describe("GET /api/recognition (cursor pagination)", () => {
 
 	test("maps Prisma validation errors with a cursor to 400 Invalid cursor", async () => {
 		vi.mocked(prisma.recognitionCard.findMany).mockRejectedValueOnce(
-			new Prisma.PrismaClientValidationError("bad cursor", { clientVersion: "x" }),
+			prismaValidationError("bad cursor"),
 		);
 
 		const res = await GET(makeRequest("http://x/api/recognition?cursor=abc"));
@@ -160,7 +165,7 @@ describe("GET /api/recognition (cursor pagination)", () => {
 
 	test("surfaces findMany failures without a cursor as 500", async () => {
 		vi.mocked(prisma.recognitionCard.findMany).mockRejectedValueOnce(
-			new Prisma.PrismaClientValidationError("db down", { clientVersion: "x" }),
+			prismaValidationError("no-cursor path"),
 		);
 
 		const res = await GET(makeRequest("http://x/api/recognition"));

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -172,19 +172,27 @@ export async function GET(request: NextRequest) {
 		}
 
 		const limitParam = Number(request.nextUrl.searchParams.get("limit"));
-		const limit = Math.min(
-			50,
-			Math.max(1, Number.isFinite(limitParam) && limitParam > 0 ? limitParam : 50),
+		const limit = Math.floor(
+			Math.min(50, Math.max(1, Number.isFinite(limitParam) && limitParam > 0 ? limitParam : 50)),
 		);
-		const cursor = request.nextUrl.searchParams.get("cursor") || undefined;
+		const rawCursor = request.nextUrl.searchParams.get("cursor");
+		// Cursor is a card id (uuid ≈ 36 chars). Anything longer is malformed input we ignore.
+		const cursor =
+			rawCursor && rawCursor.length > 0 && rawCursor.length <= 64 ? rawCursor : undefined;
 
-		const rows = await prisma.recognitionCard.findMany({
-			where,
-			include,
-			orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-			take: limit + 1,
-			...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
-		});
+		const rows = await prisma.recognitionCard
+			.findMany({
+				where,
+				include,
+				orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+				take: limit + 1,
+				...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+			})
+			.catch(() => null);
+
+		if (rows === null) {
+			return Response.json({ success: false, error: "Invalid cursor" }, { status: 400 });
+		}
 
 		const hasMore = rows.length > limit;
 		const cards = hasMore ? rows.slice(0, limit) : rows;

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -180,18 +180,26 @@ export async function GET(request: NextRequest) {
 		const cursor =
 			rawCursor && rawCursor.length > 0 && rawCursor.length <= 64 ? rawCursor : undefined;
 
-		const rows = await prisma.recognitionCard
-			.findMany({
+		let rows: Awaited<
+			ReturnType<typeof prisma.recognitionCard.findMany<{ include: typeof include }>>
+		>;
+		try {
+			rows = await prisma.recognitionCard.findMany({
 				where,
 				include,
 				orderBy: [{ createdAt: "desc" }, { id: "desc" }],
 				take: limit + 1,
 				...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
-			})
-			.catch(() => null);
-
-		if (rows === null) {
-			return Response.json({ success: false, error: "Invalid cursor" }, { status: 400 });
+			});
+		} catch (err) {
+			// Only surface as a client error when the caller provided a cursor — a
+			// malformed cursor is the only way bad user input can make this query
+			// throw. Any other failure (pool exhaustion, timeouts, DB down) is an
+			// infrastructure problem and should fall through to the outer 500.
+			if (cursor) {
+				return Response.json({ success: false, error: "Invalid cursor" }, { status: 400 });
+			}
+			throw err;
 		}
 
 		const hasMore = rows.length > limit;

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { Prisma } from "@/app/generated/prisma/client";
+import type { Prisma } from "@/app/generated/prisma/client";
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { getUserRole, hasMinRole } from "@/lib/permissions";
@@ -196,10 +196,12 @@ export async function GET(request: NextRequest) {
 			// Infrastructure failures (pool exhaustion, timeouts, DB down) are different
 			// classes of error and must fall through to the outer 500 — mapping them to
 			// 400 would hide real outages as client bad-input in monitoring.
+			// Name check (not instanceof) keeps us resilient to Prisma constructor
+			// drift between majors.
+			const name = err instanceof Error ? err.name : "";
 			const isCursorError =
 				!!cursor &&
-				(err instanceof Prisma.PrismaClientValidationError ||
-					err instanceof Prisma.PrismaClientKnownRequestError);
+				(name === "PrismaClientValidationError" || name === "PrismaClientKnownRequestError");
 			if (isCursorError) {
 				return Response.json({ success: false, error: "Invalid cursor" }, { status: 400 });
 			}

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import type { Prisma } from "@/app/generated/prisma/client";
+import { Prisma } from "@/app/generated/prisma/client";
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { getUserRole, hasMinRole } from "@/lib/permissions";
@@ -192,11 +192,15 @@ export async function GET(request: NextRequest) {
 				...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
 			});
 		} catch (err) {
-			// Only surface as a client error when the caller provided a cursor — a
-			// malformed cursor is the only way bad user input can make this query
-			// throw. Any other failure (pool exhaustion, timeouts, DB down) is an
-			// infrastructure problem and should fall through to the outer 500.
-			if (cursor) {
+			// A malformed cursor produces a Prisma validation / known-request error.
+			// Infrastructure failures (pool exhaustion, timeouts, DB down) are different
+			// classes of error and must fall through to the outer 500 — mapping them to
+			// 400 would hide real outages as client bad-input in monitoring.
+			const isCursorError =
+				!!cursor &&
+				(err instanceof Prisma.PrismaClientValidationError ||
+					err instanceof Prisma.PrismaClientKnownRequestError);
+			if (isCursorError) {
 				return Response.json({ success: false, error: "Invalid cursor" }, { status: 400 });
 			}
 			throw err;

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -171,12 +171,24 @@ export async function GET(request: NextRequest) {
 			});
 		}
 
-		const cards = await prisma.recognitionCard.findMany({
+		const limitParam = Number(request.nextUrl.searchParams.get("limit"));
+		const limit = Math.min(
+			50,
+			Math.max(1, Number.isFinite(limitParam) && limitParam > 0 ? limitParam : 50),
+		);
+		const cursor = request.nextUrl.searchParams.get("cursor") || undefined;
+
+		const rows = await prisma.recognitionCard.findMany({
 			where,
 			include,
-			orderBy: { createdAt: "desc" },
-			take: 50,
+			orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+			take: limit + 1,
+			...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
 		});
+
+		const hasMore = rows.length > limit;
+		const cards = hasMore ? rows.slice(0, limit) : rows;
+		const nextCursor = hasMore ? (cards[cards.length - 1]?.id ?? null) : null;
 
 		const cardIds = cards.map((c) => c.id);
 
@@ -230,6 +242,7 @@ export async function GET(request: NextRequest) {
 				...mapCounts(card),
 				reactionSummary: Array.from(reactionsByCard.get(card.id)?.values() ?? []),
 			})),
+			nextCursor,
 		});
 	} catch {
 		return Response.json({ success: false, error: "Internal server error" }, { status: 500 });

--- a/hooks/use-intersection-observer.test.tsx
+++ b/hooks/use-intersection-observer.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { useIntersectionObserver } from "./use-intersection-observer";
+
+type Callback = (entries: Array<{ isIntersecting: boolean }>) => void;
+
+const observerInstances: Array<{
+	callback: Callback;
+	observe: ReturnType<typeof vi.fn>;
+	disconnect: ReturnType<typeof vi.fn>;
+}> = [];
+
+beforeEach(() => {
+	observerInstances.length = 0;
+	class MockIO {
+		callback: Callback;
+		observe = vi.fn();
+		disconnect = vi.fn();
+		constructor(cb: Callback) {
+			this.callback = cb;
+			observerInstances.push({ callback: cb, observe: this.observe, disconnect: this.disconnect });
+		}
+	}
+	vi.stubGlobal("IntersectionObserver", MockIO);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("useIntersectionObserver", () => {
+	test("creates an observer when ref is attached and enabled", () => {
+		const { result } = renderHook(() => useIntersectionObserver());
+		act(() => {
+			result.current.ref(document.createElement("div"));
+		});
+		expect(observerInstances).toHaveLength(1);
+		expect(observerInstances[0]?.observe).toHaveBeenCalledTimes(1);
+	});
+
+	test("updates isIntersecting when callback fires", () => {
+		const { result } = renderHook(() => useIntersectionObserver());
+		act(() => {
+			result.current.ref(document.createElement("div"));
+		});
+		expect(result.current.isIntersecting).toBe(false);
+
+		act(() => {
+			observerInstances[0]?.callback([{ isIntersecting: true }]);
+		});
+		expect(result.current.isIntersecting).toBe(true);
+	});
+
+	test("does not create observer when disabled", () => {
+		const { result } = renderHook(() => useIntersectionObserver({ enabled: false }));
+		act(() => {
+			result.current.ref(document.createElement("div"));
+		});
+		expect(observerInstances).toHaveLength(0);
+	});
+
+	test("disconnects on unmount", () => {
+		const { result, unmount } = renderHook(() => useIntersectionObserver());
+		act(() => {
+			result.current.ref(document.createElement("div"));
+		});
+		const instance = observerInstances[0];
+		unmount();
+		expect(instance?.disconnect).toHaveBeenCalled();
+	});
+});

--- a/hooks/use-intersection-observer.ts
+++ b/hooks/use-intersection-observer.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Options {
+	rootMargin?: string;
+	threshold?: number;
+	enabled?: boolean;
+}
+
+export function useIntersectionObserver({
+	rootMargin = "400px",
+	threshold = 0,
+	enabled = true,
+}: Options = {}) {
+	const [isIntersecting, setIsIntersecting] = useState(false);
+	const observerRef = useRef<IntersectionObserver | null>(null);
+
+	const ref = useCallback(
+		(node: Element | null) => {
+			if (observerRef.current) {
+				observerRef.current.disconnect();
+				observerRef.current = null;
+			}
+			if (!enabled || !node || typeof IntersectionObserver === "undefined") {
+				setIsIntersecting(false);
+				return;
+			}
+			const observer = new IntersectionObserver(
+				(entries) => {
+					const entry = entries[0];
+					if (entry) setIsIntersecting(entry.isIntersecting);
+				},
+				{ rootMargin, threshold },
+			);
+			observer.observe(node);
+			observerRef.current = observer;
+		},
+		[enabled, rootMargin, threshold],
+	);
+
+	useEffect(() => {
+		return () => {
+			observerRef.current?.disconnect();
+			observerRef.current = null;
+		};
+	}, []);
+
+	return { ref, isIntersecting };
+}

--- a/lib/recognition-cache.ts
+++ b/lib/recognition-cache.ts
@@ -1,0 +1,22 @@
+import type { InfiniteData, QueryClient } from "@tanstack/react-query";
+import type { RecognitionCard } from "@/lib/recognition";
+
+type FeedPage = {
+	success: boolean;
+	data: RecognitionCard[];
+	nextCursor: string | null;
+};
+
+/**
+ * Invalidates the recognition feed without triggering a refetch of every loaded
+ * infinite-scroll page. We first slice each cached infinite query down to its
+ * first page so the follow-up refetch only hits page 1.
+ */
+export async function invalidateRecognitionFeed(queryClient: QueryClient) {
+	queryClient.setQueriesData<InfiniteData<FeedPage>>({ queryKey: ["recognition-cards"] }, (prev) =>
+		prev && Array.isArray(prev.pages) && prev.pages.length > 1
+			? { pages: prev.pages.slice(0, 1), pageParams: prev.pageParams.slice(0, 1) }
+			: prev,
+	);
+	await queryClient.invalidateQueries({ queryKey: ["recognition-cards"] });
+}


### PR DESCRIPTION
## Summary
- `GET /api/recognition` gains backward-compatible `limit` (1–50, default 50) and `cursor` query params; adds `nextCursor` to the response. Admin `paginated=true` and `export=true` branches untouched.
- Dashboard widget now fetches 10 cards instead of 50 (5× smaller initial payload for the most-visited surface).
- Inbox `received` and `sent` pages switch to `useInfiniteQuery` with an IntersectionObserver sentinel (400px prefetch) + accessible "Load more" fallback button.
- New `useIntersectionObserver` hook (no new dependency).
- Query key stays prefix-compatible (`["recognition-cards", ...]`), so existing `invalidateQueries` in `recognition-form` and `recognition-table` keep working against both static and infinite queries.

## Regression guardrails
- `/api/recognition` with no new params = previous behaviour (50 cards, no cursor) plus an additive `nextCursor` field old clients ignore.
- `orderBy` now `[{ createdAt: desc }, { id: desc }]` to guarantee stable cursors across same-ms rows.
- Reaction summary join uses the trimmed page (not the `+1` overfetch row).
- Admin `paginated=true` branch shape (page/pageSize/total/totalPages) unchanged.
- React-query invalidations from card create (`recognition-form`) and admin delete (`recognition-table`) already use the `["recognition-cards"]` prefix, which matches both `useQuery` and `useInfiniteQuery` — verified by inspection.

## Tests added
- `app/api/recognition/route.test.ts` — 8 cases: defaults, limit+1 overfetch, cursor forwarding, clamping, empty result, reaction batch scope.
- `hooks/use-intersection-observer.test.tsx` — 4 cases: observe, callback, disabled, disconnect on unmount.
- `app/(dashboard)/dashboard/recognition/_components/recognition-feed.test.tsx` — 3 cases: first page, Load more appends page 2 with cursor, no button when `nextCursor` null.

## Test plan
- [ ] Dashboard: widget loads 10 cards, tab `Public` ⇄ `My Department` still refetches.
- [ ] Inbox received: first 10 cards render, scroll to bottom → next 10 appear; "Load more" button works when scroll is impractical.
- [ ] Inbox sent: same as received.
- [ ] Create a new card → appears at the top of infinite feed (invalidation through query prefix).
- [ ] React/comment on a card → still works (per-card invalidation path unchanged).
- [ ] Admin `/dashboard/recognition/all` paginated table unaffected.
- [ ] CSV export (admin) unaffected.
- [ ] Unread "New" badge still flags unread cards across page boundaries.

Closes #147