### PR TITLE
Insights dashboard, part 2: top recognisers + category mix

### DIFF
--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/category-mix-card.test.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/category-mix-card.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CategoryTally } from "@/lib/insights/queries";
+import { CategoryMixCard } from "./category-mix-card";
+
+afterEach(() => {
+	cleanup();
+});
+
+const allZero: CategoryTally[] = [
+	{ category: "HR", count: 0 },
+	{ category: "IT_WEBSITE", count: 0 },
+	{ category: "PAYROLL", count: 0 },
+	{ category: "FACILITIES", count: 0 },
+	{ category: "OTHER", count: 0 },
+];
+
+describe("CategoryMixCard", () => {
+	it("renders the empty-state copy when total is zero, even if data has entries", () => {
+		// Important: the query always returns 5 zero-fill entries when no
+		// tickets exist. The card should still render the empty-state message.
+		render(<CategoryMixCard data={allZero} daysBack={30} />);
+		expect(screen.getByText(/no tickets created in this window yet/i)).toBeInTheDocument();
+		expect(screen.queryByRole("list")).not.toBeInTheDocument();
+	});
+
+	it("renders one row per category with humanised label and share %", () => {
+		render(
+			<CategoryMixCard
+				data={[
+					{ category: "HR", count: 6 },
+					{ category: "IT_WEBSITE", count: 3 },
+					{ category: "PAYROLL", count: 1 },
+					{ category: "FACILITIES", count: 0 },
+					{ category: "OTHER", count: 0 },
+				]}
+				daysBack={30}
+			/>,
+		);
+
+		const items = screen.getAllByRole("listitem");
+		expect(items).toHaveLength(5);
+
+		// Labels are humanised (IT_WEBSITE -> "IT / Website").
+		expect(screen.getByText("HR")).toBeInTheDocument();
+		expect(screen.getByText("IT / Website")).toBeInTheDocument();
+
+		// Share % is rounded against total=10. HR=60%, IT=30%, Payroll=10%.
+		expect(items[0]?.textContent).toMatch(/HR.*6.*\(60%\)/);
+		expect(items[1]?.textContent).toMatch(/IT \/ Website.*3.*\(30%\)/);
+		expect(items[2]?.textContent).toMatch(/Payroll.*1.*\(10%\)/);
+	});
+
+	it("scales bars against in-data max (regression: don't assume sorted desc)", () => {
+		// Deliberately-unsorted input — bar widths should still scale against
+		// the leader (count=8 = 100%), not data[0].
+		const { container } = render(
+			<CategoryMixCard
+				data={[
+					{ category: "FACILITIES", count: 2 },
+					{ category: "HR", count: 8 },
+					{ category: "OTHER", count: 4 },
+					{ category: "IT_WEBSITE", count: 0 },
+					{ category: "PAYROLL", count: 0 },
+				]}
+				daysBack={30}
+			/>,
+		);
+		const bars = Array.from(container.querySelectorAll<HTMLDivElement>("li > div > div"));
+		const widths = bars.map((b) => b.style.width);
+		// 2/8=25%, 8/8=100%, 4/8=50%, 0=0%, 0=0%
+		expect(widths).toEqual(["25%", "100%", "50%", "0%", "0%"]);
+	});
+});

