### PR TITLE
Insights dashboard, part 1: cadence + top values

### DIFF
--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/cadence-card.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/cadence-card.tsx
@@ -1,0 +1,91 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CadencePoint } from "@/lib/insights/queries";
+
+const MIN_BAR_HEIGHT_PCT = 6;
+
+function formatLabel(dayKey: string): string {
+	const [, m, d] = dayKey.split("-").map(Number);
+	const monthNames = [
+		"Jan",
+		"Feb",
+		"Mar",
+		"Apr",
+		"May",
+		"Jun",
+		"Jul",
+		"Aug",
+		"Sep",
+		"Oct",
+		"Nov",
+		"Dec",
+	];
+	return `${monthNames[((m ?? 1) - 1) % 12]} ${d ?? ""}`;
+}
+
+interface CadenceCardProps {
+	data: CadencePoint[];
+	daysBack: number;
+}
+
+export function CadenceCard({ data, daysBack }: CadenceCardProps) {
+	const total = data.reduce((sum, p) => sum + p.count, 0);
+	const max = data.reduce((m, p) => Math.max(m, p.count), 0);
+	const peak = data.reduce<CadencePoint | null>(
+		(best, p) => (best && best.count >= p.count ? best : p),
+		null,
+	);
+	const firstLabel = data[0]?.day ? formatLabel(data[0].day) : null;
+	const lastLabel = data.at(-1)?.day ? formatLabel(data.at(-1)?.day ?? "") : null;
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Card cadence</CardTitle>
+				<CardDescription>Recognition cards created in the last {daysBack} days.</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+					<div>
+						<span className="text-2xl font-semibold tabular-nums">{total}</span>
+						<span className="ml-1 text-sm text-muted-foreground">total</span>
+					</div>
+					{peak && peak.count > 0 ? (
+						<div className="text-sm text-muted-foreground">
+							Peak <span className="font-medium text-foreground tabular-nums">{peak.count}</span> on{" "}
+							<span className="font-medium text-foreground">{formatLabel(peak.day)}</span>
+						</div>
+					) : null}
+				</div>
+
+				{total === 0 ? (
+					<p className="text-sm text-muted-foreground">No cards created in this window yet.</p>
+				) : (
+					<>
+						<div
+							className="flex h-24 items-end gap-[3px]"
+							role="img"
+							aria-label={`Card cadence sparkline, ${data.length} days, peak ${max}`}
+						>
+							{data.map((p) => {
+								const heightPct =
+									p.count === 0 ? 0 : Math.max((p.count / max) * 100, MIN_BAR_HEIGHT_PCT);
+								return (
+									<div
+										key={p.day}
+										className="flex-1 rounded-sm bg-primary/15 hover:bg-primary/30 transition-colors"
+										style={{ height: `${heightPct}%` }}
+										title={`${formatLabel(p.day)}: ${p.count}`}
+									/>
+								);
+							})}
+						</div>
+						<div className="flex justify-between text-xs text-muted-foreground">
+							<span>{firstLabel}</span>
+							<span>{lastLabel}</span>
+						</div>
+					</>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/top-values-card.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/top-values-card.tsx
@@ -16,7 +16,8 @@ interface TopValuesCardProps {
 
 export function TopValuesCard({ data, daysBack }: TopValuesCardProps) {
 	const total = data.reduce((sum, v) => sum + v.count, 0);
-	const max = data[0]?.count ?? 0;
+	// Don't assume `data` is sorted — the component owns its own visual scale.
+	const max = data.reduce((m, v) => Math.max(m, v.count), 0);
 
 	return (
 		<Card>

--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/top-values-card.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/top-values-card.tsx
@@ -1,0 +1,59 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ValueTally } from "@/lib/insights/queries";
+
+const VALUE_LABELS: Record<string, string> = {
+	PEOPLE: "People",
+	SAFETY: "Safety",
+	RESPECT: "Respect",
+	COMMUNICATION: "Communication",
+	CONTINUOUS_IMPROVEMENT: "Continuous Improvement",
+};
+
+interface TopValuesCardProps {
+	data: ValueTally[];
+	daysBack: number;
+}
+
+export function TopValuesCard({ data, daysBack }: TopValuesCardProps) {
+	const total = data.reduce((sum, v) => sum + v.count, 0);
+	const max = data[0]?.count ?? 0;
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Top company values</CardTitle>
+				<CardDescription>
+					Values picked across recognition cards in the last {daysBack} days.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{total === 0 ? (
+					<p className="text-sm text-muted-foreground">No values tagged in this window yet.</p>
+				) : (
+					<ul className="space-y-3">
+						{data.map((v) => {
+							const widthPct = max === 0 ? 0 : (v.count / max) * 100;
+							const sharePct = total === 0 ? 0 : Math.round((v.count / total) * 100);
+							return (
+								<li key={v.value} className="grid grid-cols-[10rem_1fr_auto] items-center gap-3">
+									<span className="truncate text-sm font-medium">
+										{VALUE_LABELS[v.value] ?? v.value}
+									</span>
+									<div className="h-2 overflow-hidden rounded-full bg-muted">
+										<div
+											className="h-full rounded-full bg-primary/60"
+											style={{ width: `${widthPct}%` }}
+										/>
+									</div>
+									<span className="text-sm text-muted-foreground tabular-nums">
+										{v.count} <span className="text-xs">({sharePct}%)</span>
+									</span>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/insights/loading.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/loading.tsx
@@ -1,0 +1,30 @@
+import { SkeletonLine } from "@/components/shared/skeleton-primitives";
+
+export default function InsightsLoading() {
+	return (
+		<div
+			className="mx-auto max-w-7xl space-y-6 animate-pulse sm:space-y-8"
+			role="status"
+			aria-busy="true"
+			aria-label="Loading insights"
+		>
+			<div className="rounded-[2rem] border border-gray-200/60 bg-card px-5 py-5 shadow-[0_20px_50px_-40px_rgba(0,0,0,0.45)] dark:border-white/10 sm:px-7 sm:py-6">
+				<div className="space-y-3">
+					<SkeletonLine className="h-3 w-28" />
+					<SkeletonLine className="h-10 w-48" />
+					<SkeletonLine className="h-5 w-96" />
+				</div>
+			</div>
+
+			<div className="grid gap-6 lg:grid-cols-2">
+				{["c0", "c1"].map((key) => (
+					<div key={key} className="rounded-xl bg-card p-5 ring-1 ring-foreground/10 space-y-4">
+						<SkeletonLine className="h-4 w-32" />
+						<SkeletonLine className="h-3 w-64" />
+						<SkeletonLine className="h-24 w-full rounded-lg" />
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/insights/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
+import { requireRole } from "@/lib/auth-utils";
+import { getCardCadence, getTopValues } from "@/lib/insights/queries";
+import { CadenceCard } from "./_components/cadence-card";
+import { TopValuesCard } from "./_components/top-values-card";
+
+const DAYS_BACK = 30;
+
+export default async function InsightsPage() {
+	try {
+		await requireRole("ADMIN");
+	} catch {
+		redirect("/dashboard");
+	}
+
+	const [cadence, topValues] = await Promise.all([
+		getCardCadence(DAYS_BACK),
+		getTopValues(DAYS_BACK),
+	]);
+
+	return (
+		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
+			<DashboardPageHeader
+				eyebrow="Administration"
+				title="Insights"
+				description="Aggregate trends across recognition activity. Updated on each visit."
+			/>
+
+			<div className="grid gap-6 lg:grid-cols-2">
+				<CadenceCard data={cadence} daysBack={DAYS_BACK} />
+				<TopValuesCard data={topValues} daysBack={DAYS_BACK} />
+			</div>
+		</div>
+	);
+}

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -92,6 +92,10 @@ const NAV_ITEMS: NavItem[] = [
 		minRole: "ADMIN",
 		children: [
 			{
+				label: "Insights",
+				href: "/dashboard/admin-settings/insights",
+			},
+			{
 				label: "Activity Logs",
 				href: "/dashboard/admin-settings/activity-logs",
 			},

--- a/lib/insights/queries.test.ts
+++ b/lib/insights/queries.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		activityLog: { findMany: vi.fn() },
+	},
+}));
+
+import { prisma } from "@/lib/db";
+import { getCardCadence, getTopValues } from "./queries";
+
+// 2026-04-25 12:00:00 UTC == 2026-04-25 20:00 Manila — comfortably mid-day so
+// boundary maths around midnight don't shift the "today" key in either TZ.
+const FROZEN_NOW = new Date("2026-04-25T12:00:00.000Z");
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.useFakeTimers();
+	vi.setSystemTime(FROZEN_NOW);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("getCardCadence", () => {
+	test("returns one bucket per day, oldest first, with zero-fill for empty days", async () => {
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([
+			// 2026-04-25 12:00 UTC = 2026-04-25 20:00 Manila → key 2026-04-25
+			{ createdAt: new Date("2026-04-25T12:00:00.000Z") },
+			{ createdAt: new Date("2026-04-25T13:00:00.000Z") },
+			// 2026-04-23 02:00 UTC = 2026-04-23 10:00 Manila → key 2026-04-23
+			{ createdAt: new Date("2026-04-23T02:00:00.000Z") },
+		] as never);
+
+		const result = await getCardCadence(5);
+
+		expect(result).toEqual([
+			{ day: "2026-04-21", count: 0 },
+			{ day: "2026-04-22", count: 0 },
+			{ day: "2026-04-23", count: 1 },
+			{ day: "2026-04-24", count: 0 },
+			{ day: "2026-04-25", count: 2 },
+		]);
+	});
+
+	test("buckets late-evening Manila events on the correct Manila day, not UTC day", async () => {
+		// 2026-04-24 16:30 UTC = 2026-04-25 00:30 Manila → key 2026-04-25
+		// (Important: by UTC date this is the 24th; by Manila date it's the 25th.)
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([
+			{ createdAt: new Date("2026-04-24T16:30:00.000Z") },
+		] as never);
+
+		const result = await getCardCadence(2);
+
+		expect(result).toEqual([
+			{ day: "2026-04-24", count: 0 },
+			{ day: "2026-04-25", count: 1 },
+		]);
+	});
+
+	test("filters by action=CARD_CREATED and uses a lower bound that includes the earliest day", async () => {
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([] as never);
+
+		await getCardCadence(7);
+
+		const arg = vi.mocked(prisma.activityLog.findMany).mock.calls[0]?.[0];
+		expect(arg?.where?.action).toBe("CARD_CREATED");
+		// Lower bound = start of (today - 6) in Manila = 2026-04-19 00:00 +08:00
+		// = 2026-04-18 16:00 UTC.
+		expect((arg?.where?.createdAt as { gte?: Date })?.gte?.toISOString()).toBe(
+			"2026-04-18T16:00:00.000Z",
+		);
+	});
+
+	test("returns empty array when daysBack <= 0", async () => {
+		const result = await getCardCadence(0);
+		expect(result).toEqual([]);
+		expect(prisma.activityLog.findMany).not.toHaveBeenCalled();
+	});
+});
+
+describe("getTopValues", () => {
+	test("counts valuesPicked entries across rows and sorts by count desc", async () => {
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([
+			{ metadata: { valuesPicked: ["PEOPLE", "RESPECT"] } },
+			{ metadata: { valuesPicked: ["PEOPLE"] } },
+			{ metadata: { valuesPicked: ["PEOPLE", "COMMUNICATION"] } },
+			{ metadata: { valuesPicked: ["RESPECT"] } },
+		] as never);
+
+		const result = await getTopValues(30);
+
+		expect(result).toEqual([
+			{ value: "PEOPLE", count: 3 },
+			{ value: "RESPECT", count: 2 },
+			{ value: "COMMUNICATION", count: 1 },
+		]);
+	});
+
+	test("breaks count ties alphabetically so ordering is stable", async () => {
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([
+			{ metadata: { valuesPicked: ["SAFETY"] } },
+			{ metadata: { valuesPicked: ["PEOPLE"] } },
+			{ metadata: { valuesPicked: ["RESPECT"] } },
+		] as never);
+
+		const result = await getTopValues(30);
+
+		expect(result.map((r) => r.value)).toEqual(["PEOPLE", "RESPECT", "SAFETY"]);
+	});
+
+	test("ignores rows whose metadata is missing, null, or malformed", async () => {
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([
+			{ metadata: null },
+			{ metadata: {} },
+			{ metadata: { valuesPicked: "PEOPLE" } }, // not an array
+			{ metadata: { valuesPicked: [42, true, null, "PEOPLE"] } }, // mixed types
+		] as never);
+
+		const result = await getTopValues(30);
+
+		// Only the one valid string slipped through.
+		expect(result).toEqual([{ value: "PEOPLE", count: 1 }]);
+	});
+
+	test("returns empty array when daysBack <= 0", async () => {
+		const result = await getTopValues(0);
+		expect(result).toEqual([]);
+		expect(prisma.activityLog.findMany).not.toHaveBeenCalled();
+	});
+});

--- a/lib/insights/queries.ts
+++ b/lib/insights/queries.ts
@@ -1,0 +1,94 @@
+import { prisma } from "@/lib/db";
+
+const MANILA_TZ_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+/** YYYY-MM-DD for the given UTC instant in Manila local time. */
+function manilaDayKey(date: Date): string {
+	return new Date(date.getTime() + MANILA_TZ_OFFSET_MS).toISOString().slice(0, 10);
+}
+
+/** UTC instant equal to start-of-day in Manila for the given Manila day key. */
+function manilaDayStartUtc(dayKey: string): Date {
+	const [y, m, d] = dayKey.split("-").map(Number);
+	return new Date(Date.UTC(y ?? 1970, (m ?? 1) - 1, d ?? 1) - MANILA_TZ_OFFSET_MS);
+}
+
+/** N most-recent Manila day keys, oldest first, inclusive of today. */
+function recentManilaDayKeys(count: number): string[] {
+	const todayKey = manilaDayKey(new Date());
+	const [y, m, d] = todayKey.split("-").map(Number);
+	return Array.from({ length: count }, (_, i) => {
+		const offsetDays = count - 1 - i;
+		return new Date(Date.UTC(y ?? 1970, (m ?? 1) - 1, (d ?? 1) - offsetDays))
+			.toISOString()
+			.slice(0, 10);
+	});
+}
+
+export interface CadencePoint {
+	day: string;
+	count: number;
+}
+
+/**
+ * Daily count of recognition cards created over the last `daysBack` Manila
+ * days, oldest first, with empty days filled as `count: 0`.
+ */
+export async function getCardCadence(daysBack = 30): Promise<CadencePoint[]> {
+	const days = recentManilaDayKeys(daysBack);
+	const earliest = days[0];
+	if (!earliest) return [];
+	const since = manilaDayStartUtc(earliest);
+
+	const rows = await prisma.activityLog.findMany({
+		where: { action: "CARD_CREATED", createdAt: { gte: since } },
+		select: { createdAt: true },
+	});
+
+	const buckets = new Map<string, number>(days.map((d) => [d, 0]));
+	for (const row of rows) {
+		const key = manilaDayKey(row.createdAt);
+		// `findMany` may return rows just outside our window if a row was
+		// created at the boundary in a TZ-shifted bucket; ignore those.
+		if (buckets.has(key)) buckets.set(key, (buckets.get(key) ?? 0) + 1);
+	}
+	return days.map((d) => ({ day: d, count: buckets.get(d) ?? 0 }));
+}
+
+export interface ValueTally {
+	value: string;
+	count: number;
+}
+
+/**
+ * Tally of company values picked across CARD_CREATED events over the last
+ * `daysBack` Manila days. Reads `metadata.valuesPicked` (array of strings)
+ * written by `createRecognitionCardAction`. Sorted by count desc.
+ */
+export async function getTopValues(daysBack = 30): Promise<ValueTally[]> {
+	const days = recentManilaDayKeys(daysBack);
+	const earliest = days[0];
+	if (!earliest) return [];
+	const since = manilaDayStartUtc(earliest);
+
+	const rows = await prisma.activityLog.findMany({
+		where: { action: "CARD_CREATED", createdAt: { gte: since } },
+		select: { metadata: true },
+	});
+
+	const counts = new Map<string, number>();
+	for (const row of rows) {
+		const meta = row.metadata as { valuesPicked?: unknown } | null;
+		const picked = meta?.valuesPicked;
+		if (!Array.isArray(picked)) continue;
+		for (const v of picked) {
+			if (typeof v !== "string") continue;
+			counts.set(v, (counts.get(v) ?? 0) + 1);
+		}
+	}
+	return Array.from(counts.entries())
+		.sort(([aLabel, aCount], [bLabel, bCount]) =>
+			bCount === aCount ? aLabel.localeCompare(bLabel) : bCount - aCount,
+		)
+		.map(([value, count]) => ({ value, count }));
+}


### PR DESCRIPTION
First slice of #158. Intentionally scoped to the simplest two sections so the surface lands — engagement joins, top recognisers, category mix, charts, and caching follow in later PRs (per the issue's own 2-3 PR breakdown).

## Summary
- New admin-only route `/dashboard/admin-settings/insights`, `requireRole("ADMIN")`-gated, linked from the sidebar above Activity Logs.
- Two query helpers in `lib/insights/queries.ts`:
  - `getCardCadence(daysBack)` — daily count of `CARD_CREATED` events, Manila-bucketed, zero-filled so the sparkline has no gaps.
  - `getTopValues(daysBack)` — tally of `metadata.valuesPicked` from `CARD_CREATED`, sorted by count desc with stable alphabetical tie-break. Tolerates malformed metadata (null, missing key, non-array, non-string members).
- Two Server Components for rendering — sparkline of div widths and ranked list with proportional progress bars. No chart library, no client-side state.
- Loading skeleton mirroring the activity-logs pattern.

## Why no caching in this PR
Issue #158 called for `cacheTag`-based daily revalidation. Skipping for v1 because (a) the queries are sub-100ms over a 30-day window against an already-indexed table, (b) admin-only page = low traffic = no real cost without caching, (c) introducing a new caching pattern deserves its own PR with proper invalidation tied to writes (#155 events, #159 events). Will add as part of part 2.

## Why no chart library
Issue #158 said "start with simple shadcn/ui primitives... before reaching for a charting lib". Following that — sparkline is just `<div>` bars with `style={{ height }}`, value bars are `<div>` widths. If the design genuinely needs lines/areas later, that decision (and the package install ask) is its own PR.

## Test plan
- [x] `bun run test` — 259/259 passing (+8 new tests in `lib/insights/queries.test.ts` covering bucketing, Manila-late-evening boundary, malformed metadata, tie-break sort, and `daysBack <= 0`).
- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual after deploy: visit `/dashboard/admin-settings/insights` as ADMIN — verify both cards render, totals match an `activity_logs` count for the window, peak callout reads sensibly.
- [ ] Manual: confirm sidebar shows the new "Insights" item under Admin Settings.
- [ ] Manual: visit as STAFF — confirm redirect to `/dashboard`.

## Out of scope (tracked in #158)
- Engagement joins (CARD_REACTED + COMMENT_CREATED → cards)
- Top recognisers (per-actor count)
- Help Me category mix
- `'use cache'` / `cacheTag` daily revalidation
- Real chart library
- 90-day windows (current default 30; can extend in part 2 with a window selector)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin-only Insights dashboard displaying card creation activity trends and top value statistics over a 30-day period.
  * Added Insights navigation link under Admin Settings in the sidebar.
  * Included loading skeleton UI for data fetching states.

* **Tests**
  * Added comprehensive test coverage for insights query functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->