### PR TITLE
Centralise admin-page auth gate via requireRoleOrRedirect

### DIFF
--- a/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/activity-logs/page.tsx
@@ -1,8 +1,7 @@
-import { redirect } from "next/navigation";
 import type { ActivityAction, Prisma } from "@/app/generated/prisma/client";
 import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { pruneActivityLogsIfNeeded } from "@/lib/activity-log";
-import { requireRole } from "@/lib/auth-utils";
+import { requireRoleOrRedirect } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { ActivityLogFilters } from "./_components/activity-log-filters";
 import { ActivityLogTable } from "./_components/activity-log-table";
@@ -65,11 +64,7 @@ export default async function ActivityLogsPage({
 }: {
 	searchParams: Promise<SearchParams>;
 }) {
-	try {
-		await requireRole("ADMIN");
-	} catch {
-		redirect("/dashboard");
-	}
+	await requireRoleOrRedirect("ADMIN");
 
 	await pruneActivityLogsIfNeeded();
 

--- a/app/(dashboard)/dashboard/admin-settings/insights/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/page.tsx
@@ -1,6 +1,5 @@
-import { redirect } from "next/navigation";
 import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
-import { requireRole } from "@/lib/auth-utils";
+import { requireRoleOrRedirect } from "@/lib/auth-utils";
 import { getCardCadence, getTopValues } from "@/lib/insights/queries";
 import { CadenceCard } from "./_components/cadence-card";
 import { TopValuesCard } from "./_components/top-values-card";
@@ -8,11 +7,7 @@ import { TopValuesCard } from "./_components/top-values-card";
 const DAYS_BACK = 30;
 
 export default async function InsightsPage() {
-	try {
-		await requireRole("ADMIN");
-	} catch {
-		redirect("/dashboard");
-	}
+	await requireRoleOrRedirect("ADMIN");
 
 	const [cadence, topValues] = await Promise.all([
 		getCardCadence(DAYS_BACK),

--- a/app/(dashboard)/dashboard/admin-settings/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/page.tsx
@@ -1,21 +1,16 @@
-import { redirect } from "next/navigation";
 import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import {
 	getHelpMeEnabled,
 	getLeaderboardVisibilitySettings,
 	getTopRecognizedLimit,
 } from "@/lib/actions/settings-actions";
-import { requireRole } from "@/lib/auth-utils";
+import { requireRoleOrRedirect } from "@/lib/auth-utils";
 import { HelpMeVisibilityPanel } from "./_components/helpme-visibility";
 import { LeaderboardVisibilityPanel } from "./_components/leaderboard-visibility";
 import { RecognitionSettingsPanel } from "./_components/recognition-settings";
 
 export default async function AdminSettingsPage() {
-	try {
-		await requireRole("ADMIN");
-	} catch {
-		redirect("/dashboard");
-	}
+	await requireRoleOrRedirect("ADMIN");
 
 	const [topLimit, visibility, helpMeEnabled] = await Promise.all([
 		getTopRecognizedLimit(),

--- a/app/(dashboard)/dashboard/super-admin/page.tsx
+++ b/app/(dashboard)/dashboard/super-admin/page.tsx
@@ -1,20 +1,15 @@
-import { redirect } from "next/navigation";
 import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import {
 	getActivityLogRetentionDays,
 	getOAuthProviderAvailability,
 	getOAuthSettings,
 } from "@/lib/actions/settings-actions";
-import { requireRole } from "@/lib/auth-utils";
+import { requireRoleOrRedirect } from "@/lib/auth-utils";
 import { ActivityLogRetentionPanel } from "./_components/activity-log-retention";
 import { OAuthSettingsPanel } from "./_components/oauth-settings";
 
 export default async function SuperAdminPage() {
-	try {
-		await requireRole("SUPERADMIN");
-	} catch {
-		redirect("/dashboard");
-	}
+	await requireRoleOrRedirect("SUPERADMIN");
 
 	const [oauthSettings, providerAvailability, retentionDays] = await Promise.all([
 		getOAuthSettings(),

--- a/lib/auth-utils.test.ts
+++ b/lib/auth-utils.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("next/headers", () => ({
+	headers: vi.fn(async () => new Headers()),
+}));
+
+vi.mock("next/navigation", () => ({
+	redirect: vi.fn((url: string) => {
+		throw new Error(`__redirect__:${url}`);
+	}),
+}));
+
+vi.mock("@/lib/auth", () => ({
+	auth: { api: { getSession: vi.fn() } },
+}));
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		user: { findUnique: vi.fn() },
+	},
+}));
+
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { AuthError, requireRoleOrRedirect } from "./auth-utils";
+
+const adminSession = {
+	user: { id: "u1", role: "ADMIN" as const },
+	session: { id: "s1" },
+};
+
+const superadminSession = {
+	user: { id: "u2", role: "SUPERADMIN" as const },
+	session: { id: "s2" },
+};
+
+const staffSession = {
+	user: { id: "u3", role: "STAFF" as const },
+	session: { id: "s3" },
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(prisma.user.findUnique).mockResolvedValue({ deletedAt: null } as never);
+});
+
+describe("requireRoleOrRedirect", () => {
+	test("returns the session when role is satisfied", async () => {
+		vi.mocked(auth.api.getSession).mockResolvedValue(adminSession as never);
+
+		const result = await requireRoleOrRedirect("ADMIN");
+
+		expect(result).toEqual(adminSession);
+		expect(redirect).not.toHaveBeenCalled();
+	});
+
+	test("redirects when there is no active session", async () => {
+		vi.mocked(auth.api.getSession).mockResolvedValue(null);
+
+		await expect(requireRoleOrRedirect("ADMIN")).rejects.toThrow(/__redirect__:\/dashboard/);
+		expect(redirect).toHaveBeenCalledWith("/dashboard");
+	});
+
+	test("redirects when the user role is below the minimum", async () => {
+		vi.mocked(auth.api.getSession).mockResolvedValue(staffSession as never);
+
+		await expect(requireRoleOrRedirect("ADMIN")).rejects.toThrow(/__redirect__:\/dashboard/);
+		expect(redirect).toHaveBeenCalledWith("/dashboard");
+	});
+
+	test("redirects when the user has been soft-deleted since their session was issued", async () => {
+		vi.mocked(auth.api.getSession).mockResolvedValue(adminSession as never);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({ deletedAt: new Date() } as never);
+
+		await expect(requireRoleOrRedirect("ADMIN")).rejects.toThrow(/__redirect__:\/dashboard/);
+		expect(redirect).toHaveBeenCalledWith("/dashboard");
+	});
+
+	test("honours a custom redirect target", async () => {
+		vi.mocked(auth.api.getSession).mockResolvedValue(null);
+
+		await expect(requireRoleOrRedirect("ADMIN", "/login")).rejects.toThrow(/__redirect__:\/login/);
+		expect(redirect).toHaveBeenCalledWith("/login");
+	});
+
+	test("SUPERADMIN satisfies ADMIN minimum", async () => {
+		vi.mocked(auth.api.getSession).mockResolvedValue(superadminSession as never);
+
+		const result = await requireRoleOrRedirect("ADMIN");
+
+		expect(result).toEqual(superadminSession);
+		expect(redirect).not.toHaveBeenCalled();
+	});
+
+	test("re-throws non-AuthError exceptions instead of redirecting", async () => {
+		// Simulate an infrastructure failure inside requireSession's user lookup —
+		// the kind of error that previously got silently swallowed by the bare
+		// catch + redirect pattern. Should now surface to the route's error.tsx.
+		vi.mocked(auth.api.getSession).mockResolvedValue(adminSession as never);
+		vi.mocked(prisma.user.findUnique).mockRejectedValue(new Error("db connection lost"));
+
+		await expect(requireRoleOrRedirect("ADMIN")).rejects.toThrow("db connection lost");
+		expect(redirect).not.toHaveBeenCalled();
+	});
+
+	test("AuthError is the only signal that triggers a redirect", async () => {
+		// Sanity check on the exception-narrowing: an AuthError thrown from
+		// elsewhere in the call chain should still redirect, but anything else
+		// (TypeError, generic Error, etc.) shouldn't.
+		vi.mocked(auth.api.getSession).mockRejectedValue(new AuthError("Unauthorized", 401));
+
+		await expect(requireRoleOrRedirect("ADMIN")).rejects.toThrow(/__redirect__:\/dashboard/);
+		expect(redirect).toHaveBeenCalledWith("/dashboard");
+	});
+});

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -1,4 +1,5 @@
 import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 import { cache } from "react";
 import type { Role } from "@/app/generated/prisma/client";
 import { auth } from "@/lib/auth";
@@ -42,4 +43,27 @@ export async function requireRole(minimumRole: "ADMIN" | "SUPERADMIN") {
 		throw new AuthError("Forbidden", 403);
 	}
 	return session;
+}
+
+/**
+ * Server Component variant of `requireRole` that redirects unauthenticated /
+ * unauthorised users instead of throwing. Crucially, only `AuthError` is
+ * treated as a redirect signal — every other exception (DB outage, transient
+ * network glitch on the auth handler, programming bugs) is re-thrown so the
+ * route's `error.tsx` boundary can surface it. The previous bare-`catch` +
+ * `redirect("/dashboard")` pattern silently swallowed those, masking real
+ * issues from observability.
+ */
+export async function requireRoleOrRedirect(
+	minimumRole: "ADMIN" | "SUPERADMIN",
+	redirectTo = "/dashboard",
+) {
+	try {
+		return await requireRole(minimumRole);
+	} catch (err) {
+		if (err instanceof AuthError) {
+			redirect(redirectTo);
+		}
+		throw err;
+	}
 }


### PR DESCRIPTION
Closes #162.

## Summary
- Replaces the bare-catch + redirect pattern repeated across **4** admin Server Components (issue body said 3 — `super-admin/page.tsx` was missed in the original survey but shared the same pattern, so it's included here).
- New `requireRoleOrRedirect(minimumRole, redirectTo?)` helper in `lib/auth-utils.ts` narrows the catch to `AuthError` and re-throws everything else. Infrastructure failures (DB outage, network glitch, programming bugs) now reach `error.tsx` and observability instead of silently redirecting to `/dashboard`.
- 8 unit tests in `lib/auth-utils.test.ts` cover: happy path returns session, all three AuthError-producing conditions trigger redirect (no session, role too low, soft-deleted user), SUPERADMIN-satisfies-ADMIN, custom redirect target, AuthError thrown anywhere in the chain still redirects, and **critically: non-AuthError exceptions re-throw rather than redirect** — that's the regression the helper exists to prevent.

## Behaviour change

This is intentional. Previously: any exception during auth → `/dashboard` redirect. Now: `AuthError` (401/403) → `/dashboard` redirect; everything else → re-thrown to route's `error.tsx`.

A previously-silent failure mode (infra glitch during the `prisma.user.findUnique` inside `requireSession`) now becomes visible to end users as the route's error UI. That's better for debugging and matches Next.js conventions, but it does mean transient infra issues that previously caused a quiet bounce-to-dashboard now show an error screen briefly. Net positive — silent failures are worse than visible ones.

## Test plan
- [x] `bun run test` — 267/267 passing (+8 new tests in `lib/auth-utils.test.ts`)
- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: visit `/dashboard/admin-settings` as STAFF → still redirects to `/dashboard`
- [ ] Manual: visit as ADMIN → renders normally
- [ ] Manual: same checks against the 3 other admin pages (`activity-logs`, `insights`, `super-admin`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated authorization flows across admin dashboard pages to improve code consistency and maintainability. Authorization failures now follow a unified redirect pattern for better predictability.

* **Tests**
  * Added comprehensive test coverage for authorization validation, including role verification, session handling, authorization failures, soft-deletion checks, and redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->