### PR TITLE
feat(recognition): support physical card logging via external sender name

### DIFF
--- a/app/(dashboard)/dashboard/profile/page.tsx
+++ b/app/(dashboard)/dashboard/profile/page.tsx
@@ -23,7 +23,9 @@ export default async function ProfilePage() {
 				image: true,
 			},
 		}),
-		prisma.recognitionCard.count({ where: { senderId: session.user.id } }),
+		prisma.recognitionCard.count({
+			where: { senderId: session.user.id, externalSenderName: null },
+		}),
 		prisma.recognitionCard.count({ where: { recipientId: session.user.id } }),
 	]);
 

--- a/app/(dashboard)/dashboard/recognition/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/edit/page.tsx
@@ -48,6 +48,7 @@ export default async function EditRecognitionPage({ params }: { params: Promise<
 						valuesRespect: card.valuesRespect,
 						valuesCommunication: card.valuesCommunication,
 						valuesContinuousImprovement: card.valuesContinuousImprovement,
+						externalSenderName: card.externalSenderName ?? undefined,
 					}}
 					defaultRecipient={{
 						id: card.recipient.id,

--- a/app/(dashboard)/dashboard/recognition/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/recognition/[id]/page.tsx
@@ -99,7 +99,9 @@ export default async function RecognitionDetailPage({
 	const { initialReactions, commentCount } = await getCardReactionSummary(id, session.user.id);
 
 	const recipientName = `${card.recipient.firstName} ${card.recipient.lastName}`;
-	const senderName = `${card.sender.firstName} ${card.sender.lastName}`;
+	const adminName = `${card.sender.firstName} ${card.sender.lastName}`;
+	const senderName = card.externalSenderName ?? adminName;
+	const isPhysicalCard = !!card.externalSenderName;
 	const department = card.recipient.department?.name ?? "";
 
 	const card1Front = (
@@ -272,7 +274,11 @@ export default async function RecognitionDetailPage({
 			<DashboardPageHeader
 				eyebrow="Recognition"
 				title="Recognition Card"
-				description={`From ${senderName} to ${recipientName}`}
+				description={
+					isPhysicalCard
+						? `From ${senderName} to ${recipientName} · Physical card logged by ${adminName}`
+						: `From ${senderName} to ${recipientName}`
+				}
 				actions={<CardDetailActions cardId={id} isSender={isSender} />}
 			/>
 

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-card-mini.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-card-mini.tsx
@@ -248,7 +248,7 @@ export function RecognitionCardMini({
 					>
 						<span className={cn("font-black text-black mb-0.5", s.labelText)}>FROM</span>
 						<FitText className={cn("text-[#222]", s.valueText)}>
-							{`${card.sender.firstName} ${card.sender.lastName}`}
+							{card.externalSenderName ?? `${card.sender.firstName} ${card.sender.lastName}`}
 						</FitText>
 					</div>
 					<div

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type InfiniteData, useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { ArrowRight, Eye, Heart, Pencil, Share2 } from "lucide-react";
+import { ArrowRight, Eye, Heart, Mail, Pencil, Share2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { SkeletonCard, SkeletonLine } from "@/components/shared/skeleton-primitives";
@@ -413,7 +413,8 @@ function FeedLayout({
 						>
 							{isPhysicalCard && (
 								<div className="px-5 pt-4">
-									<span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-0.5 text-[11px] font-medium text-amber-900 ring-1 ring-amber-200">
+									<span className="inline-flex items-center gap-1.5 rounded-full border border-dashed border-border bg-muted/60 px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+										<Mail size={11} className="opacity-70" aria-hidden="true" />
 										Physical card · logged by {adminName}
 									</span>
 								</div>
@@ -455,7 +456,7 @@ function FeedLayout({
 									lastName=""
 									avatar={null}
 									size="lg"
-									className="bg-amber-100 text-amber-900"
+									className="border border-dashed border-border bg-muted text-muted-foreground"
 								/>
 							) : (
 								<UserAvatar
@@ -473,7 +474,8 @@ function FeedLayout({
 										: `${card.sender.firstName} ${card.sender.lastName}`}
 								</span>
 								{isPhysicalCard ? (
-									<p className="text-muted-foreground text-xs">
+									<p className="text-muted-foreground text-xs flex items-center gap-1">
+										<Mail size={10} className="opacity-70" aria-hidden="true" />
 										Physical card · logged by {adminName}
 									</p>
 								) : (

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -394,6 +394,8 @@ function FeedLayout({
 			)}
 			{cards.map((card) => {
 				const isSender = currentUserId === card.sender.id;
+				const isPhysicalCard = !!card.externalSenderName;
+				const adminName = `${card.sender.firstName} ${card.sender.lastName}`;
 				const actions =
 					showActions && onShare ? (
 						<CardActions cardId={card.id} isSender={isSender} onShare={handleShare} />
@@ -409,6 +411,13 @@ function FeedLayout({
 								cardMaxWidth,
 							)}
 						>
+							{isPhysicalCard && (
+								<div className="px-5 pt-4">
+									<span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-0.5 text-[11px] font-medium text-amber-900 ring-1 ring-amber-200">
+										Physical card · logged by {adminName}
+									</span>
+								</div>
+							)}
 							<div className="relative overflow-hidden rounded-t-[2rem]">
 								<RecognitionCardMini card={card} size={cardSize} isNew={isNew} />
 								{actions && <div className="absolute top-3 right-3 z-10">{actions}</div>}
@@ -440,19 +449,37 @@ function FeedLayout({
 						)}
 					>
 						<div className="flex items-center gap-3 mb-3">
-							<UserAvatar
-								firstName={card.sender.firstName}
-								lastName={card.sender.lastName}
-								avatar={card.sender.avatar}
-								size="lg"
-								className="bg-primary/10 text-primary"
-							/>
+							{isPhysicalCard ? (
+								<UserAvatar
+									firstName={card.externalSenderName ?? ""}
+									lastName=""
+									avatar={null}
+									size="lg"
+									className="bg-amber-100 text-amber-900"
+								/>
+							) : (
+								<UserAvatar
+									firstName={card.sender.firstName}
+									lastName={card.sender.lastName}
+									avatar={card.sender.avatar}
+									size="lg"
+									className="bg-primary/10 text-primary"
+								/>
+							)}
 							<div className="text-sm">
 								<span className="font-medium text-foreground">
-									{card.sender.firstName} {card.sender.lastName}
+									{isPhysicalCard
+										? card.externalSenderName
+										: `${card.sender.firstName} ${card.sender.lastName}`}
 								</span>
-								{card.sender.position && (
-									<p className="text-muted-foreground text-xs">{card.sender.position}</p>
+								{isPhysicalCard ? (
+									<p className="text-muted-foreground text-xs">
+										Physical card · logged by {adminName}
+									</p>
+								) : (
+									card.sender.position && (
+										<p className="text-muted-foreground text-xs">{card.sender.position}</p>
+									)
 								)}
 							</div>
 							<ArrowRight size={16} className="text-muted-foreground mx-1" />

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-feed.tsx
@@ -412,7 +412,7 @@ function FeedLayout({
 							)}
 						>
 							{isPhysicalCard && (
-								<div className="px-5 pt-4">
+								<div className="px-5 pt-4 pb-3">
 									<span className="inline-flex items-center gap-1.5 rounded-full border border-dashed border-border bg-muted/60 px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground">
 										<Mail size={11} className="opacity-70" aria-hidden="true" />
 										Physical card · logged by {adminName}

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
@@ -422,7 +422,7 @@ export function RecognitionForm({
 				<ProgressBar currentStep={step} />
 
 				{isAdmin && step === 1 && (
-					<div className="w-full max-w-5xl rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+					<div className="w-full max-w-5xl rounded-2xl border border-border bg-muted/40 px-4 py-3 text-sm text-foreground">
 						<label className="flex items-start gap-3 cursor-pointer">
 							<input
 								type="checkbox"
@@ -434,11 +434,11 @@ export function RecognitionForm({
 										setValue("externalSenderName", undefined, { shouldValidate: true });
 									}
 								}}
-								className="mt-0.5 h-4 w-4 accent-amber-600"
+								className="mt-0.5 h-4 w-4 accent-primary"
 							/>
 							<span>
 								<span className="font-medium">Log a physical card</span>
-								<span className="block text-xs text-amber-800/80">
+								<span className="block text-xs text-muted-foreground">
 									Use this when recording a paper card from someone outside the platform. The
 									recipient will be notified, and the card will be marked as logged by you.
 								</span>

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-form.tsx
@@ -248,6 +248,8 @@ interface RecognitionFormProps {
 	defaultRecipient?: ActiveUser | null;
 }
 
+const ADMIN_ROLES = new Set(["ADMIN", "SUPERADMIN"]);
+
 export function RecognitionForm({
 	mode = "create",
 	cardId,
@@ -267,7 +269,9 @@ export function RecognitionForm({
 	const dropdownRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
 
-	const senderName = session?.user ? `${session.user.firstName} ${session.user.lastName}` : "";
+	const isAdmin = ADMIN_ROLES.has(session?.user?.role ?? "");
+	const [isPhysicalCard, setIsPhysicalCard] = useState<boolean>(!!editDefaults?.externalSenderName);
+	const adminName = session?.user ? `${session.user.firstName} ${session.user.lastName}` : "";
 
 	const [todayLocal, setTodayLocal] = useState(() => formatLocalDate(new Date()));
 
@@ -295,8 +299,12 @@ export function RecognitionForm({
 			valuesRespect: editDefaults?.valuesRespect ?? false,
 			valuesCommunication: editDefaults?.valuesCommunication ?? false,
 			valuesContinuousImprovement: editDefaults?.valuesContinuousImprovement ?? false,
+			externalSenderName: editDefaults?.externalSenderName ?? undefined,
 		},
 	});
+
+	const externalSenderName = watch("externalSenderName");
+	const senderName = isPhysicalCard && externalSenderName ? externalSenderName : adminName;
 
 	const { data: usersData } = useQuery<{
 		success: boolean;
@@ -413,6 +421,32 @@ export function RecognitionForm({
 				{/* Progress Bar */}
 				<ProgressBar currentStep={step} />
 
+				{isAdmin && step === 1 && (
+					<div className="w-full max-w-5xl rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+						<label className="flex items-start gap-3 cursor-pointer">
+							<input
+								type="checkbox"
+								checked={isPhysicalCard}
+								onChange={(e) => {
+									const next = e.target.checked;
+									setIsPhysicalCard(next);
+									if (!next) {
+										setValue("externalSenderName", undefined, { shouldValidate: true });
+									}
+								}}
+								className="mt-0.5 h-4 w-4 accent-amber-600"
+							/>
+							<span>
+								<span className="font-medium">Log a physical card</span>
+								<span className="block text-xs text-amber-800/80">
+									Use this when recording a paper card from someone outside the platform. The
+									recipient will be notified, and the card will be marked as logged by you.
+								</span>
+							</span>
+						</label>
+					</div>
+				)}
+
 				{/* ============================================ */}
 				{/* STEP 1 — Card 2 (Back / Fill Card)          */}
 				{/* ============================================ */}
@@ -488,7 +522,21 @@ export function RecognitionForm({
 								<div className="flex gap-4">
 									<div className="bg-white p-3 md:p-4 rounded-sm flex flex-col flex-1 h-20 shadow-sm">
 										<span className="text-xs font-black text-black mb-1">FROM</span>
-										<span className="text-lg text-[#222]">{senderName}</span>
+										{isPhysicalCard ? (
+											<input
+												type="text"
+												{...register("externalSenderName")}
+												placeholder="Sender name (e.g. Jane Doe)"
+												className="w-full outline-none text-lg bg-transparent text-[#222] placeholder:text-gray-400"
+												maxLength={100}
+												spellCheck="false"
+											/>
+										) : (
+											<span className="text-lg text-[#222]">{senderName}</span>
+										)}
+										{errors.externalSenderName && (
+											<p className="text-xs text-red-600">{errors.externalSenderName.message}</p>
+										)}
 									</div>
 									<div className="bg-white p-3 md:p-4 rounded-sm flex flex-col flex-1 h-20 shadow-sm">
 										<span className="text-xs font-black text-black mb-1">DATE</span>

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
@@ -367,21 +367,39 @@ export function RecognitionTable() {
 										<TableRow key={card.id}>
 											<TableCell>
 												<div className="flex items-center gap-2">
-													<UserAvatar
-														firstName={card.sender.firstName}
-														lastName={card.sender.lastName}
-														avatar={card.sender.avatar}
-														size="sm"
-														className="bg-primary/10 text-primary"
-													/>
+													{card.externalSenderName ? (
+														<UserAvatar
+															firstName={card.externalSenderName}
+															lastName=""
+															avatar={null}
+															size="sm"
+															className="bg-amber-100 text-amber-900"
+														/>
+													) : (
+														<UserAvatar
+															firstName={card.sender.firstName}
+															lastName={card.sender.lastName}
+															avatar={card.sender.avatar}
+															size="sm"
+															className="bg-primary/10 text-primary"
+														/>
+													)}
 													<div className="min-w-0">
 														<p className="text-sm font-medium text-foreground truncate">
-															{card.sender.firstName} {card.sender.lastName}
+															{card.externalSenderName ??
+																`${card.sender.firstName} ${card.sender.lastName}`}
 														</p>
-														{card.sender.position && (
+														{card.externalSenderName ? (
 															<p className="text-xs text-muted-foreground truncate">
-																{card.sender.position}
+																Physical card · logged by {card.sender.firstName}{" "}
+																{card.sender.lastName}
 															</p>
+														) : (
+															card.sender.position && (
+																<p className="text-xs text-muted-foreground truncate">
+																	{card.sender.position}
+																</p>
+															)
 														)}
 													</div>
 												</div>

--- a/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
+++ b/app/(dashboard)/dashboard/recognition/_components/recognition-table.tsx
@@ -6,6 +6,7 @@ import {
 	ChevronRight,
 	Eye,
 	Heart,
+	Mail,
 	Pencil,
 	Search,
 	Share2,
@@ -373,7 +374,7 @@ export function RecognitionTable() {
 															lastName=""
 															avatar={null}
 															size="sm"
-															className="bg-amber-100 text-amber-900"
+															className="border border-dashed border-border bg-muted text-muted-foreground"
 														/>
 													) : (
 														<UserAvatar
@@ -390,9 +391,16 @@ export function RecognitionTable() {
 																`${card.sender.firstName} ${card.sender.lastName}`}
 														</p>
 														{card.externalSenderName ? (
-															<p className="text-xs text-muted-foreground truncate">
-																Physical card · logged by {card.sender.firstName}{" "}
-																{card.sender.lastName}
+															<p className="text-xs text-muted-foreground flex items-center gap-1 min-w-0">
+																<Mail
+																	size={10}
+																	className="opacity-70 shrink-0"
+																	aria-hidden="true"
+																/>
+																<span className="truncate">
+																	Physical card · logged by {card.sender.firstName}{" "}
+																	{card.sender.lastName}
+																</span>
 															</p>
 														) : (
 															card.sender.position && (

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
 		if (filter === "received") {
 			where = { recipientId: session.user.id };
 		} else if (filter === "sent") {
-			where = { senderId: session.user.id };
+			where = { senderId: session.user.id, externalSenderName: null };
 		} else if (filter === "department") {
 			const departmentId = session.user.departmentId as string | null | undefined;
 			if (departmentId) {

--- a/app/api/recognition/route.ts
+++ b/app/api/recognition/route.ts
@@ -85,6 +85,7 @@ export async function GET(request: NextRequest) {
 						{ sender: { lastName: { contains: search, mode: "insensitive" } } },
 						{ recipient: { firstName: { contains: search, mode: "insensitive" } } },
 						{ recipient: { lastName: { contains: search, mode: "insensitive" } } },
+						{ externalSenderName: { contains: search, mode: "insensitive" } },
 					],
 				});
 			}

--- a/app/api/recognition/stats/route.test.ts
+++ b/app/api/recognition/stats/route.test.ts
@@ -105,7 +105,11 @@ describe("GET /api/recognition/stats", () => {
 
 		const calls = vi.mocked(prisma.recognitionCard.count).mock.calls;
 		expect(calls[0]?.[0]).toEqual({
-			where: { senderId: USER_ID, createdAt: { gte: START, lt: END } },
+			where: {
+				senderId: USER_ID,
+				externalSenderName: null,
+				createdAt: { gte: START, lt: END },
+			},
 		});
 		expect(calls[1]?.[0]).toEqual({
 			where: { recipientId: USER_ID, createdAt: { gte: START, lt: END } },

--- a/app/api/recognition/stats/route.ts
+++ b/app/api/recognition/stats/route.ts
@@ -35,6 +35,7 @@ export async function GET() {
 			prisma.recognitionCard.count({
 				where: {
 					senderId: userId,
+					externalSenderName: null,
 					createdAt: { gte: startOfMonth, lt: endOfMonth },
 				},
 			}),

--- a/app/recognition/[id]/opengraph-image.tsx
+++ b/app/recognition/[id]/opengraph-image.tsx
@@ -42,7 +42,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
 	}
 
 	const recipientName = `${card.recipient.firstName} ${card.recipient.lastName}`;
-	const senderName = `${card.sender.firstName} ${card.sender.lastName}`;
+	const senderName = card.externalSenderName ?? `${card.sender.firstName} ${card.sender.lastName}`;
 	const message = card.message.length > 150 ? `${card.message.slice(0, 150)}...` : card.message;
 	const [year, month, day] = card.date.toISOString().split("T")[0].split("-");
 	const dateStr = new Date(Number(year), Number(month) - 1, Number(day)).toLocaleDateString(

--- a/app/recognition/[id]/page.tsx
+++ b/app/recognition/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { Check } from "lucide-react";
+import { Check, Mail } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -321,7 +321,8 @@ export default async function SharePage({ params }: { params: Promise<{ id: stri
 	return (
 		<div className="min-h-screen bg-[#f5f5f5] flex flex-col items-center justify-center py-8 px-4">
 			{isPhysicalCard && (
-				<div className="mb-4 inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-900 ring-1 ring-amber-200">
+				<div className="mb-4 inline-flex items-center gap-2 rounded-full border border-dashed border-border bg-muted/60 px-3 py-1 text-xs font-medium text-muted-foreground">
+					<Mail size={12} className="opacity-70" aria-hidden="true" />
 					Physical card · logged by {adminName}
 				</div>
 			)}

--- a/app/recognition/[id]/page.tsx
+++ b/app/recognition/[id]/page.tsx
@@ -63,7 +63,7 @@ export async function generateMetadata({
 	}
 
 	const recipientName = `${card.recipient.firstName} ${card.recipient.lastName}`;
-	const senderName = `${card.sender.firstName} ${card.sender.lastName}`;
+	const senderName = card.externalSenderName ?? `${card.sender.firstName} ${card.sender.lastName}`;
 	const title = `Recognition for ${recipientName}`;
 	const description = `${senderName} recognized ${recipientName}: ${card.message.slice(0, 120)}${card.message.length > 120 ? "..." : ""}`;
 
@@ -141,7 +141,9 @@ export default async function SharePage({ params }: { params: Promise<{ id: stri
 	);
 
 	const recipientName = `${card.recipient.firstName} ${card.recipient.lastName}`;
-	const senderName = `${card.sender.firstName} ${card.sender.lastName}`;
+	const adminName = `${card.sender.firstName} ${card.sender.lastName}`;
+	const senderName = card.externalSenderName ?? adminName;
+	const isPhysicalCard = !!card.externalSenderName;
 	const department = card.recipient.department?.name ?? "";
 
 	const card1Front = (
@@ -318,6 +320,11 @@ export default async function SharePage({ params }: { params: Promise<{ id: stri
 
 	return (
 		<div className="min-h-screen bg-[#f5f5f5] flex flex-col items-center justify-center py-8 px-4">
+			{isPhysicalCard && (
+				<div className="mb-4 inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-900 ring-1 ring-amber-200">
+					Physical card · logged by {adminName}
+				</div>
+			)}
 			<FlipCard front={card1Front} back={card2Back} />
 
 			{canInteract && userId ? (

--- a/lib/actions/recognition-actions.test.ts
+++ b/lib/actions/recognition-actions.test.ts
@@ -201,6 +201,15 @@ describe("createRecognitionCardAction", () => {
 				message: expect.stringContaining("Jane Doe"),
 			}),
 		});
+		expect(logActivityForRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "CARD_CREATED",
+				metadata: expect.objectContaining({
+					physicalCard: true,
+					externalSenderName: "Jane Doe",
+				}),
+			}),
+		);
 	});
 
 	test("non-admin cannot submit externalSenderName", async () => {
@@ -342,6 +351,62 @@ describe("updateRecognitionCardAction", () => {
 			error: "Only admins can log physical cards",
 		});
 		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("non-admin cannot change recipient on an existing physical card", async () => {
+		const CARD_ID = "card_phys_recip";
+		const NEW_RECIPIENT = "recipient_new";
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(SENDER_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.recognitionCard.findUnique).mockResolvedValue({
+			senderId: SENDER_ID,
+			recipientId: RECIPIENT_ID,
+			externalSenderName: "Jane Doe",
+		} as never);
+
+		const result = await updateRecognitionCardAction(
+			CARD_ID,
+			validInput({ recipientId: NEW_RECIPIENT, externalSenderName: "Jane Doe" }),
+		);
+
+		expect(result).toEqual({
+			success: false,
+			error: "Only admins can change the recipient on a physical card",
+		});
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("admin can change recipient on an existing physical card", async () => {
+		const CARD_ID = "card_phys_admin_recip";
+		const NEW_RECIPIENT = "recipient_new_2";
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(SENDER_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.recognitionCard.findUnique).mockResolvedValue({
+			senderId: SENDER_ID,
+			recipientId: RECIPIENT_ID,
+			externalSenderName: "Jane Doe",
+		} as never);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: NEW_RECIPIENT } as never);
+
+		const updatedCard = { id: CARD_ID, senderId: SENDER_ID, recipientId: NEW_RECIPIENT };
+		const tx = {
+			recognitionCard: { update: vi.fn().mockResolvedValue(updatedCard) },
+			notification: {
+				create: vi.fn().mockResolvedValue({}),
+				deleteMany: vi.fn().mockResolvedValue({}),
+			},
+		};
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
+			cb(tx)) as never);
+
+		const result = await updateRecognitionCardAction(
+			CARD_ID,
+			validInput({ recipientId: NEW_RECIPIENT, externalSenderName: "Jane Doe" }),
+		);
+
+		expect(result.success).toBe(true);
 	});
 
 	test("non-admin cannot newly set externalSenderName on existing regular card", async () => {

--- a/lib/actions/recognition-actions.test.ts
+++ b/lib/actions/recognition-actions.test.ts
@@ -169,6 +169,92 @@ describe("createRecognitionCardAction", () => {
 
 		expect(result).toEqual({ success: false, error: "Unauthorized" });
 	});
+
+	test("admin can log a physical card with externalSenderName", async () => {
+		const ADMIN_ID = "admin_1";
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(ADMIN_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: RECIPIENT_ID } as never);
+
+		const createdCard = { id: "card_phys_1", senderId: ADMIN_ID, recipientId: RECIPIENT_ID };
+		const tx = {
+			recognitionCard: { create: vi.fn().mockResolvedValue(createdCard) },
+			notification: { create: vi.fn().mockResolvedValue({}) },
+		};
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
+			cb(tx)) as never);
+
+		const result = await createRecognitionCardAction(
+			validInput({ externalSenderName: "Jane Doe" }),
+		);
+
+		expect(result).toEqual({ success: true, data: createdCard });
+		expect(tx.recognitionCard.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				senderId: ADMIN_ID,
+				externalSenderName: "Jane Doe",
+			}),
+		});
+		expect(tx.notification.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				message: expect.stringContaining("Jane Doe"),
+			}),
+		});
+	});
+
+	test("non-admin cannot submit externalSenderName", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(SENDER_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+
+		const result = await createRecognitionCardAction(
+			validInput({ externalSenderName: "Jane Doe" }),
+		);
+
+		expect(result).toEqual({
+			success: false,
+			error: "Only admins can log physical cards",
+		});
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("rejects whitespace-only externalSenderName at zod layer", async () => {
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(SENDER_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+
+		const result = await createRecognitionCardAction(validInput({ externalSenderName: "   " }));
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const err = result.error as Record<string, string[] | undefined>;
+			expect(err.externalSenderName?.[0]).toContain("required");
+		}
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("admin can self-recognize when logging on behalf of an external sender", async () => {
+		const ADMIN_ID = "admin_2";
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(ADMIN_ID, "ADMIN") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: ADMIN_ID } as never);
+
+		const createdCard = { id: "card_self", senderId: ADMIN_ID, recipientId: ADMIN_ID };
+		const tx = {
+			recognitionCard: { create: vi.fn().mockResolvedValue(createdCard) },
+			notification: { create: vi.fn().mockResolvedValue({}) },
+		};
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
+			cb(tx)) as never);
+
+		const result = await createRecognitionCardAction(
+			validInput({ recipientId: ADMIN_ID, externalSenderName: "Jane Doe" }),
+		);
+
+		expect(result.success).toBe(true);
+	});
 });
 
 describe("updateRecognitionCardAction", () => {
@@ -205,6 +291,80 @@ describe("updateRecognitionCardAction", () => {
 				targetId: CARD_ID,
 			}),
 		);
+	});
+
+	test("demoted admin can edit own physical card when externalSenderName is unchanged", async () => {
+		const CARD_ID = "card_phys_existing";
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(SENDER_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.recognitionCard.findUnique).mockResolvedValue({
+			senderId: SENDER_ID,
+			recipientId: RECIPIENT_ID,
+			externalSenderName: "Jane Doe",
+		} as never);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: RECIPIENT_ID } as never);
+
+		const updatedCard = { id: CARD_ID, senderId: SENDER_ID, recipientId: RECIPIENT_ID };
+		const tx = {
+			recognitionCard: { update: vi.fn().mockResolvedValue(updatedCard) },
+			notification: {
+				create: vi.fn().mockResolvedValue({}),
+				deleteMany: vi.fn().mockResolvedValue({}),
+			},
+		};
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
+			cb(tx)) as never);
+
+		const result = await updateRecognitionCardAction(
+			CARD_ID,
+			validInput({ message: "Updated message", externalSenderName: "Jane Doe" }),
+		);
+
+		expect(result.success).toBe(true);
+	});
+
+	test("non-admin cannot remove externalSenderName from existing physical card", async () => {
+		const CARD_ID = "card_phys_existing_2";
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(SENDER_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.recognitionCard.findUnique).mockResolvedValue({
+			senderId: SENDER_ID,
+			recipientId: RECIPIENT_ID,
+			externalSenderName: "Jane Doe",
+		} as never);
+
+		const result = await updateRecognitionCardAction(CARD_ID, validInput());
+
+		expect(result).toEqual({
+			success: false,
+			error: "Only admins can log physical cards",
+		});
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("non-admin cannot newly set externalSenderName on existing regular card", async () => {
+		const CARD_ID = "card_regular";
+		vi.mocked(requireSession).mockResolvedValue(
+			mockSession(SENDER_ID, "STAFF") as unknown as Awaited<ReturnType<typeof requireSession>>,
+		);
+		vi.mocked(prisma.recognitionCard.findUnique).mockResolvedValue({
+			senderId: SENDER_ID,
+			recipientId: RECIPIENT_ID,
+			externalSenderName: null,
+		} as never);
+
+		const result = await updateRecognitionCardAction(
+			CARD_ID,
+			validInput({ externalSenderName: "Jane Doe" }),
+		);
+
+		expect(result).toEqual({
+			success: false,
+			error: "Only admins can log physical cards",
+		});
+		expect(prisma.$transaction).not.toHaveBeenCalled();
 	});
 });
 

--- a/lib/actions/recognition-actions.ts
+++ b/lib/actions/recognition-actions.ts
@@ -143,7 +143,10 @@ export async function updateRecognitionCardAction(cardId: string, formData: unkn
 			};
 		}
 
-		if (isPhysicalCard && !hasMinRole(session.user.role as Role, "ADMIN")) {
+		const externalSenderChanged =
+			(externalSenderName ?? null) !== (existingCard.externalSenderName ?? null);
+
+		if (externalSenderChanged && !hasMinRole(session.user.role as Role, "ADMIN")) {
 			return {
 				success: false as const,
 				error: "Only admins can log physical cards",

--- a/lib/actions/recognition-actions.ts
+++ b/lib/actions/recognition-actions.ts
@@ -1,9 +1,11 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import type { Role } from "@/app/generated/prisma/client";
 import { logActivityForRequest } from "@/lib/activity-log";
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
+import { hasMinRole } from "@/lib/permissions";
 import { createRecognitionCardSchema } from "@/lib/validations/recognition";
 
 function pickedValues(input: {
@@ -35,9 +37,19 @@ export async function createRecognitionCardAction(formData: unknown) {
 			};
 		}
 
-		const { date, recipientId, ...rest } = parsed.data;
+		const { date, recipientId, externalSenderName: rawExternal, ...rest } = parsed.data;
+		const externalSenderName =
+			rawExternal && rawExternal.trim().length > 0 ? rawExternal.trim() : undefined;
+		const isPhysicalCard = !!externalSenderName;
 
-		if (recipientId === session.user.id) {
+		if (isPhysicalCard && !hasMinRole(session.user.role as Role, "ADMIN")) {
+			return {
+				success: false as const,
+				error: "Only admins can log physical cards",
+			};
+		}
+
+		if (!isPhysicalCard && recipientId === session.user.id) {
 			return {
 				success: false as const,
 				error: "You cannot send a recognition card to yourself",
@@ -62,6 +74,7 @@ export async function createRecognitionCardAction(formData: unknown) {
 					...rest,
 					recipientId,
 					senderId: session.user.id,
+					externalSenderName: externalSenderName ?? null,
 					date: new Date(`${date}T00:00:00`),
 				},
 			});
@@ -70,7 +83,9 @@ export async function createRecognitionCardAction(formData: unknown) {
 				data: {
 					userId: recipientId,
 					type: "CARD_RECEIVED",
-					message: `${session.user.name} sent you a recognition card`,
+					message: isPhysicalCard
+						? `${externalSenderName} sent you a recognition card (logged by ${session.user.name})`
+						: `${session.user.name} sent you a recognition card`,
 					cardId: created.id,
 				},
 			});
@@ -83,7 +98,11 @@ export async function createRecognitionCardAction(formData: unknown) {
 			actorId: session.user.id,
 			targetType: "recognition_card",
 			targetId: card.id,
-			metadata: { recipientId, valuesPicked: pickedValues(rest) },
+			metadata: {
+				recipientId,
+				valuesPicked: pickedValues(rest),
+				...(isPhysicalCard ? { externalSenderName } : {}),
+			},
 		});
 
 		revalidatePath("/dashboard/recognition");
@@ -107,11 +126,14 @@ export async function updateRecognitionCardAction(cardId: string, formData: unkn
 			};
 		}
 
-		const { date, recipientId, ...rest } = parsed.data;
+		const { date, recipientId, externalSenderName: rawExternal, ...rest } = parsed.data;
+		const externalSenderName =
+			rawExternal && rawExternal.trim().length > 0 ? rawExternal.trim() : undefined;
+		const isPhysicalCard = !!externalSenderName;
 
 		const existingCard = await prisma.recognitionCard.findUnique({
 			where: { id: cardId },
-			select: { senderId: true, recipientId: true },
+			select: { senderId: true, recipientId: true, externalSenderName: true },
 		});
 
 		if (!existingCard || existingCard.senderId !== session.user.id) {
@@ -121,7 +143,14 @@ export async function updateRecognitionCardAction(cardId: string, formData: unkn
 			};
 		}
 
-		if (recipientId === session.user.id) {
+		if (isPhysicalCard && !hasMinRole(session.user.role as Role, "ADMIN")) {
+			return {
+				success: false as const,
+				error: "Only admins can log physical cards",
+			};
+		}
+
+		if (!isPhysicalCard && recipientId === session.user.id) {
 			return {
 				success: false as const,
 				error: "You cannot send a recognition card to yourself",
@@ -148,6 +177,7 @@ export async function updateRecognitionCardAction(cardId: string, formData: unkn
 				data: {
 					...rest,
 					recipientId,
+					externalSenderName: externalSenderName ?? null,
 					date: new Date(`${date}T00:00:00`),
 				},
 			});
@@ -158,13 +188,17 @@ export async function updateRecognitionCardAction(cardId: string, formData: unkn
 				});
 			}
 
+			const senderLabel = isPhysicalCard
+				? `${externalSenderName} (logged by ${session.user.name})`
+				: session.user.name;
+
 			await tx.notification.create({
 				data: {
 					userId: updated.recipientId,
 					type: recipientChanged ? "CARD_RECEIVED" : "CARD_EDITED",
 					message: recipientChanged
-						? `${session.user.name} sent you a recognition card`
-						: `${session.user.name} edited a recognition card sent to you`,
+						? `${senderLabel} sent you a recognition card`
+						: `${senderLabel} edited a recognition card sent to you`,
 					cardId: updated.id,
 				},
 			});

--- a/lib/actions/recognition-actions.ts
+++ b/lib/actions/recognition-actions.ts
@@ -101,7 +101,7 @@ export async function createRecognitionCardAction(formData: unknown) {
 			metadata: {
 				recipientId,
 				valuesPicked: pickedValues(rest),
-				...(isPhysicalCard ? { externalSenderName } : {}),
+				...(isPhysicalCard ? { physicalCard: true, externalSenderName } : {}),
 			},
 		});
 
@@ -145,11 +145,21 @@ export async function updateRecognitionCardAction(cardId: string, formData: unkn
 
 		const externalSenderChanged =
 			(externalSenderName ?? null) !== (existingCard.externalSenderName ?? null);
+		const isAdmin = hasMinRole(session.user.role as Role, "ADMIN");
+		const wasPhysicalCard = !!existingCard.externalSenderName;
+		const recipientChanged = existingCard.recipientId !== recipientId;
 
-		if (externalSenderChanged && !hasMinRole(session.user.role as Role, "ADMIN")) {
+		if (externalSenderChanged && !isAdmin) {
 			return {
 				success: false as const,
 				error: "Only admins can log physical cards",
+			};
+		}
+
+		if (wasPhysicalCard && recipientChanged && !isAdmin) {
+			return {
+				success: false as const,
+				error: "Only admins can change the recipient on a physical card",
 			};
 		}
 
@@ -171,8 +181,6 @@ export async function updateRecognitionCardAction(cardId: string, formData: unkn
 				error: "Recipient not found or deleted",
 			};
 		}
-
-		const recipientChanged = existingCard.recipientId !== recipientId;
 
 		const card = await prisma.$transaction(async (tx) => {
 			const updated = await tx.recognitionCard.update({

--- a/lib/insights/queries.test.ts
+++ b/lib/insights/queries.test.ts
@@ -242,6 +242,13 @@ describe("getTopRecognisers", () => {
 		const arg = vi.mocked(prisma.activityLog.groupBy).mock.calls[0]?.[0];
 		expect(arg?.where?.action).toBe("CARD_CREATED");
 		expect(arg?.where?.actorId).toEqual({ not: null });
+		// Physical cards are logged by an admin on behalf of an external sender.
+		// The CARD_CREATED audit row stays for accountability, but the recogniser
+		// leaderboard must exclude them so admins aren't inflated for paper-card
+		// data entry. See `metadata.physicalCard` set in recognition-actions.ts.
+		expect(arg?.where?.NOT).toEqual({
+			metadata: { path: ["physicalCard"], equals: true },
+		});
 	});
 
 	test("returns empty array when daysBack <= 0", async () => {

--- a/lib/insights/queries.ts
+++ b/lib/insights/queries.ts
@@ -133,6 +133,7 @@ export async function getTopRecognisers(daysBack = 30, limit = 10): Promise<TopR
 			action: "CARD_CREATED",
 			createdAt: { gte: since },
 			actorId: { not: null },
+			NOT: { metadata: { path: ["physicalCard"], equals: true } },
 		},
 		_count: { _all: true },
 	});

--- a/lib/recognition.ts
+++ b/lib/recognition.ts
@@ -53,6 +53,7 @@ export interface RecognitionCard {
 	createdAt: string;
 	sender: RecognitionUser;
 	recipient: RecognitionUser;
+	externalSenderName: string | null;
 	valuesPeople: boolean;
 	valuesSafety: boolean;
 	valuesRespect: boolean;
@@ -120,6 +121,7 @@ export interface ExportRecognitionCard {
 	date: string;
 	sender: ExportRecognitionUser;
 	recipient: ExportRecognitionUser;
+	externalSenderName: string | null;
 	valuesPeople: boolean;
 	valuesSafety: boolean;
 	valuesRespect: boolean;
@@ -178,7 +180,7 @@ export function generateRecognitionCsv(cards: ExportRecognitionCard[]): string {
 		formatDateForExport(card.date),
 		card.recipient.branch ?? "",
 		card.sender.branch ?? "",
-		`${card.sender.firstName} ${card.sender.lastName}`,
+		card.externalSenderName ?? `${card.sender.firstName} ${card.sender.lastName}`,
 		card.message,
 		card.valuesSafety ? "x" : "",
 		card.valuesPeople ? "x" : "",

--- a/lib/validations/recognition.ts
+++ b/lib/validations/recognition.ts
@@ -21,6 +21,7 @@ export const createRecognitionCardSchema = z
 		externalSenderName: z
 			.string()
 			.trim()
+			.min(1, "Sender name is required")
 			.max(100, "Sender name must be 100 characters or less")
 			.optional(),
 	})

--- a/lib/validations/recognition.ts
+++ b/lib/validations/recognition.ts
@@ -18,6 +18,11 @@ export const createRecognitionCardSchema = z
 		valuesRespect: z.boolean(),
 		valuesCommunication: z.boolean(),
 		valuesContinuousImprovement: z.boolean(),
+		externalSenderName: z
+			.string()
+			.trim()
+			.max(100, "Sender name must be 100 characters or less")
+			.optional(),
 	})
 	.refine(
 		(data) =>

--- a/prisma/migrations/0010_add_external_sender_name/migration.sql
+++ b/prisma/migrations/0010_add_external_sender_name/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "recognition_cards" ADD COLUMN "external_sender_name" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -217,10 +217,11 @@ model RecognitionCard {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  senderId    String @map("sender_id")
-  sender      User   @relation("sender", fields: [senderId], references: [id])
-  recipientId String @map("recipient_id")
-  recipient   User   @relation("recipient", fields: [recipientId], references: [id])
+  senderId           String  @map("sender_id")
+  sender             User    @relation("sender", fields: [senderId], references: [id])
+  recipientId        String  @map("recipient_id")
+  recipient          User    @relation("recipient", fields: [recipientId], references: [id])
+  externalSenderName String? @map("external_sender_name")
 
   valuesPeople                Boolean @default(false) @map("values_people")
   valuesSafety                Boolean @default(false) @map("values_safety")


### PR DESCRIPTION
Closes #167

## Summary
- Adds optional `externalSenderName` (nullable) on `RecognitionCard` so admins can log paper cards from people outside the system (e.g. the Perth team).
- When set, FROM swaps to the external name across feed, table, mini card, dashboard detail, public share, OG image, and CSV export.
- Card is visually marked **"Physical card · logged by `<admin>`"** in feed (badge above mini card; subtitle in list/table view), dashboard detail (header description), and public share (badge above flip card).
- Recipient still receives a `CARD_RECEIVED` notification; message reads `"<external> sent you a recognition card (logged by <admin>)"`.
- Admin avatar is replaced with a neutral placeholder (initials of external name) in feed/table to avoid implying the admin sent it.
- Logging admin is **excluded** from their personal "sent" count (`externalSenderName: null` filter on the stats query) so data entry doesn't inflate their stats. Recipient stats unaffected.
- Only `ADMIN`/`SUPERADMIN` can submit `externalSenderName`; otherwise the action returns a 403-equivalent error. Edit remains gated by `senderId === session.user.id`; delete unchanged (already role-gated).
- Form: admin-only "Log a physical card" toggle above the card; when on, the FROM static text becomes a free-text input bound to `externalSenderName` (max 100 chars).
- Admin search on the paginated feed now also matches `externalSenderName`.

## Schema
Additive, nullable column — safe migration:
```prisma
externalSenderName String? @map("external_sender_name")
```

⚠️ Note for reviewer: in this dev DB, `bunx prisma db push` reported an *unrelated* drift on `accounts(user_id, provider_id)` unique constraint and was skipped. Before merging, run `bunx prisma migrate dev --name add_external_sender_name` against a clean DB to generate the migration file, and review the accounts drift separately. Production deploy must use `migrate deploy`, not `db push`.

## Test plan
- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test` — 297/297 unit + component tests pass (stats test updated for new where clause)
- [ ] Manual smoke (admin): toggle physical card → submit → verify badge + FROM in feed, table, detail, public share
- [ ] Manual smoke (admin): verify own "sent" count is unchanged after logging a physical card
- [ ] Manual smoke (recipient): verify notification copy reads `"<external> sent you a recognition card (logged by <admin>)"`
- [ ] Manual smoke (non-admin staff): verify toggle is hidden and direct API call with `externalSenderName` is rejected
- [ ] Verify CSV export `Given By` column shows external name when set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can log physical recognition cards by supplying an external sender name; form supports default recipient and an admin-only "Log a physical card" option.

* **Improvements**
  * Physical cards display a “Physical card · logged by [admin name]” badge across feed, lists, mini cards, detail/share pages, and preview images.
  * Search, CSV export, stats, and leaderboards now respect and exclude physical-card entries where appropriate.

* **Validation & Permissions**
  * External sender names validated and restricted to admin roles.

* **Tests & Chore**
  * Tests added for external-sender behavior; database updated to store external sender names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->