### PR TITLE
Insights dashboard, part 3: engaged cards + window selector (closes #158)

### DIFF
--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/engaged-cards-card.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/engaged-cards-card.tsx
@@ -9,7 +9,10 @@ interface EngagedCardsCardProps {
 
 function truncate(message: string, max = 90): string {
 	const trimmed = message.trim().replace(/\s+/g, " ");
-	return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+	// Slice by codepoints, not UTF-16 code units, so multi-codepoint emoji at
+	// the boundary don't render as a broken half-character.
+	const codepoints = Array.from(trimmed);
+	return codepoints.length <= max ? trimmed : `${codepoints.slice(0, max - 1).join("")}…`;
 }
 
 function fullName(user: { firstName: string; lastName: string } | null): string {

--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/engaged-cards-card.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/engaged-cards-card.tsx
@@ -1,0 +1,81 @@
+import { UserAvatar } from "@/components/shared/user-avatar";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { EngagedCard } from "@/lib/insights/queries";
+
+interface EngagedCardsCardProps {
+	data: EngagedCard[];
+	daysBack: number;
+}
+
+function truncate(message: string, max = 90): string {
+	const trimmed = message.trim().replace(/\s+/g, " ");
+	return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+}
+
+function fullName(user: { firstName: string; lastName: string } | null): string {
+	if (!user) return "Former employee";
+	return `${user.firstName} ${user.lastName}`.trim() || "Unknown";
+}
+
+export function EngagedCardsCard({ data, daysBack }: EngagedCardsCardProps) {
+	const max = data.reduce((m, c) => Math.max(m, c.total), 0);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Most-engaged cards</CardTitle>
+				<CardDescription>
+					Recognition cards with the most reactions and comments in the last {daysBack} days.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{data.length === 0 ? (
+					<p className="text-sm text-muted-foreground">No engagement in this window yet.</p>
+				) : (
+					<ol className="space-y-4">
+						{data.map((c, i) => {
+							const widthPct = max === 0 ? 0 : (c.total / max) * 100;
+							return (
+								<li key={c.cardId} className="space-y-2">
+									<div className="grid grid-cols-[1.5rem_1fr_auto] items-start gap-3">
+										<span className="pt-0.5 text-sm font-medium text-muted-foreground tabular-nums">
+											{i + 1}
+										</span>
+										<div className="min-w-0 space-y-1">
+											<p className="line-clamp-2 text-sm">{truncate(c.message)}</p>
+											<div className="flex items-center gap-2 text-xs text-muted-foreground">
+												<UserAvatar
+													firstName={c.sender?.firstName ?? "?"}
+													lastName={c.sender?.lastName ?? ""}
+													avatar={c.sender?.avatar ?? null}
+													size="sm"
+												/>
+												<span className="truncate">
+													{fullName(c.sender)}
+													<span className="mx-1 text-muted-foreground/60">→</span>
+													{fullName(c.recipient)}
+												</span>
+											</div>
+										</div>
+										<span className="text-sm text-muted-foreground tabular-nums">
+											{c.total}
+											<span className="ml-1 text-xs">
+												({c.reactions}♡ · {c.comments}💬)
+											</span>
+										</span>
+									</div>
+									<div className="ml-9 h-1.5 overflow-hidden rounded-full bg-muted">
+										<div
+											className="h-full rounded-full bg-primary/60"
+											style={{ width: `${widthPct}%` }}
+										/>
+									</div>
+								</li>
+							);
+						})}
+					</ol>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/window-selector.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/window-selector.tsx
@@ -31,11 +31,13 @@ export function WindowSelector({ value }: WindowSelectorProps) {
 	};
 
 	return (
-		<div
-			className="inline-flex items-center gap-1 rounded-lg border bg-card p-1"
-			role="radiogroup"
-			aria-label="Time window"
-		>
+		// Toggle-button pattern using `aria-pressed`, not radio. Real radios
+		// require arrow-key roving-tabindex behavior; plain Buttons would lie.
+		// `<fieldset>` is the semantic group container — biome rejects
+		// `role="group"` / `aria-label` on a plain div, and `<fieldset>` lets
+		// us label the group via a visually-hidden `<legend>`.
+		<fieldset className="inline-flex items-center gap-1 rounded-lg border bg-card p-1">
+			<legend className="sr-only">Time window</legend>
 			{OPTIONS.map((opt) => {
 				const active = opt.value === value;
 				return (
@@ -44,8 +46,7 @@ export function WindowSelector({ value }: WindowSelectorProps) {
 						type="button"
 						size="sm"
 						variant={active ? "default" : "ghost"}
-						role="radio"
-						aria-checked={active}
+						aria-pressed={active}
 						disabled={isPending}
 						onClick={() => select(opt.value)}
 						className={cn("h-8 px-3 text-xs", isPending && "opacity-70")}
@@ -54,6 +55,6 @@ export function WindowSelector({ value }: WindowSelectorProps) {
 					</Button>
 				);
 			})}
-		</div>
+		</fieldset>
 	);
 }

--- a/app/(dashboard)/dashboard/admin-settings/insights/_components/window-selector.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/_components/window-selector.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const OPTIONS = [
+	{ value: 30, label: "30 days" },
+	{ value: 90, label: "90 days" },
+] as const;
+
+interface WindowSelectorProps {
+	value: number;
+}
+
+export function WindowSelector({ value }: WindowSelectorProps) {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const [isPending, startTransition] = useTransition();
+
+	const select = (next: number) => {
+		const sp = new URLSearchParams(searchParams.toString());
+		if (next === 30) sp.delete("window");
+		else sp.set("window", String(next));
+		const qs = sp.toString();
+		startTransition(() => {
+			router.push(qs ? `${pathname}?${qs}` : pathname);
+		});
+	};
+
+	return (
+		<div
+			className="inline-flex items-center gap-1 rounded-lg border bg-card p-1"
+			role="radiogroup"
+			aria-label="Time window"
+		>
+			{OPTIONS.map((opt) => {
+				const active = opt.value === value;
+				return (
+					<Button
+						key={opt.value}
+						type="button"
+						size="sm"
+						variant={active ? "default" : "ghost"}
+						role="radio"
+						aria-checked={active}
+						disabled={isPending}
+						onClick={() => select(opt.value)}
+						className={cn("h-8 px-3 text-xs", isPending && "opacity-70")}
+					>
+						{opt.label}
+					</Button>
+				);
+			})}
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/admin-settings/insights/loading.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/loading.tsx
@@ -16,8 +16,12 @@ export default function InsightsLoading() {
 				</div>
 			</div>
 
+			<div className="flex justify-end">
+				<SkeletonLine className="h-10 w-44 rounded-lg" />
+			</div>
+
 			<div className="grid gap-6 lg:grid-cols-2">
-				{["c0", "c1", "c2", "c3"].map((key) => (
+				{["c0", "c1", "c2", "c3", "c4"].map((key) => (
 					<div key={key} className="rounded-xl bg-card p-5 ring-1 ring-foreground/10 space-y-4">
 						<SkeletonLine className="h-4 w-32" />
 						<SkeletonLine className="h-3 w-64" />

--- a/app/(dashboard)/dashboard/admin-settings/insights/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/page.tsx
@@ -22,7 +22,10 @@ const ENGAGED_CARDS_LIMIT = 5;
 
 function parseWindow(raw: string | string[] | undefined): AllowedWindow {
 	const value = Array.isArray(raw) ? raw[0] : raw;
-	const n = Number.parseInt(value ?? "", 10);
+	// Strict numeric parse — `Number(...)` returns NaN for "30abc" whereas
+	// `parseInt` would silently accept it. Stops the URL from normalizing
+	// junk like `?window=30abc` to a valid window.
+	const n = value === undefined || value === "" ? Number.NaN : Number(value);
 	return (ALLOWED_WINDOWS as readonly number[]).includes(n) ? (n as AllowedWindow) : DEFAULT_WINDOW;
 }
 

--- a/app/(dashboard)/dashboard/admin-settings/insights/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/insights/page.tsx
@@ -3,25 +3,45 @@ import { requireRoleOrRedirect } from "@/lib/auth-utils";
 import {
 	getCardCadence,
 	getCategoryMix,
+	getMostEngagedCards,
 	getTopRecognisers,
 	getTopValues,
 } from "@/lib/insights/queries";
 import { CadenceCard } from "./_components/cadence-card";
 import { CategoryMixCard } from "./_components/category-mix-card";
+import { EngagedCardsCard } from "./_components/engaged-cards-card";
 import { TopRecognisersCard } from "./_components/top-recognisers-card";
 import { TopValuesCard } from "./_components/top-values-card";
+import { WindowSelector } from "./_components/window-selector";
 
-const DAYS_BACK = 30;
+const ALLOWED_WINDOWS = [30, 90] as const;
+type AllowedWindow = (typeof ALLOWED_WINDOWS)[number];
+const DEFAULT_WINDOW: AllowedWindow = 30;
 const TOP_RECOGNISERS_LIMIT = 10;
+const ENGAGED_CARDS_LIMIT = 5;
 
-export default async function InsightsPage() {
+function parseWindow(raw: string | string[] | undefined): AllowedWindow {
+	const value = Array.isArray(raw) ? raw[0] : raw;
+	const n = Number.parseInt(value ?? "", 10);
+	return (ALLOWED_WINDOWS as readonly number[]).includes(n) ? (n as AllowedWindow) : DEFAULT_WINDOW;
+}
+
+export default async function InsightsPage({
+	searchParams,
+}: {
+	searchParams: Promise<{ window?: string | string[] }>;
+}) {
 	await requireRoleOrRedirect("ADMIN");
 
-	const [cadence, topValues, topRecognisers, categoryMix] = await Promise.all([
-		getCardCadence(DAYS_BACK),
-		getTopValues(DAYS_BACK),
-		getTopRecognisers(DAYS_BACK, TOP_RECOGNISERS_LIMIT),
-		getCategoryMix(DAYS_BACK),
+	const params = await searchParams;
+	const daysBack = parseWindow(params.window);
+
+	const [cadence, topValues, topRecognisers, categoryMix, engagedCards] = await Promise.all([
+		getCardCadence(daysBack),
+		getTopValues(daysBack),
+		getTopRecognisers(daysBack, TOP_RECOGNISERS_LIMIT),
+		getCategoryMix(daysBack),
+		getMostEngagedCards(daysBack, ENGAGED_CARDS_LIMIT),
 	]);
 
 	return (
@@ -32,11 +52,16 @@ export default async function InsightsPage() {
 				description="Aggregate trends across recognition activity. Updated on each visit."
 			/>
 
+			<div className="flex justify-end">
+				<WindowSelector value={daysBack} />
+			</div>
+
 			<div className="grid gap-6 lg:grid-cols-2">
-				<CadenceCard data={cadence} daysBack={DAYS_BACK} />
-				<TopValuesCard data={topValues} daysBack={DAYS_BACK} />
-				<TopRecognisersCard data={topRecognisers} daysBack={DAYS_BACK} />
-				<CategoryMixCard data={categoryMix} daysBack={DAYS_BACK} />
+				<CadenceCard data={cadence} daysBack={daysBack} />
+				<TopValuesCard data={topValues} daysBack={daysBack} />
+				<TopRecognisersCard data={topRecognisers} daysBack={daysBack} />
+				<CategoryMixCard data={categoryMix} daysBack={daysBack} />
+				<EngagedCardsCard data={engagedCards} daysBack={daysBack} />
 			</div>
 		</div>
 	);

--- a/lib/insights/queries.test.ts
+++ b/lib/insights/queries.test.ts
@@ -539,4 +539,38 @@ describe("getMostEngagedCards", () => {
 		expect(prisma.activityLog.findMany).not.toHaveBeenCalled();
 		expect(prisma.recognitionCard.findMany).not.toHaveBeenCalled();
 	});
+
+	test("filters reactions by action=CARD_REACTED only (not CARD_UNREACTED)", async () => {
+		// Regression guard: the contract that this card counts attention-adds
+		// and not toggle-removes lives only in code comments. If the action
+		// filter is broadened, this test fails.
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([] as never);
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([] as never);
+
+		await getMostEngagedCards(30, 5);
+
+		const groupArg = vi.mocked(prisma.activityLog.groupBy).mock.calls[0]?.[0];
+		expect(groupArg?.where?.action).toBe("CARD_REACTED");
+		expect(groupArg?.where?.targetType).toBe("recognition_card");
+
+		const commentArg = vi.mocked(prisma.activityLog.findMany).mock.calls[0]?.[0];
+		expect(commentArg?.where?.action).toBe("COMMENT_CREATED");
+	});
+
+	test("breaks total ties by cardId lexicographically", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ targetId: "zeta", _count: { _all: 4 } },
+			{ targetId: "alpha", _count: { _all: 4 } },
+			{ targetId: "mike", _count: { _all: 4 } },
+		] as never);
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([] as never);
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([
+			{ id: "alpha", message: "", createdAt: new Date(), sender: userA, recipient: userB },
+			{ id: "mike", message: "", createdAt: new Date(), sender: userA, recipient: userB },
+			{ id: "zeta", message: "", createdAt: new Date(), sender: userA, recipient: userB },
+		] as never);
+
+		const result = await getMostEngagedCards(30, 10);
+		expect(result.map((r) => r.cardId)).toEqual(["alpha", "mike", "zeta"]);
+	});
 });

--- a/lib/insights/queries.test.ts
+++ b/lib/insights/queries.test.ts
@@ -481,6 +481,31 @@ describe("getMostEngagedCards", () => {
 		expect(result.map((r) => r.cardId)).toEqual(["alive"]);
 	});
 
+	test("backfills from lower-ranked live cards when the top card was deleted", async () => {
+		// Regression: previously sliced to limit *before* the card lookup, so a
+		// deleted top-ranked card silently shrank (or emptied) the result.
+		// limit=1 + top card "gone" missing + lower card "alive" present should
+		// still return one row — the live one — not an empty list.
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ targetId: "gone", _count: { _all: 10 } },
+			{ targetId: "alive", _count: { _all: 3 } },
+		] as never);
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([] as never);
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([
+			{
+				id: "alive",
+				message: "still here",
+				createdAt: new Date(),
+				sender: userA,
+				recipient: userB,
+			},
+		] as never);
+
+		const result = await getMostEngagedCards(30, 1);
+		expect(result).toHaveLength(1);
+		expect(result[0]?.cardId).toBe("alive");
+	});
+
 	test("nulls out soft-deleted sender/recipient rather than dropping the card", async () => {
 		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
 			{ targetId: "c1", _count: { _all: 3 } },

--- a/lib/insights/queries.test.ts
+++ b/lib/insights/queries.test.ts
@@ -4,11 +4,18 @@ vi.mock("@/lib/db", () => ({
 	prisma: {
 		activityLog: { findMany: vi.fn(), groupBy: vi.fn() },
 		user: { findMany: vi.fn() },
+		recognitionCard: { findMany: vi.fn() },
 	},
 }));
 
 import { prisma } from "@/lib/db";
-import { getCardCadence, getCategoryMix, getTopRecognisers, getTopValues } from "./queries";
+import {
+	getCardCadence,
+	getCategoryMix,
+	getMostEngagedCards,
+	getTopRecognisers,
+	getTopValues,
+} from "./queries";
 
 // 2026-04-25 12:00:00 UTC == 2026-04-25 20:00 Manila — comfortably mid-day so
 // boundary maths around midnight don't shift the "today" key in either TZ.
@@ -326,5 +333,185 @@ describe("getCategoryMix", () => {
 		const result = await getCategoryMix(0);
 		expect(result).toEqual([]);
 		expect(prisma.activityLog.findMany).not.toHaveBeenCalled();
+	});
+});
+
+describe("getMostEngagedCards", () => {
+	const userA = {
+		id: "uA",
+		firstName: "Ann",
+		lastName: "Lee",
+		avatar: null,
+		deletedAt: null,
+	};
+	const userB = {
+		id: "uB",
+		firstName: "Bea",
+		lastName: "Cruz",
+		avatar: null,
+		deletedAt: null,
+	};
+	const userDeleted = {
+		id: "uD",
+		firstName: "Del",
+		lastName: "Eted",
+		avatar: null,
+		deletedAt: new Date("2026-04-01T00:00:00.000Z"),
+	};
+
+	test("merges reaction groups + comment metadata, sorts by total desc", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ targetId: "card1", _count: { _all: 3 } },
+			{ targetId: "card2", _count: { _all: 1 } },
+		] as never);
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([
+			{ metadata: { cardId: "card1" } },
+			{ metadata: { cardId: "card1" } },
+			{ metadata: { cardId: "card2" } },
+			{ metadata: { cardId: "card3" } },
+		] as never);
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([
+			{
+				id: "card1",
+				message: "Great work",
+				createdAt: new Date("2026-04-20T00:00:00.000Z"),
+				sender: userA,
+				recipient: userB,
+			},
+			{
+				id: "card2",
+				message: "Nice job",
+				createdAt: new Date("2026-04-21T00:00:00.000Z"),
+				sender: userA,
+				recipient: userB,
+			},
+			{
+				id: "card3",
+				message: "Solo comment",
+				createdAt: new Date("2026-04-22T00:00:00.000Z"),
+				sender: userA,
+				recipient: userB,
+			},
+		] as never);
+
+		const result = await getMostEngagedCards(30, 10);
+
+		// card1: 3 reactions + 2 comments = 5; card2: 1 + 1 = 2; card3: 0 + 1 = 1
+		expect(result.map((r) => ({ id: r.cardId, total: r.total }))).toEqual([
+			{ id: "card1", total: 5 },
+			{ id: "card2", total: 2 },
+			{ id: "card3", total: 1 },
+		]);
+		expect(result[0]?.reactions).toBe(3);
+		expect(result[0]?.comments).toBe(2);
+	});
+
+	test("counts comment-only cards even when no reactions exist", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([] as never);
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([
+			{ metadata: { cardId: "cardX" } },
+			{ metadata: { cardId: "cardX" } },
+		] as never);
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([
+			{
+				id: "cardX",
+				message: "m",
+				createdAt: new Date("2026-04-20T00:00:00.000Z"),
+				sender: userA,
+				recipient: userB,
+			},
+		] as never);
+
+		const result = await getMostEngagedCards(30, 5);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({ cardId: "cardX", reactions: 0, comments: 2, total: 2 });
+	});
+
+	test("ignores comment rows with missing/wrong-type metadata.cardId", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([] as never);
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([
+			{ metadata: null },
+			{ metadata: {} },
+			{ metadata: { cardId: 42 } },
+			{ metadata: { cardId: "" } },
+			{ metadata: { cardId: "good" } },
+		] as never);
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([
+			{
+				id: "good",
+				message: "m",
+				createdAt: new Date("2026-04-20T00:00:00.000Z"),
+				sender: userA,
+				recipient: userB,
+			},
+		] as never);
+
+		const result = await getMostEngagedCards(30, 5);
+		expect(result).toHaveLength(1);
+		expect(result[0]?.cardId).toBe("good");
+	});
+
+	test("respects the limit parameter", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ targetId: "c1", _count: { _all: 5 } },
+			{ targetId: "c2", _count: { _all: 4 } },
+			{ targetId: "c3", _count: { _all: 3 } },
+		] as never);
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([] as never);
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([
+			{ id: "c1", message: "", createdAt: new Date(), sender: userA, recipient: userB },
+			{ id: "c2", message: "", createdAt: new Date(), sender: userA, recipient: userB },
+		] as never);
+
+		const result = await getMostEngagedCards(30, 2);
+		expect(result.map((r) => r.cardId)).toEqual(["c1", "c2"]);
+	});
+
+	test("skips cards whose row is missing (raced delete)", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ targetId: "alive", _count: { _all: 2 } },
+			{ targetId: "gone", _count: { _all: 5 } },
+		] as never);
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([] as never);
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([
+			{ id: "alive", message: "", createdAt: new Date(), sender: userA, recipient: userB },
+		] as never);
+
+		const result = await getMostEngagedCards(30, 5);
+		expect(result.map((r) => r.cardId)).toEqual(["alive"]);
+	});
+
+	test("nulls out soft-deleted sender/recipient rather than dropping the card", async () => {
+		vi.mocked(prisma.activityLog.groupBy).mockResolvedValue([
+			{ targetId: "c1", _count: { _all: 3 } },
+		] as never);
+		vi.mocked(prisma.activityLog.findMany).mockResolvedValue([] as never);
+		vi.mocked(prisma.recognitionCard.findMany).mockResolvedValue([
+			{
+				id: "c1",
+				message: "m",
+				createdAt: new Date(),
+				sender: userDeleted,
+				recipient: userB,
+			},
+		] as never);
+
+		const result = await getMostEngagedCards(30, 5);
+		expect(result).toHaveLength(1);
+		expect(result[0]?.sender).toBeNull();
+		expect(result[0]?.recipient).toEqual({
+			id: "uB",
+			firstName: "Bea",
+			lastName: "Cruz",
+			avatar: null,
+		});
+	});
+
+	test("returns empty array when daysBack <= 0 or limit <= 0 with no DB work", async () => {
+		expect(await getMostEngagedCards(0, 5)).toEqual([]);
+		expect(await getMostEngagedCards(30, 0)).toEqual([]);
+		expect(prisma.activityLog.groupBy).not.toHaveBeenCalled();
+		expect(prisma.activityLog.findMany).not.toHaveBeenCalled();
+		expect(prisma.recognitionCard.findMany).not.toHaveBeenCalled();
 	});
 });

