### PR TITLE
feat(users): show Hired date column instead of Joined

### DIFF
--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -88,11 +88,23 @@ const hireDateFormatter = new Intl.DateTimeFormat("en-AU", {
 	timeZone: "UTC",
 });
 
+const joinedDateFormatter = new Intl.DateTimeFormat("en-AU", {
+	day: "2-digit",
+	month: "short",
+	year: "numeric",
+});
+
 function formatHireDate(value: string | null) {
 	if (!value) return "—";
 	const parsed = new Date(value);
 	if (Number.isNaN(parsed.getTime())) return "—";
 	return hireDateFormatter.format(parsed);
+}
+
+function formatJoinedDate(value: string) {
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return "—";
+	return joinedDateFormatter.format(parsed);
 }
 
 function getDateDisplay(
@@ -103,7 +115,7 @@ function getDateDisplay(
 		const formatted = formatHireDate(hireDate);
 		if (formatted !== "—") return { value: formatted, fallback: false };
 	}
-	return { value: formatHireDate(createdAt), fallback: true };
+	return { value: formatJoinedDate(createdAt), fallback: true };
 }
 
 function TableSkeleton() {

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -85,6 +85,7 @@ const hireDateFormatter = new Intl.DateTimeFormat("en-AU", {
 	day: "2-digit",
 	month: "short",
 	year: "numeric",
+	timeZone: "UTC",
 });
 
 function formatHireDate(value: string | null) {

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -94,6 +94,17 @@ function formatHireDate(value: string | null) {
 	return hireDateFormatter.format(parsed);
 }
 
+function getDateDisplay(
+	hireDate: string | null,
+	createdAt: string,
+): { value: string; fallback: boolean } {
+	if (hireDate) {
+		const formatted = formatHireDate(hireDate);
+		if (formatted !== "—") return { value: formatted, fallback: false };
+	}
+	return { value: formatHireDate(createdAt), fallback: true };
+}
+
 function TableSkeleton() {
 	return (
 		<div
@@ -432,9 +443,19 @@ export function UserListClient({ mode, currentUserRole, departments }: UserListC
 												<span className="text-sm text-foreground">{user.branch ?? "—"}</span>
 											</TableCell>
 											<TableCell>
-												<span className="text-sm text-foreground">
-													{formatHireDate(user.hireDate)}
-												</span>
+												{(() => {
+													const { value, fallback } = getDateDisplay(user.hireDate, user.createdAt);
+													return (
+														<div className="flex flex-col">
+															<span className="text-sm text-foreground">{value}</span>
+															{fallback && (
+																<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+																	joined
+																</span>
+															)}
+														</div>
+													);
+												})()}
 											</TableCell>
 											<TableCell>
 												<div className="flex flex-col gap-1.5">

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -448,11 +448,9 @@ export function UserListClient({ mode, currentUserRole, departments }: UserListC
 													return (
 														<div className="flex flex-col">
 															<span className="text-sm text-foreground">{value}</span>
-															{fallback && (
-																<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-																	joined
-																</span>
-															)}
+															<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+																{fallback ? "joined" : "hired"}
+															</span>
 														</div>
 													);
 												})()}

--- a/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-list-client.tsx
@@ -55,6 +55,7 @@ interface User {
 	position: string | null;
 	branch: string | null;
 	createdAt: string;
+	hireDate: string | null;
 	department: { id: string; name: string; code: string } | null;
 }
 
@@ -80,16 +81,17 @@ function roleBadgeVariant(role: string) {
 	}
 }
 
-const joinedDateFormatter = new Intl.DateTimeFormat("en-AU", {
+const hireDateFormatter = new Intl.DateTimeFormat("en-AU", {
 	day: "2-digit",
 	month: "short",
 	year: "numeric",
 });
 
-function formatJoinedDate(value: string) {
+function formatHireDate(value: string | null) {
+	if (!value) return "—";
 	const parsed = new Date(value);
 	if (Number.isNaN(parsed.getTime())) return "—";
-	return joinedDateFormatter.format(parsed);
+	return hireDateFormatter.format(parsed);
 }
 
 function TableSkeleton() {
@@ -390,7 +392,7 @@ export function UserListClient({ mode, currentUserRole, departments }: UserListC
 									<TableHead>Employee</TableHead>
 									<TableHead>Position / Dept</TableHead>
 									<TableHead>Branch</TableHead>
-									<TableHead>Joined</TableHead>
+									<TableHead>Hired</TableHead>
 									<TableHead>Status</TableHead>
 									<TableHead className="text-right">Actions</TableHead>
 								</TableRow>
@@ -431,7 +433,7 @@ export function UserListClient({ mode, currentUserRole, departments }: UserListC
 											</TableCell>
 											<TableCell>
 												<span className="text-sm text-foreground">
-													{formatJoinedDate(user.createdAt)}
+													{formatHireDate(user.hireDate)}
 												</span>
 											</TableCell>
 											<TableCell>

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -6,6 +6,7 @@ export interface ExportUser {
 	position: string | null;
 	branch: string | null;
 	createdAt: Date | string;
+	hireDate: Date | string | null;
 	deletedAt: Date | string | null;
 	department: { name: string } | null;
 }
@@ -24,18 +25,20 @@ const CSV_HEADERS = [
 	"Role",
 	"Department",
 	"Branch",
+	"Hired",
 	"Joined",
 	"Position",
 	"Status",
 ];
 
-function formatCsvDate(value: Date | string): string {
+function formatCsvDate(value: Date | string, opts?: { utc?: boolean }): string {
 	const parsed = value instanceof Date ? value : new Date(value);
 	if (Number.isNaN(parsed.getTime())) return "";
 	return new Intl.DateTimeFormat("en-AU", {
 		day: "2-digit",
 		month: "short",
 		year: "numeric",
+		...(opts?.utc ? { timeZone: "UTC" } : {}),
 	}).format(parsed);
 }
 
@@ -47,6 +50,7 @@ export function generateUserCsv(users: ExportUser[]): string {
 		user.role,
 		user.department?.name ?? "",
 		user.branch ?? "",
+		user.hireDate ? formatCsvDate(user.hireDate, { utc: true }) : "",
 		formatCsvDate(user.createdAt),
 		user.position ?? "",
 		user.deletedAt ? "Deleted" : "Active",


### PR DESCRIPTION
## Summary
- Replace the **Joined** column on `/dashboard/users` with **Hired**, sourced from `user.hireDate` (formatted in UTC since it is a `@db.Date`).
- When `hireDate` is missing, fall back to `user.createdAt` and mark the row with a small **JOINED** tag so the source is unambiguous. Rows with `hireDate` show a **HIRED** tag.
- Update the CSV export to include a new **Hired** column (UTC-formatted `hireDate`) alongside the existing **Joined** column so exports match the UI.

Note: the original issue #171 specified rendering `—` when `hireDate` is missing. During implementation we decided a labelled fallback to `createdAt` is more useful for admins — missing values stay distinguishable via the **JOINED** tag.

Closes #171

## Test plan
- [ ] Open `/dashboard/users` — column header reads **Hired**.
- [ ] User with `hireDate` set: shows the formatted date with a **HIRED** sublabel.
- [ ] User without `hireDate`: shows `createdAt` with a **JOINED** sublabel.
- [ ] Hire date renders the same calendar day regardless of the admin's timezone (UTC formatting).
- [ ] Joined fallback date matches the **Joined** date on `/dashboard/users/[id]` (local timezone formatting).
- [ ] Export to CSV: contains both **Hired** and **Joined** columns; **Hired** is blank when `hireDate` is null.
- [ ] Skeleton/loading state still renders correctly.