### PR TITLE
Allow admins to set initial password for OAuth-only users

### DIFF
--- a/lib/actions/user-actions.test.ts
+++ b/lib/actions/user-actions.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+	revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+	headers: vi.fn(async () => new Headers()),
+}));
+
+vi.mock("@/lib/auth", () => ({
+	auth: { api: { signUpEmail: vi.fn() } },
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+	requireRole: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		account: {
+			findFirst: vi.fn(),
+			update: vi.fn(),
+			create: vi.fn(),
+		},
+		session: {
+			deleteMany: vi.fn(),
+		},
+		user: {
+			findUnique: vi.fn(),
+		},
+		$transaction: vi.fn(),
+	},
+}));
+
+vi.mock("@/lib/activity-log", () => ({
+	logActivity: vi.fn(),
+	extractRequestMeta: vi.fn(() => ({ ipAddress: "1.1.1.1", userAgent: "vitest" })),
+}));
+
+vi.mock("better-auth/crypto", () => ({
+	hashPassword: vi.fn(async (pw: string) => `hashed:${pw}`),
+}));
+
+import { hashPassword } from "better-auth/crypto";
+import { Prisma } from "@/app/generated/prisma/client";
+import { logActivity } from "@/lib/activity-log";
+import { requireRole } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+import { adminResetPasswordAction } from "./user-actions";
+
+const ADMIN_ID = "admin_1";
+const TARGET_ID = "user_1";
+
+const mockAdminSession = () => ({
+	user: { id: ADMIN_ID, name: "Admin", role: "ADMIN" as const },
+	session: { id: "sess_admin", createdAt: new Date() },
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(requireRole).mockResolvedValue(
+		mockAdminSession() as unknown as Awaited<ReturnType<typeof requireRole>>,
+	);
+	vi.mocked(prisma.user.findUnique).mockResolvedValue({
+		role: "STAFF",
+		deletedAt: null,
+	} as never);
+	vi.mocked(prisma.$transaction).mockResolvedValue([] as never);
+});
+
+describe("adminResetPasswordAction", () => {
+	test("updates an existing credential account and revokes sessions", async () => {
+		vi.mocked(prisma.account.findFirst).mockResolvedValue({ id: "acct_1" } as never);
+
+		const result = await adminResetPasswordAction(TARGET_ID, {
+			newPassword: "supersecret",
+			confirmPassword: "supersecret",
+		});
+
+		expect(result).toEqual({ success: true, data: null });
+		expect(hashPassword).toHaveBeenCalledWith("supersecret");
+		expect(prisma.account.update).toHaveBeenCalledWith({
+			where: { id: "acct_1" },
+			data: { password: "hashed:supersecret" },
+		});
+		expect(prisma.session.deleteMany).toHaveBeenCalledWith({ where: { userId: TARGET_ID } });
+		expect(prisma.account.create).not.toHaveBeenCalled();
+		expect(logActivity).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "PASSWORD_RESET",
+				actorId: ADMIN_ID,
+				targetType: "user",
+				targetId: TARGET_ID,
+			}),
+		);
+	});
+
+	test("creates a credential account for an OAuth-only user and logs PASSWORD_SET", async () => {
+		vi.mocked(prisma.account.findFirst).mockResolvedValue(null);
+		vi.mocked(prisma.account.create).mockResolvedValue({} as never);
+
+		const result = await adminResetPasswordAction(TARGET_ID, {
+			newPassword: "supersecret",
+			confirmPassword: "supersecret",
+		});
+
+		expect(result).toEqual({ success: true, data: null });
+		expect(prisma.account.create).toHaveBeenCalledWith({
+			data: {
+				userId: TARGET_ID,
+				accountId: TARGET_ID,
+				providerId: "credential",
+				password: "hashed:supersecret",
+			},
+		});
+		expect(prisma.account.update).not.toHaveBeenCalled();
+		expect(prisma.session.deleteMany).not.toHaveBeenCalled();
+		expect(logActivity).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "PASSWORD_SET",
+				actorId: ADMIN_ID,
+				targetType: "user",
+				targetId: TARGET_ID,
+			}),
+		);
+	});
+
+	test("handles concurrent-create race (P2002) with a clean error", async () => {
+		vi.mocked(prisma.account.findFirst).mockResolvedValue(null);
+		vi.mocked(prisma.account.create).mockRejectedValue(
+			new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+				code: "P2002",
+				clientVersion: "test",
+			}),
+		);
+
+		const result = await adminResetPasswordAction(TARGET_ID, {
+			newPassword: "supersecret",
+			confirmPassword: "supersecret",
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/just set|reload/i);
+		}
+		expect(logActivity).not.toHaveBeenCalled();
+	});
+
+	test("rejects when the target user does not exist", async () => {
+		vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+
+		const result = await adminResetPasswordAction(TARGET_ID, {
+			newPassword: "supersecret",
+			confirmPassword: "supersecret",
+		});
+
+		expect(result.success).toBe(false);
+		expect(prisma.account.findFirst).not.toHaveBeenCalled();
+		expect(logActivity).not.toHaveBeenCalled();
+	});
+
+	test("rejects when the target user is soft-deleted", async () => {
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			role: "STAFF",
+			deletedAt: new Date(),
+		} as never);
+
+		const result = await adminResetPasswordAction(TARGET_ID, {
+			newPassword: "supersecret",
+			confirmPassword: "supersecret",
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/deleted/i);
+		}
+		expect(prisma.account.findFirst).not.toHaveBeenCalled();
+		expect(logActivity).not.toHaveBeenCalled();
+	});
+
+	test("rejects when admin lacks permission to assign target's role", async () => {
+		// Admin trying to reset a SUPERADMIN's password — canAssignRole returns false.
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			role: "SUPERADMIN",
+			deletedAt: null,
+		} as never);
+
+		const result = await adminResetPasswordAction(TARGET_ID, {
+			newPassword: "supersecret",
+			confirmPassword: "supersecret",
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/permission/i);
+		}
+		expect(prisma.account.findFirst).not.toHaveBeenCalled();
+		expect(logActivity).not.toHaveBeenCalled();
+	});
+
+	test("rejects mismatched passwords without touching the database", async () => {
+		const result = await adminResetPasswordAction(TARGET_ID, {
+			newPassword: "supersecret",
+			confirmPassword: "different1",
+		});
+
+		expect(result.success).toBe(false);
+		expect(prisma.user.findUnique).not.toHaveBeenCalled();
+		expect(prisma.account.findFirst).not.toHaveBeenCalled();
+	});
+
+	test("returns success even when post-persist logging fails", async () => {
+		vi.mocked(prisma.account.findFirst).mockResolvedValue(null);
+		vi.mocked(prisma.account.create).mockResolvedValue({} as never);
+		vi.mocked(logActivity).mockRejectedValueOnce(new Error("activity-log down"));
+		const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		try {
+			const result = await adminResetPasswordAction(TARGET_ID, {
+				newPassword: "supersecret",
+				confirmPassword: "supersecret",
+			});
+
+			expect(result).toEqual({ success: true, data: null });
+			expect(prisma.account.create).toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		} finally {
+			consoleErrorSpy.mockRestore();
+		}
+	});
+});

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -2,7 +2,9 @@
 
 import { hashPassword } from "better-auth/crypto";
 import { revalidatePath } from "next/cache";