--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/category-mix-card.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/category-mix-card.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CategoryTally } from "@/lib/insights/queries";
+
+const CATEGORY_LABELS: Record<string, string> = {
+	HR: "HR",
+	IT_WEBSITE: "IT / Website",
+	PAYROLL: "Payroll",
+	FACILITIES: "Facilities",
+	OTHER: "Other",
+};
+
+interface CategoryMixCardProps {
+	data: CategoryTally[];
+	daysBack: number;
+}
+
+export function CategoryMixCard({ data, daysBack }: CategoryMixCardProps) {
+	const total = data.reduce((sum, c) => sum + c.count, 0);
+	const max = data.reduce((m, c) => Math.max(m, c.count), 0);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Help Me category mix</CardTitle>
+				<CardDescription>Tickets created by category in the last {daysBack} days.</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{total === 0 ? (
+					<p className="text-sm text-muted-foreground">No tickets created in this window yet.</p>
+				) : (
+					<ul className="space-y-3">
+						{data.map((c) => {
+							const widthPct = max === 0 ? 0 : (c.count / max) * 100;
+							const sharePct = total === 0 ? 0 : Math.round((c.count / total) * 100);
+							return (
+								<li key={c.category} className="grid grid-cols-[8rem_1fr_auto] items-center gap-3">
+									<span className="truncate text-sm font-medium">
+										{CATEGORY_LABELS[c.category] ?? c.category}
+									</span>
+									<div className="h-2 overflow-hidden rounded-full bg-muted">
+										<div
+											className="h-full rounded-full bg-primary/60"
+											style={{ width: `${widthPct}%` }}
+										/>
+									</div>
+									<span className="text-sm text-muted-foreground tabular-nums">
+										{c.count} <span className="text-xs">({sharePct}%)</span>
+									</span>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/category-mix-card.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/category-mix-card.tsx
@@ -1,7 +1,10 @@
+import type { TicketCategory } from "@/app/generated/prisma/client";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { CategoryTally } from "@/lib/insights/queries";
 
-const CATEGORY_LABELS: Record<string, string> = {
+// Typed against the enum so a future `TicketCategory` value (e.g. LEGAL)
+// fails the build here rather than rendering as the raw enum string.
+const CATEGORY_LABELS: Record<TicketCategory, string> = {
 	HR: "HR",
 	IT_WEBSITE: "IT / Website",
 	PAYROLL: "Payroll",
@@ -35,7 +38,7 @@ export function CategoryMixCard({ data, daysBack }: CategoryMixCardProps) {
 							return (
 								<li key={c.category} className="grid grid-cols-[8rem_1fr_auto] items-center gap-3">
 									<span className="truncate text-sm font-medium">
-										{CATEGORY_LABELS[c.category] ?? c.category}
+										{CATEGORY_LABELS[c.category]}
 									</span>
 									<div className="h-2 overflow-hidden rounded-full bg-muted">
 										<div

--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/top-recognisers-card.test.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/top-recognisers-card.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TopRecognisersCard } from "./top-recognisers-card";
+
+afterEach(() => {
+	cleanup();
+});
+
+const fixture = (count: number) => ({
+	userId: `u${count}`,
+	firstName: "User",
+	lastName: `${count}`,
+	avatar: null,
+	count,
+});
+
+describe("TopRecognisersCard", () => {
+	it("renders the empty-state copy when there are no recognisers", () => {
+		render(<TopRecognisersCard data={[]} daysBack={30} />);
+		expect(screen.getByText(/no recognition activity in this window yet/i)).toBeInTheDocument();
+		// No <ol> is rendered in the empty state.
+		expect(screen.queryByRole("list")).not.toBeInTheDocument();
+	});
+
+	it("renders one list item per recogniser with rank and count", () => {
+		render(<TopRecognisersCard data={[fixture(12), fixture(7), fixture(3)]} daysBack={30} />);
+
+		const items = screen.getAllByRole("listitem");
+		expect(items).toHaveLength(3);
+
+		// Rank prefix renders alongside the count for each row.
+		expect(items[0]?.textContent).toMatch(/1.*User 12.*12$/);
+		expect(items[1]?.textContent).toMatch(/2.*User 7.*7$/);
+		expect(items[2]?.textContent).toMatch(/3.*User 3.*3$/);
+	});
+
+	it("uses the leader's count to scale all bars (regression: don't assume sorted)", () => {
+		// Pass deliberately-unsorted data; component should still scale bars
+		// against the in-data max, not data[0].
+		const { container } = render(
+			<TopRecognisersCard data={[fixture(2), fixture(10), fixture(6)]} daysBack={30} />,
+		);
+		const bars = Array.from(container.querySelectorAll<HTMLDivElement>("li > div > div > div"));
+		// Leader (count=10) -> 100%, count=6 -> 60%, count=2 -> 20%.
+		const widths = bars.map((b) => b.style.width);
+		expect(widths).toEqual(["20%", "100%", "60%"]);
+	});
+
+	it("renders zero-width bars when every count is zero", () => {
+		const { container } = render(
+			<TopRecognisersCard
+				data={[
+					{ ...fixture(0), userId: "u_a" },
+					{ ...fixture(0), userId: "u_b" },
+				]}
+				daysBack={30}
+			/>,
+		);
+		const bars = Array.from(container.querySelectorAll<HTMLDivElement>("li > div > div > div"));
+		expect(bars.every((b) => b.style.width === "0%")).toBe(true);
+	});
+});

--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/top-recognisers-card.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/top-recognisers-card.tsx
@@ -1,0 +1,64 @@
+import { UserAvatar } from "@/components/shared/user-avatar";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { TopRecogniser } from "@/lib/insights/queries";
+
+interface TopRecognisersCardProps {
+	data: TopRecogniser[];
+	daysBack: number;
+}
+
+export function TopRecognisersCard({ data, daysBack }: TopRecognisersCardProps) {
+	const max = data.reduce((m, r) => Math.max(m, r.count), 0);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Top recognisers</CardTitle>
+				<CardDescription>
+					Who's sending the most recognition cards in the last {daysBack} days.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{data.length === 0 ? (
+					<p className="text-sm text-muted-foreground">
+						No recognition activity in this window yet.
+					</p>
+				) : (
+					<ol className="space-y-3">
+						{data.map((r, i) => {
+							const widthPct = max === 0 ? 0 : (r.count / max) * 100;
+							return (
+								<li
+									key={r.userId}
+									className="grid grid-cols-[1.5rem_2.25rem_1fr_auto] items-center gap-3"
+								>
+									<span className="text-sm font-medium text-muted-foreground tabular-nums">
+										{i + 1}
+									</span>
+									<UserAvatar
+										firstName={r.firstName}
+										lastName={r.lastName}
+										avatar={r.avatar}
+										size="sm"
+									/>
+									<div className="min-w-0">
+										<p className="truncate text-sm font-medium">
+											{r.firstName} {r.lastName}
+										</p>
+										<div className="mt-1 h-1.5 overflow-hidden rounded-full bg-muted">
+											<div
+												className="h-full rounded-full bg-primary/60"
+												style={{ width: `${widthPct}%` }}
+											/>
+										</div>
+									</div>
+									<span className="text-sm text-muted-foreground tabular-nums">{r.count}</span>
+								</li>
+							);
+						})}
+					</ol>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/insights/loading.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/loading.tsx
@@ -17,7 +17,7 @@ export default function InsightsLoading() {
 			</div>
 
 			<div className="grid gap-6 lg:grid-cols-2">
-				{["c0", "c1"].map((key) => (
+				{["c0", "c1", "c2", "c3"].map((key) => (
 					<div key={key} className="rounded-xl bg-card p-5 ring-1 ring-foreground/10 space-y-4">
 						<SkeletonLine className="h-4 w-32" />
 						<SkeletonLine className="h-3 w-64" />

--- a/app/(dashboard)/dashboard/admin-settings/insights/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/page.tsx
@@ -1,17 +1,27 @@
 import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
 import { requireRoleOrRedirect } from "@/lib/auth-utils";
-import { getCardCadence, getTopValues } from "@/lib/insights/queries";
+import {
+	getCardCadence,
+	getCategoryMix,
+	getTopRecognisers,
+	getTopValues,
+} from "@/lib/insights/queries";
 import { CadenceCard } from "./_components/cadence-card";
+import { CategoryMixCard } from "./_components/category-mix-card";
+import { TopRecognisersCard } from "./_components/top-recognisers-card";
 import { TopValuesCard } from "./_components/top-values-card";
 
 const DAYS_BACK = 30;
+const TOP_RECOGNISERS_LIMIT = 10;
 
 export default async function InsightsPage() {
 	await requireRoleOrRedirect("ADMIN");
 
-	const [cadence, topValues] = await Promise.all([
+	const [cadence, topValues, topRecognisers, categoryMix] = await Promise.all([
 		getCardCadence(DAYS_BACK),
 		getTopValues(DAYS_BACK),
+		getTopRecognisers(DAYS_BACK, TOP_RECOGNISERS_LIMIT),
+		getCategoryMix(DAYS_BACK),
 	]);
 
 	return (
@@ -25,6 +35,8 @@ export default async function InsightsPage() {
 			<div className="grid gap-6 lg:grid-cols-2">
 				<CadenceCard data={cadence} daysBack={DAYS_BACK} />
 				<TopValuesCard data={topValues} daysBack={DAYS_BACK} />
+				<TopRecognisersCard data={topRecognisers} daysBack={DAYS_BACK} />
+				<CategoryMixCard data={categoryMix} daysBack={DAYS_BACK} />
 			</div>
 		</div>
 	);

--- a/lib/insights/queries.test.ts
+++ b/lib/insights/queries.test.ts
@@ -242,6 +242,18 @@ describe("getTopRecognisers", () => {
 		expect(result).toEqual([]);
 		expect(prisma.activityLog.groupBy).not.toHaveBeenCalled();
 	});
+
+	test("returns empty array when limit <= 0 without doing any DB work", async () => {
+		// Regression guard against `slice(0, -n)` returning all-but-last n
+		// silently. Caller asking for "0 results" should get [].
+		const result = await getTopRecognisers(30, 0);
+		expect(result).toEqual([]);
+		expect(prisma.activityLog.groupBy).not.toHaveBeenCalled();
+		expect(prisma.user.findMany).not.toHaveBeenCalled();
+
+		const negative = await getTopRecognisers(30, -3);
+		expect(negative).toEqual([]);
+	});
 });
 
 describe("getCategoryMix", () => {

--- a/lib/insights/queries.test.ts
+++ b/lib/insights/queries.test.ts
@@ -203,6 +203,28 @@ describe("getTopRecognisers", () => {
 		expect(result[0]?.userId).toBe("u1");
 	});
 
+	test("excludes soft-deleted users via deletedAt filter on the user lookup", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ actorId: "u1", _count: { _all: 5 } },
+			{ actorId: "u2", _count: { _all: 9 } },
+		] as never);
+		// Simulate the DB-level filter: `findMany` with `deletedAt: null` only
+		// returns the live user. The deleted user's groupBy row should be
+		// dropped from the result.
+		vi.mocked(prisma.user.findMany).mockResolvedValue([
+			{ id: "u1", firstName: "Live", lastName: "User", avatar: null },
+		] as never);
+
+		const result = await getTopRecognisers(30, 10);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.userId).toBe("u1");
+		// Verify the filter was actually requested at the query layer, not
+		// just that the mock happened to return one row.
+		const arg = vi.mocked(prisma.user.findMany).mock.calls[0]?.[0];
+		expect(arg?.where).toEqual({ id: { in: ["u1", "u2"] }, deletedAt: null });
+	});
+
 	test("filters out null actorIds in the where clause and short-circuits when group is empty", async () => {
 		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([] as never);
 

--- a/lib/insights/queries.test.ts
+++ b/lib/insights/queries.test.ts
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("@/lib/db", () => ({
 	prisma: {
-		activityLog: { findMany: vi.fn() },
+		activityLog: { findMany: vi.fn(), groupBy: vi.fn() },
+		user: { findMany: vi.fn() },
 	},
 }));
 
 import { prisma } from "@/lib/db";
-import { getCardCadence, getTopValues } from "./queries";
+import { getCardCadence, getCategoryMix, getTopRecognisers, getTopValues } from "./queries";
 
 // 2026-04-25 12:00:00 UTC == 2026-04-25 20:00 Manila — comfortably mid-day so
 // boundary maths around midnight don't shift the "today" key in either TZ.
@@ -126,6 +127,169 @@ describe("getTopValues", () => {
 
 	test("returns empty array when daysBack <= 0", async () => {
 		const result = await getTopValues(0);
+		expect(result).toEqual([]);
+		expect(prisma.activityLog.findMany).not.toHaveBeenCalled();
+	});
+});
+
+describe("getTopRecognisers", () => {
+	test("merges grouped counts with user details and sorts by count desc", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ actorId: "u1", _count: { _all: 5 } },
+			{ actorId: "u2", _count: { _all: 12 } },
+			{ actorId: "u3", _count: { _all: 7 } },
+		] as never);
+		vi.mocked(prisma.user.findMany).mockResolvedValue([
+			{ id: "u1", firstName: "Ann", lastName: "Lee", avatar: null },
+			{ id: "u2", firstName: "Bea", lastName: "Cruz", avatar: "/a.png" },
+			{ id: "u3", firstName: "Cal", lastName: "Reyes", avatar: null },
+		] as never);
+
+		const result = await getTopRecognisers(30, 10);
+
+		expect(result).toEqual([
+			{ userId: "u2", firstName: "Bea", lastName: "Cruz", avatar: "/a.png", count: 12 },
+			{ userId: "u3", firstName: "Cal", lastName: "Reyes", avatar: null, count: 7 },
+			{ userId: "u1", firstName: "Ann", lastName: "Lee", avatar: null, count: 5 },
+		]);
+	});
+
+	test("breaks count ties by full name alphabetically", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ actorId: "u1", _count: { _all: 5 } },
+			{ actorId: "u2", _count: { _all: 5 } },
+		] as never);
+		vi.mocked(prisma.user.findMany).mockResolvedValue([
+			{ id: "u1", firstName: "Bea", lastName: "Cruz", avatar: null },
+			{ id: "u2", firstName: "Ann", lastName: "Lee", avatar: null },
+		] as never);
+
+		const result = await getTopRecognisers(30, 10);
+
+		expect(result.map((r) => r.firstName)).toEqual(["Ann", "Bea"]);
+	});
+
+	test("respects the limit parameter", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ actorId: "u1", _count: { _all: 5 } },
+			{ actorId: "u2", _count: { _all: 4 } },
+			{ actorId: "u3", _count: { _all: 3 } },
+		] as never);
+		vi.mocked(prisma.user.findMany).mockResolvedValue([
+			{ id: "u1", firstName: "A", lastName: "X", avatar: null },
+			{ id: "u2", firstName: "B", lastName: "X", avatar: null },
+			{ id: "u3", firstName: "C", lastName: "X", avatar: null },
+		] as never);
+
+		const result = await getTopRecognisers(30, 2);
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.userId)).toEqual(["u1", "u2"]);
+	});
+
+	test("skips actors whose User row is missing (raced soft-delete)", async () => {
+		// Group says u1 + u2; user lookup only returns u1.
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ actorId: "u1", _count: { _all: 5 } },
+			{ actorId: "u2", _count: { _all: 9 } },
+		] as never);
+		vi.mocked(prisma.user.findMany).mockResolvedValue([
+			{ id: "u1", firstName: "Ann", lastName: "Lee", avatar: null },
+		] as never);
+
+		const result = await getTopRecognisers(30, 10);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.userId).toBe("u1");
+	});
+
+	test("filters out null actorIds in the where clause and short-circuits when group is empty", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([] as never);
+
+		const result = await getTopRecognisers(30, 10);
+
+		expect(result).toEqual([]);
+		expect(prisma.user.findMany).not.toHaveBeenCalled();
+		const arg = vi.mocked(prisma.activityLog.groupBy).mock.calls[0]?.[0];
+		expect(arg?.where?.action).toBe("CARD_CREATED");
+		expect(arg?.where?.actorId).toEqual({ not: null });
+	});
+
+	test("returns empty array when daysBack <= 0", async () => {
+		const result = await getTopRecognisers(0, 10);
+		expect(result).toEqual([]);
+		expect(prisma.activityLog.groupBy).not.toHaveBeenCalled();
+	});
+});
+
+describe("getCategoryMix", () => {
+	test("counts categories from TICKET_CREATED metadata, sorted by count desc", async () => {
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([
+			{ metadata: { category: "HR" } },
+			{ metadata: { category: "HR" } },
+			{ metadata: { category: "PAYROLL" } },
+			{ metadata: { category: "HR" } },
+			{ metadata: { category: "IT_WEBSITE" } },
+		] as never);
+
+		const result = await getCategoryMix(30);
+
+		// First three sorted by count desc; remaining two zero-fill alphabetically.
+		expect(result).toEqual([
+			{ category: "HR", count: 3 },
+			{ category: "IT_WEBSITE", count: 1 },
+			{ category: "PAYROLL", count: 1 },
+			{ category: "FACILITIES", count: 0 },
+			{ category: "OTHER", count: 0 },
+		]);
+	});
+
+	test("always returns all five categories even when no events match", async () => {
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([] as never);
+
+		const result = await getCategoryMix(30);
+
+		expect(result.map((r) => r.category).sort()).toEqual([
+			"FACILITIES",
+			"HR",
+			"IT_WEBSITE",
+			"OTHER",
+			"PAYROLL",
+		]);
+		expect(result.every((r) => r.count === 0)).toBe(true);
+	});
+
+	test("ignores rows whose metadata.category is missing or unknown", async () => {
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([
+			{ metadata: null },
+			{ metadata: {} },
+			{ metadata: { category: 42 } }, // wrong type
+			{ metadata: { category: "BOGUS" } }, // not a real enum
+			{ metadata: { category: "HR" } },
+		] as never);
+
+		const result = await getCategoryMix(30);
+
+		const hr = result.find((r) => r.category === "HR");
+		expect(hr?.count).toBe(1);
+		// The garbage rows shouldn't have leaked a "BOGUS" entry into the result.
+		expect(result.map((r) => r.category)).not.toContain("BOGUS");
+	});
+
+	test("filters by action=TICKET_CREATED with the right time bound", async () => {
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([] as never);
+
+		await getCategoryMix(7);
+
+		const arg = vi.mocked(prisma.activityLog.findMany).mock.calls[0]?.[0];
+		expect(arg?.where?.action).toBe("TICKET_CREATED");
+		expect((arg?.where?.createdAt as { gte?: Date })?.gte?.toISOString()).toBe(
+			"2026-04-18T16:00:00.000Z",
+		);
+	});
+
+	test("returns empty array when daysBack <= 0", async () => {
+		const result = await getCategoryMix(0);
 		expect(result).toEqual([]);
 		expect(prisma.activityLog.findMany).not.toHaveBeenCalled();
 	});

--- a/lib/insights/queries.ts
+++ b/lib/insights/queries.ts
@@ -1,3 +1,4 @@
+import { TicketCategory } from "@/app/generated/prisma/client";
 import { prisma } from "@/lib/db";
 
 const MANILA_TZ_OFFSET_MS = 8 * 60 * 60 * 1000;
@@ -91,4 +92,121 @@ export async function getTopValues(daysBack = 30): Promise<ValueTally[]> {
 			bCount === aCount ? aLabel.localeCompare(bLabel) : bCount - aCount,
 		)
 		.map(([value, count]) => ({ value, count }));
+}
+
+export interface TopRecogniser {
+	userId: string;
+	firstName: string;
+	lastName: string;
+	avatar: string | null;
+	count: number;
+}
+
+/**
+ * Top recognisers by `CARD_CREATED` count over the last `daysBack` Manila
+ * days, joined back to `User` for display. Sorted by count desc with name
+ * tie-break. Excludes events whose actor has been deleted entirely (rare —
+ * `actorId` is `SetNull` on user delete in the schema, so deleted users'
+ * events still exist but with `actorId = null`).
+ */
+export async function getTopRecognisers(daysBack = 30, limit = 10): Promise<TopRecogniser[]> {
+	const days = recentManilaDayKeys(daysBack);
+	const earliest = days[0];
+	if (!earliest) return [];
+	const since = manilaDayStartUtc(earliest);
+
+	const grouped = await prisma.activityLog.groupBy({
+		by: ["actorId"],
+		where: {
+			action: "CARD_CREATED",
+			createdAt: { gte: since },
+			actorId: { not: null },
+		},
+		_count: { _all: true },
+	});
+
+	if (grouped.length === 0) return [];
+
+	const ids = grouped.map((g) => g.actorId).filter((id): id is string => id !== null);
+
+	const users = await prisma.user.findMany({
+		where: { id: { in: ids } },
+		select: { id: true, firstName: true, lastName: true, avatar: true },
+	});
+	const usersById = new Map(users.map((u) => [u.id, u]));
+
+	return grouped
+		.flatMap((g) => {
+			if (g.actorId === null) return [];
+			const user = usersById.get(g.actorId);
+			// User soft-deleted between groupBy and findMany — skip rather than
+			// surface a partial row. Their events stay in the audit log; they
+			// just don't show on a current "top recognisers" leaderboard.
+			if (!user) return [];
+			return [
+				{
+					userId: user.id,
+					firstName: user.firstName,
+					lastName: user.lastName,
+					avatar: user.avatar,
+					count: g._count._all,
+				},
+			];
+		})
+		.sort((a, b) => {
+			if (b.count !== a.count) return b.count - a.count;
+			const an = `${a.firstName} ${a.lastName}`;
+			const bn = `${b.firstName} ${b.lastName}`;
+			return an.localeCompare(bn);
+		})
+		.slice(0, limit);
+}
+
+export interface CategoryTally {
+	category: TicketCategory;
+	count: number;
+}
+
+const ALL_CATEGORIES: readonly TicketCategory[] = [
+	TicketCategory.HR,
+	TicketCategory.IT_WEBSITE,
+	TicketCategory.PAYROLL,
+	TicketCategory.FACILITIES,
+	TicketCategory.OTHER,
+];
+
+/**
+ * Tally of Help Me ticket categories created in the last `daysBack` Manila
+ * days. Reads `metadata.category` from `TICKET_CREATED` events. Always
+ * returns one entry per category, including zero-counts, so the chart
+ * doesn't reshuffle between renders. Sorted by count desc with category
+ * name tie-break.
+ */
+export async function getCategoryMix(daysBack = 30): Promise<CategoryTally[]> {
+	const days = recentManilaDayKeys(daysBack);
+	const earliest = days[0];
+	if (!earliest) return [];
+	const since = manilaDayStartUtc(earliest);
+
+	const rows = await prisma.activityLog.findMany({
+		where: { action: "TICKET_CREATED", createdAt: { gte: since } },
+		select: { metadata: true },
+	});
+
+	const counts = new Map<TicketCategory, number>(ALL_CATEGORIES.map((c) => [c, 0]));
+	for (const row of rows) {
+		const meta = row.metadata as { category?: unknown } | null;
+		const cat = meta?.category;
+		if (typeof cat !== "string") continue;
+		if (!ALL_CATEGORIES.includes(cat as TicketCategory)) continue;
+		const key = cat as TicketCategory;
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+	}
+
+	return Array.from(counts.entries())
+		.map(([category, count]) => ({ category, count }))
+		.sort((a, b) => {
+			if (b.count !== a.count) return b.count - a.count;
+			return a.category.localeCompare(b.category);
+		});
 }

--- a/lib/insights/queries.ts
+++ b/lib/insights/queries.ts
@@ -117,6 +117,11 @@ export interface TopRecogniser {
  *   any future hard-delete path.
  */
 export async function getTopRecognisers(daysBack = 30, limit = 10): Promise<TopRecogniser[]> {
+	// Guard non-positive limit before any DB work — `slice(0, -n)` returns
+	// all-but-last n items, which would silently produce wrong results
+	// rather than the empty array a caller asking for "0 results" expects.
+	// Mirrors the daysBack <= 0 short-circuit below.
+	if (limit <= 0) return [];
 	const days = recentManilaDayKeys(daysBack);
 	const earliest = days[0];
 	if (!earliest) return [];

--- a/lib/insights/queries.ts
+++ b/lib/insights/queries.ts
@@ -129,8 +129,13 @@ export async function getTopRecognisers(daysBack = 30, limit = 10): Promise<TopR
 
 	const ids = grouped.map((g) => g.actorId).filter((id): id is string => id !== null);
 
+	// Filter `deletedAt: null` to match the rest of the app (requireSession,
+	// getUsersAction, etc.). Soft-deleted ex-employees still have user rows
+	// and their CARD_CREATED audit events stay (actorId remains non-null until
+	// hard-delete), so without this filter they'd silently show up on a live
+	// admin leaderboard.
 	const users = await prisma.user.findMany({
-		where: { id: { in: ids } },
+		where: { id: { in: ids }, deletedAt: null },
 		select: { id: true, firstName: true, lastName: true, avatar: true },
 	});
 	const usersById = new Map(users.map((u) => [u.id, u]));

--- a/lib/insights/queries.ts
+++ b/lib/insights/queries.ts
@@ -89,7 +89,7 @@ export async function getTopValues(daysBack = 30): Promise<ValueTally[]> {
 	}
 	return Array.from(counts.entries())
 		.sort(([aLabel, aCount], [bLabel, bCount]) =>
-			bCount === aCount ? aLabel.localeCompare(bLabel) : bCount - aCount,
+			bCount === aCount ? aLabel.localeCompare(bLabel, "en") : bCount - aCount,
 		)
 		.map(([value, count]) => ({ value, count }));
 }
@@ -105,9 +105,16 @@ export interface TopRecogniser {
 /**
  * Top recognisers by `CARD_CREATED` count over the last `daysBack` Manila
  * days, joined back to `User` for display. Sorted by count desc with name
- * tie-break. Excludes events whose actor has been deleted entirely (rare —
- * `actorId` is `SetNull` on user delete in the schema, so deleted users'
- * events still exist but with `actorId = null`).
+ * tie-break.
+ *
+ * Excludes:
+ * - Soft-deleted users (via `deletedAt: null` on the user lookup) — keeps
+ *   the leaderboard consistent with the rest of the app's user-listing
+ *   surfaces (`requireSession`, `getUsersAction`).
+ * - Rows whose user row was missing entirely from the lookup. The schema
+ *   has `actorId: SetNull on delete`, but the app currently soft-deletes
+ *   only — so this branch is essentially a defensive guard for races and
+ *   any future hard-delete path.
  */
 export async function getTopRecognisers(daysBack = 30, limit = 10): Promise<TopRecogniser[]> {
 	const days = recentManilaDayKeys(daysBack);
@@ -162,7 +169,7 @@ export async function getTopRecognisers(daysBack = 30, limit = 10): Promise<TopR
 			if (b.count !== a.count) return b.count - a.count;
 			const an = `${a.firstName} ${a.lastName}`;
 			const bn = `${b.firstName} ${b.lastName}`;
-			return an.localeCompare(bn);
+			return an.localeCompare(bn, "en");
 		})
 		.slice(0, limit);
 }
@@ -212,6 +219,6 @@ export async function getCategoryMix(daysBack = 30): Promise<CategoryTally[]> {
 		.map(([category, count]) => ({ category, count }))
 		.sort((a, b) => {
 			if (b.count !== a.count) return b.count - a.count;
-			return a.category.localeCompare(b.category);
+			return a.category.localeCompare(b.category, "en");
 		});
 }


### PR DESCRIPTION
Second slice of #158. Adds the two new sections that read entirely from `activity_logs` data already being captured — no schema changes, no new infra.

## Summary
- **`getTopRecognisers(daysBack, limit)`** — groupBy `CARD_CREATED` events by `actorId`, then a single `findMany` to resolve user details. Sort by count desc with full-name tie-break. Skips actors whose User row went missing between groupBy and lookup (raced soft-delete) rather than rendering partial rows.
- **`getCategoryMix(daysBack)`** — reads `metadata.category` from `TICKET_CREATED` events. Always returns one entry per `TicketCategory` enum value (zero-fill) so the chart doesn't reshuffle when a category drops to zero. Defends against null/missing/wrong-type/unknown-string `category` values in metadata.
- **Two new cards** matching the part-1 visual pattern: ranked list with avatars + bar, and category bars with share-of-total %.
- **`page.tsx`** Promise.all expanded to four queries; loading skeleton bumped from 2 to 4 cards.

## Why these two specifically
Per the issue's planned breakdown, these are the sections whose data lives entirely in `activity_logs` events already being written. **Engagement-on-cards** (cross-referencing `CARD_REACTED` + `COMMENT_CREATED` to specific recognition cards) needs a backreference resolve from `metadata.cardId` and is more interesting/risky — saving for part 3. **90-day window selector**, **caching with `cacheTag`**, and **chart library** also remain for part 3.

## Why no caching, again
Same rationale as part 1: queries are sub-100ms over a 30-day window against an already-indexed table; admin-only page; introducing `cacheTag` deserves its own PR with proper invalidation tied to writes (#155 events). Will land in part 3 with a coherent invalidation story.

## Test plan
- [x] `bun run test` — 270/270 passing (+11 new tests in `lib/insights/queries.test.ts`)
- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: visit `/dashboard/admin-settings/insights` as ADMIN — verify all four cards render, top-recognisers shows real users with correct counts, category mix shows all five categories (including zero-counts).
- [ ] Manual: confirm tie-break ordering when two users have the same recognise count (alphabetical by full name).
- [ ] Manual: open a ticket in each category over a few days — verify they show up in category mix with correct share-of-total %.

## Scope contract for part 3 (#158 still open)
Remaining for the next PR:
- Engagement-on-cards (joining `CARD_REACTED` + `COMMENT_CREATED` to recognition cards)
- 90-day window selector
- `'use cache'` + `cacheTag` daily revalidation tied to write paths
- Chart library decision (only if design needs it beyond what plain divs deliver)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Category Mix and Top Recognisers cards to admin insights, showing ticket-category distribution and a ranked recogniser leaderboard with visual bars, percentages and counts
  * Insights dashboard now includes these cards and an expanded skeleton/loading grid

* **Tests**
  * Added comprehensive tests for new analytics queries and UI components, covering empty states, sorting/tie-breaks, and bar-width/percentage calculations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->