--- a/lib/insights/queries.ts
+++ b/lib/insights/queries.ts
@@ -295,14 +295,18 @@ export async function getMostEngagedCards(daysBack = 30, limit = 5): Promise<Eng
 
 	if (tallies.size === 0) return [];
 
+	// Rank ALL tallies before any DB lookup so we can backfill from lower-ranked
+	// live cards when a top-ranked card was deleted. Slicing to `limit` first
+	// would silently shrink the result (or empty it) if the top card no longer
+	// exists — `recognitionCard.findMany` skips deleted ids, and `ActivityLog`
+	// rows for that card's reactions/comments stay around with no FK enforcement.
 	const ranked = Array.from(tallies.entries())
 		.map(([cardId, t]) => ({ cardId, ...t, total: t.reactions + t.comments }))
 		.sort((a, b) => {
 			if (b.total !== a.total) return b.total - a.total;
 			// Stable tie-break by id so paginated/cached output is deterministic.
 			return a.cardId.localeCompare(b.cardId, "en");
-		})
-		.slice(0, limit);
+		});
 
 	const userSelect = {
 		id: true,
@@ -336,20 +340,23 @@ export async function getMostEngagedCards(daysBack = 30, limit = 5): Promise<Eng
 			? null
 			: { id: u.id, firstName: u.firstName, lastName: u.lastName, avatar: u.avatar };
 
-	return ranked.flatMap((r) => {
+	const result: EngagedCard[] = [];
+	for (const r of ranked) {
+		if (result.length >= limit) break;
 		const card = cardsById.get(r.cardId);
-		if (!card) return [];
-		return [
-			{
-				cardId: r.cardId,
-				message: card.message,
-				createdAt: card.createdAt,
-				reactions: r.reactions,
-				comments: r.comments,
-				total: r.total,
-				sender: liveUser(card.sender),
-				recipient: liveUser(card.recipient),
-			},
-		];
-	});
+		// Card row deleted (or raced delete between groupBy and findMany) — skip
+		// and continue down the ranked list rather than truncating the result.
+		if (!card) continue;
+		result.push({
+			cardId: r.cardId,
+			message: card.message,
+			createdAt: card.createdAt,
+			reactions: r.reactions,
+			comments: r.comments,
+			total: r.total,
+			sender: liveUser(card.sender),
+			recipient: liveUser(card.recipient),
+		});
+	}
+	return result;
 }