-import type { Prisma, Role } from "@/app/generated/prisma/client";
+import { headers } from "next/headers";
+import { Prisma, type Role } from "@/app/generated/prisma/client";
+import { extractRequestMeta, logActivity } from "@/lib/activity-log";
 import { auth } from "@/lib/auth";
 import { requireRole } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
@@ -321,21 +323,62 @@ export async function adminResetPasswordAction(userId: string, formData: unknown
 			where: { userId, providerId: "credential" },
 		});
 
-		if (!account) {
-			return { success: false as const, error: "User does not have a password-based account" };
-		}
-
 		const hashedPassword = await hashPassword(parsed.data.newPassword);
 
-		await prisma.$transaction([
-			prisma.account.update({
-				where: { id: account.id },
-				data: { password: hashedPassword },
-			}),
-			prisma.session.deleteMany({
-				where: { userId },
-			}),
-		]);
+		if (account) {
+			await prisma.$transaction([
+				prisma.account.update({
+					where: { id: account.id },
+					data: { password: hashedPassword },
+				}),
+				prisma.session.deleteMany({
+					where: { userId },
+				}),
+			]);
+		} else {
+			// `accountId === userId` for credential accounts — matches better-auth's
+			// internal linkAccount call so subsequent sign-in flows treat it
+			// identically to a credential account created at registration.
+			try {
+				await prisma.account.create({
+					data: {
+						userId,
+						accountId: userId,
+						providerId: "credential",
+						password: hashedPassword,
+					},
+				});
+			} catch (err) {
+				// Race-safety: a concurrent self-service set-password (#151) can
+				// pass our `findFirst` check at the same moment the admin does
+				// and both reach `create`. The composite unique index on
+				// (user_id, provider_id) makes the second insert fail with P2002.
+				if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+					return {
+						success: false as const,
+						error: "A password was just set for this user. Reload and try again.",
+					};
+				}
+				throw err;
+			}
+		}
+
+		try {
+			const { ipAddress, userAgent } = extractRequestMeta(await headers());
+			await logActivity({
+				action: account ? "PASSWORD_RESET" : "PASSWORD_SET",
+				actorId: session.user.id,
+				targetType: "user",
+				targetId: userId,
+				ipAddress,
+				userAgent,
+			});
+		} catch (err) {
+			console.error("adminResetPasswordAction post-persist side effects failed", {
+				userId,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
 
 		return { success: true as const, data: null };
 	} catch (error) {


### PR DESCRIPTION
Closes #152.

## Summary
- `adminResetPasswordAction` now handles OAuth-only users by **creating** a credential account when none exists, in addition to the existing **update** behaviour.
- Race-safe against the self-service flow added in #151: `P2002` on the `(user_id, provider_id)` unique surfaces as a clean "just set, reload" error rather than a 500.
- Adds explicit `logActivity` calls — `PASSWORD_RESET` on update, `PASSWORD_SET` on create — with `actorId = admin`, `targetType = "user"`, `targetId = subject`. Logging failures are caught so a successful persist is never reported as a failure (same pattern as `setInitialPasswordAction`).
- Update branch keeps its transactional session revocation; create branch is a single insert (no credential session exists yet, OAuth session is left untouched).
- `canAssignRole` permission gate and soft-delete guard are unchanged.

## Test plan
- [x] `bun run test` — 246/246 passing (8 new tests in `lib/actions/user-actions.test.ts`)
- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: as admin, open `/dashboard/users/<id>/edit` for an OAuth-only user, submit Reset Password → verify credential row created and `PASSWORD_SET` row in activity log
- [ ] Manual: as admin, repeat for a credential user → verify password updated, sessions revoked, `PASSWORD_RESET` row logged
- [ ] Manual: try to reset password for a SUPERADMIN as ADMIN → still rejected with permission error
- [ ] Manual: try to reset password for a soft-deleted user → still rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Admin password reset now handles all account states gracefully, including cases where credential accounts didn't previously exist.
  * Improved error handling for race conditions during password updates.
  * Enhanced activity logging with proper categorization of password reset versus initial setup actions.

* **Tests**
  * Added comprehensive test coverage for admin password reset operations, including edge cases and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->