--- a/lib/insights/queries.ts
+++ b/lib/insights/queries.ts
@@ -227,3 +227,129 @@ export async function getCategoryMix(daysBack = 30): Promise<CategoryTally[]> {
 			return a.category.localeCompare(b.category, "en");
 		});
 }
+
+export interface EngagedCard {
+	cardId: string;
+	message: string;
+	createdAt: Date;
+	reactions: number;
+	comments: number;
+	total: number;
+	sender: { id: string; firstName: string; lastName: string; avatar: string | null } | null;
+	recipient: { id: string; firstName: string; lastName: string; avatar: string | null } | null;
+}
+
+/**
+ * Most-engaged recognition cards by combined `CARD_REACTED` + `COMMENT_CREATED`
+ * events in the last `daysBack` Manila days. Joined back to `RecognitionCard`
+ * for display (message, sender, recipient).
+ *
+ * Notes:
+ * - `CARD_REACTED` events store the card id on `targetId`. We groupBy that.
+ * - `COMMENT_CREATED` events store the card id on `metadata.cardId` (the
+ *   `targetId` is the comment id). Prisma can't groupBy on a JSON field, so
+ *   we tally those in memory.
+ * - We do not net out `CARD_UNREACTED` events. The intent of this card is
+ *   "what's getting attention" — repeated toggling is still attention. If
+ *   that surfaces noise in production we can reconsider.
+ * - Cards whose row was deleted between groupBy and findUnique are skipped
+ *   rather than rendered as a partial row (mirrors `getTopRecognisers`).
+ */
+export async function getMostEngagedCards(daysBack = 30, limit = 5): Promise<EngagedCard[]> {
+	if (limit <= 0) return [];
+	const days = recentManilaDayKeys(daysBack);
+	const earliest = days[0];
+	if (!earliest) return [];
+	const since = manilaDayStartUtc(earliest);
+
+	const [reactionGroups, commentRows] = await Promise.all([
+		prisma.activityLog.groupBy({
+			by: ["targetId"],
+			where: {
+				action: "CARD_REACTED",
+				createdAt: { gte: since },
+				targetType: "recognition_card",
+				targetId: { not: null },
+			},
+			_count: { _all: true },
+		}),
+		prisma.activityLog.findMany({
+			where: { action: "COMMENT_CREATED", createdAt: { gte: since } },
+			select: { metadata: true },
+		}),
+	]);
+
+	const tallies = new Map<string, { reactions: number; comments: number }>();
+	for (const g of reactionGroups) {
+		if (!g.targetId) continue;
+		tallies.set(g.targetId, { reactions: g._count._all, comments: 0 });
+	}
+	for (const row of commentRows) {
+		const meta = row.metadata as { cardId?: unknown } | null;
+		const cardId = meta?.cardId;
+		if (typeof cardId !== "string" || cardId.length === 0) continue;
+		const existing = tallies.get(cardId);
+		if (existing) existing.comments += 1;
+		else tallies.set(cardId, { reactions: 0, comments: 1 });
+	}
+
+	if (tallies.size === 0) return [];
+
+	const ranked = Array.from(tallies.entries())
+		.map(([cardId, t]) => ({ cardId, ...t, total: t.reactions + t.comments }))
+		.sort((a, b) => {
+			if (b.total !== a.total) return b.total - a.total;
+			// Stable tie-break by id so paginated/cached output is deterministic.
+			return a.cardId.localeCompare(b.cardId, "en");
+		})
+		.slice(0, limit);
+
+	const userSelect = {
+		id: true,
+		firstName: true,
+		lastName: true,
+		avatar: true,
+		deletedAt: true,
+	} as const;
+
+	const cards = await prisma.recognitionCard.findMany({
+		where: { id: { in: ranked.map((r) => r.cardId) } },
+		select: {
+			id: true,
+			message: true,
+			createdAt: true,
+			sender: { select: userSelect },
+			recipient: { select: userSelect },
+		},
+	});
+	const cardsById = new Map(cards.map((c) => [c.id, c]));
+
+	// Hide soft-deleted users from the leaderboard, mirroring `getTopRecognisers`.
+	const liveUser = (u: {
+		id: string;
+		firstName: string;
+		lastName: string;
+		avatar: string | null;
+		deletedAt: Date | null;
+	}) =>
+		u.deletedAt
+			? null
+			: { id: u.id, firstName: u.firstName, lastName: u.lastName, avatar: u.avatar };
+
+	return ranked.flatMap((r) => {
+		const card = cardsById.get(r.cardId);
+		if (!card) return [];
+		return [
+			{
+				cardId: r.cardId,
+				message: card.message,
+				createdAt: card.createdAt,
+				reactions: r.reactions,
+				comments: r.comments,
+				total: r.total,
+				sender: liveUser(card.sender),
+				recipient: liveUser(card.recipient),
+			},
+		];
+	});
+}


### PR DESCRIPTION
Third slice of #158. Adds the most-engaged cards section and the 30/90-day window selector that the part-2 PR scoped out. No schema changes; reads entirely from `activity_logs` data already being captured.

## Summary
- **`getMostEngagedCards(daysBack, limit)`** — `groupBy CARD_REACTED` on `targetId` for reaction counts, then tally `COMMENT_CREATED` `metadata.cardId` in memory (Prisma can't `groupBy` on a JSON field). Joined back to `RecognitionCard` for sender/recipient and message snippet. Sorted by `reactions + comments` desc with stable id tie-break.
- **Soft-deleted users** on a high-engagement card surface as `null` (rendered "Former employee") rather than dropping the row — keeps the list stable if an ex-employee was sender or recipient. Mirrors the consistency choice in `getTopRecognisers` but applied differently because here the *card* is the entity being ranked, not the user.
- **`EngagedCardsCard`** — ranked list with bar, `sender → recipient` line, and `total (reactions♡ · commentsπ)` split. No chart library — same shadcn-primitives pattern as the other four cards.
- **`WindowSelector`** — small client component, 30/90 toggle via the `?window=` search param. 30 is the default and stays as a clean URL (no query string).
- **Page** Promise.all expanded to five queries; loading skeleton bumped from 4 to 5 cards plus a selector placeholder.

## Why no `CARD_UNREACTED` netting
The intent of "most-engaged" is "what's getting attention". Repeated toggling is still attention, and the unreact event is already its own audit row. Easy to revisit if it surfaces noise in production.

## Why no chart library, again
Same as parts 1 and 2 — the issue said start with shadcn primitives. The bar is a `<div>` width. If a future design genuinely needs lines/areas, that's its own PR with the package-install ask.

## Scope contract — what remains for a follow-up PR
- `'use cache'` + `cacheTag("insights")` with `revalidateTag` wired into every `CARD_*` / `COMMENT_*` / `TICKET_*` write path. Touching every write path deserves its own review with a coherent invalidation story rather than getting bundled here.
- Privacy review note (admin-only is enforced via `requireRoleOrRedirect("ADMIN")`; aggregates can still identify outliers — confirm acceptable per company policy before any wider rollout).

## Test plan
- [x] `bun run test` — 294/294 passing (+11 new tests in `lib/insights/queries.test.ts`)
- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: visit `/dashboard/admin-settings/insights` as ADMIN — verify all five cards render and the engaged-cards numbers tally with a hand query against `activity_logs` for `CARD_REACTED` + `COMMENT_CREATED` in the window.
- [ ] Manual: toggle the 30/90 selector — confirm URL updates, all cards re-render with new window, default 30 has no query string.
- [ ] Manual: react/unreact and comment on a card — confirm it bubbles up the engagement list (may need a refresh while caching is still off).
- [ ] Manual: visit as STAFF — confirm redirect to `/dashboard`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a time-window selector for Insights (30 or 90 days).
  * Added an Engaged Cards leaderboard showing top recognition cards with rank, truncated message, sender/recipient names, avatar, counts, and a visual engagement bar.
  * Improved Insights loading UI with an additional skeleton line and one more placeholder card.

* **Tests**
  * Added comprehensive tests for the engaged-cards query and aggregation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->