### PR TITLE
feat(recognition): reveal previous month's winners in a configurable window

### DIFF
--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -270,9 +270,7 @@ function LockedLeaderboard({
 					<Lock size={18} className="text-primary" />
 				</div>
 				<p className="text-sm font-medium text-foreground">This month's winners</p>
-				{revealDate && (
-					<p className="text-sm text-muted-foreground mt-0.5">Revealed {revealDate}</p>
-				)}
+				{revealDate && <p className="text-sm text-muted-foreground mt-0.5">Reveals {revealDate}</p>}
 				{showCountdown && (
 					<p className="mt-3 text-sm font-semibold tabular-nums text-primary" aria-live="polite">
 						in {formatCountdown(msRemaining)}

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -35,13 +35,13 @@ const PODIUM_STYLES = [
 const STATS_STICKY_OFFSET = 32;
 const STATS_STICKY_BREAKPOINT_QUERY = "(min-width: 1024px)";
 
-type LeaderboardVisibilityMode = "always" | "last_n_days_of_month" | "custom_range";
-
 interface LeaderboardVisibility {
 	visible: boolean;
-	mode: LeaderboardVisibilityMode;
-	revealStart: string | null;
-	revealEnd: string | null;
+	sourceMonthKey: string;
+	sourceMonthLabel: string;
+	revealStart: string;
+	revealEnd: string;
+	nextRevealStart: string;
 }
 
 interface StatsData {
@@ -59,16 +59,9 @@ interface StatsData {
 
 const REVEAL_DATE_FORMATTER = new Intl.DateTimeFormat("en-AU", {
 	timeZone: "Asia/Manila",
-	month: "short",
+	month: "long",
 	day: "numeric",
 });
-
-function formatRevealRange(startIso: string, endIso: string): string {
-	const start = new Date(startIso);
-	// revealEnd is exclusive — subtract 1ms to display the inclusive last day
-	const lastDay = new Date(new Date(endIso).getTime() - 1);
-	return `${REVEAL_DATE_FORMATTER.format(start)} – ${REVEAL_DATE_FORMATTER.format(lastDay)}`;
-}
 
 function formatCountdown(msRemaining: number): string {
 	if (msRemaining <= 0) return "any moment";
@@ -257,16 +250,13 @@ function StatsWidgetSkeleton() {
 }
 
 function LockedLeaderboard({
-	visibility,
+	nextRevealIso,
 	msRemaining,
 }: {
-	visibility: LeaderboardVisibility;
+	nextRevealIso: string | null;
 	msRemaining: number | null;
 }) {
-	const hasRange = visibility.revealStart && visibility.revealEnd;
-	const rangeLabel = hasRange
-		? formatRevealRange(visibility.revealStart as string, visibility.revealEnd as string)
-		: null;
+	const revealDate = nextRevealIso ? REVEAL_DATE_FORMATTER.format(new Date(nextRevealIso)) : null;
 	const showCountdown = msRemaining !== null && msRemaining > 0;
 
 	return (
@@ -279,13 +269,9 @@ function LockedLeaderboard({
 				<div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 mb-3">
 					<Lock size={18} className="text-primary" />
 				</div>
-				{rangeLabel ? (
-					<>
-						<p className="text-sm font-medium text-foreground">Rankings revealed</p>
-						<p className="text-sm text-muted-foreground mt-0.5">{rangeLabel}</p>
-					</>
-				) : (
-					<p className="text-sm font-medium text-foreground">Rankings hidden</p>
+				<p className="text-sm font-medium text-foreground">This month's winners</p>
+				{revealDate && (
+					<p className="text-sm text-muted-foreground mt-0.5">Revealed {revealDate}</p>
 				)}
 				{showCountdown && (
 					<p className="mt-3 text-sm font-semibold tabular-nums text-primary" aria-live="polite">
@@ -302,13 +288,23 @@ function LockedLeaderboard({
 }
 
 export function StatsWidget() {
+	// Dev-only date preview: visit /dashboard?previewNow=2026-06-01 to see the
+	// reveal window. The server ignores this param in production.
+	const previewNow =
+		typeof window !== "undefined"
+			? new URLSearchParams(window.location.search).get("previewNow")
+			: null;
+
 	const { data, isPending, isError } = useQuery<{
 		success: boolean;
 		data: StatsData;
 	}>({
-		queryKey: ["recognition-stats"],
+		queryKey: ["recognition-stats", previewNow],
 		queryFn: async () => {
-			const res = await fetch("/api/recognition/stats");
+			const url = previewNow
+				? `/api/recognition/stats?previewNow=${encodeURIComponent(previewNow)}`
+				: "/api/recognition/stats";
+			const res = await fetch(url);
 			if (!res.ok) throw new Error("Failed to fetch stats");
 			return res.json();
 		},
@@ -317,11 +313,11 @@ export function StatsWidget() {
 
 	const visibility = data?.data?.leaderboardVisibility ?? null;
 	// Always watch the next boundary: revealEnd if the leaderboard is currently
-	// visible (so we hide it at month-end / range-end), otherwise revealStart.
+	// visible (so we lock it at window-end), otherwise the next window opening.
 	const nextBoundaryIso = visibility
 		? visibility.visible
 			? visibility.revealEnd
-			: visibility.revealStart
+			: visibility.nextRevealStart
 		: null;
 	const msRemaining = useCountdown(nextBoundaryIso);
 
@@ -398,9 +394,14 @@ export function StatsWidget() {
 
 			{showList ? (
 				<div>
-					<div className="flex items-center gap-2 mb-3">
+					<div className="flex flex-wrap items-center gap-2 mb-3">
 						<Trophy size={16} className="text-primary" />
-						<h4 className="text-sm font-medium text-foreground/70">Most Recognized</h4>
+						<h4 className="text-sm font-medium text-foreground/70">
+							Most Recognized — {resolvedVisibility.sourceMonthLabel}
+						</h4>
+						<span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground">
+							Final results
+						</span>
 					</div>
 					<ol className="space-y-2">
 						{stats.topRecipients.map((person, index) => {
@@ -459,16 +460,21 @@ export function StatsWidget() {
 					</ol>
 				</div>
 			) : showLocked ? (
-				<LockedLeaderboard visibility={resolvedVisibility} msRemaining={msRemaining} />
+				<LockedLeaderboard
+					nextRevealIso={resolvedVisibility.nextRevealStart}
+					msRemaining={msRemaining}
+				/>
 			) : showEmpty ? (
 				<div>
 					<div className="flex items-center gap-2 mb-3">
 						<Trophy size={16} className="text-primary" />
-						<h4 className="text-sm font-medium text-foreground/70">Most Recognized</h4>
+						<h4 className="text-sm font-medium text-foreground/70">
+							Most Recognized — {resolvedVisibility.sourceMonthLabel}
+						</h4>
 					</div>
 					<div className="flex min-h-48 items-center justify-center rounded-2xl border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-6 py-8 text-center">
 						<p className="text-sm text-muted-foreground">
-							No recognitions yet this month — be the first!
+							No recognitions were recorded last month.
 						</p>
 					</div>
 				</div>

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -286,8 +286,9 @@ function LockedLeaderboard({
 }
 
 export function StatsWidget() {
-	// Dev-only date preview: visit /dashboard?previewNow=2026-06-01 to see the
-	// reveal window. The server ignores this param in production.
+	// Date preview: visit /dashboard?previewNow=2026-06-01 to see the reveal
+	// window. The server honors this only for SUPERADMIN and ignores it for
+	// every other role.
 	const previewNow =
 		typeof window !== "undefined"
 			? new URLSearchParams(window.location.search).get("previewNow")

--- a/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
@@ -4,66 +4,34 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
 import { updateLeaderboardVisibilitySettings } from "@/lib/actions/settings-actions";
-import {
-	type LeaderboardVisibilityMode,
-	REVEAL_DAYS_MAX,
-	REVEAL_DAYS_MIN,
-} from "@/lib/leaderboard/visibility";
-
-const MODE_LABELS: Record<LeaderboardVisibilityMode, string> = {
-	always: "Always visible",
-	last_n_days_of_month: "Last N days of month",
-	custom_range: "Custom date range",
-};
-
-const MODE_DESCRIPTIONS: Record<LeaderboardVisibilityMode, string> = {
-	always: "Show the leaderboard all month.",
-	last_n_days_of_month: "Only reveal during the last N days of each month (Asia/Manila).",
-	custom_range: "Only show between a specific start and end date.",
-};
+import { REVEAL_DAY_MAX, REVEAL_DAY_MIN } from "@/lib/leaderboard/visibility";
 
 export interface LeaderboardVisibilityPanelProps {
-	initialMode: LeaderboardVisibilityMode;
-	initialDays: number;
-	initialCustomStart: string | null;
-	initialCustomEnd: string | null;
+	initialStartDay: number;
+	initialEndDay: number;
+}
+
+function clampDay(value: number): number {
+	const n = Number.isFinite(value) ? value : REVEAL_DAY_MIN;
+	return Math.min(Math.max(Math.trunc(n), REVEAL_DAY_MIN), REVEAL_DAY_MAX);
 }
 
 export function LeaderboardVisibilityPanel({
-	initialMode,
-	initialDays,
-	initialCustomStart,
-	initialCustomEnd,
+	initialStartDay,
+	initialEndDay,
 }: LeaderboardVisibilityPanelProps) {
-	const [mode, setMode] = useState<LeaderboardVisibilityMode>(initialMode);
-	const [days, setDays] = useState<number>(initialDays);
-	const [customStart, setCustomStart] = useState<string>(initialCustomStart ?? "");
-	const [customEnd, setCustomEnd] = useState<string>(initialCustomEnd ?? "");
+	const [startDay, setStartDay] = useState<number>(initialStartDay);
+	const [endDay, setEndDay] = useState<number>(initialEndDay);
 	const [isPending, startTransition] = useTransition();
 	const queryClient = useQueryClient();
 
-	function save(next: {
-		mode: LeaderboardVisibilityMode;
-		days: number;
-		customStart: string;
-		customEnd: string;
-	}) {
+	function save(nextStart: number, nextEnd: number) {
 		startTransition(async () => {
 			try {
 				const result = await updateLeaderboardVisibilitySettings({
-					mode: next.mode,
-					revealDays: next.days,
-					customStart: next.customStart || null,
-					customEnd: next.customEnd || null,
+					revealStartDay: nextStart,
+					revealEndDay: nextEnd,
 				});
 
 				if (!result.success) {
@@ -79,30 +47,24 @@ export function LeaderboardVisibilityPanel({
 		});
 	}
 
-	function handleModeChange(newMode: LeaderboardVisibilityMode) {
-		setMode(newMode);
-		save({ mode: newMode, days, customStart, customEnd });
+	function handleStartBlur() {
+		const clamped = clampDay(startDay);
+		const nextEnd = Math.max(clamped, endDay);
+		if (clamped !== startDay) setStartDay(clamped);
+		if (nextEnd !== endDay) setEndDay(nextEnd);
+		save(clamped, nextEnd);
 	}
 
-	function handleDaysBlur() {
-		const clamped = Math.min(
-			Math.max(Number.isFinite(days) ? days : REVEAL_DAYS_MIN, REVEAL_DAYS_MIN),
-			REVEAL_DAYS_MAX,
-		);
-		if (clamped !== days) setDays(clamped);
-		save({ mode, days: clamped, customStart, customEnd });
-	}
-
-	function handleCustomStartBlur() {
-		save({ mode, days, customStart, customEnd });
-	}
-
-	function handleCustomEndBlur() {
-		if (customStart && customEnd && customStart > customEnd) {
-			toast.error("Start date must be on or before end date");
+	function handleEndBlur() {
+		const clamped = clampDay(endDay);
+		if (clamped < startDay) {
+			toast.error("Reveal end day must be on or after the start day");
+			setEndDay(startDay);
+			save(startDay, startDay);
 			return;
 		}
-		save({ mode, days, customStart, customEnd });
+		if (clamped !== endDay) setEndDay(clamped);
+		save(startDay, clamped);
 	}
 
 	return (
@@ -112,101 +74,50 @@ export function LeaderboardVisibilityPanel({
 					Leaderboard Visibility
 				</h3>
 				<p className="mt-2 text-sm text-muted-foreground">
-					Control when the "Most Recognized" leaderboard is revealed on the dashboard. The
-					leaderboard resets each calendar month. All dates and month boundaries are interpreted in
-					Asia/Manila time.
+					The dashboard "Most Recognized" panel reveals the previous month's winners during this
+					window each month. Outside it, the panel stays locked. Counting always covers the full
+					calendar month (Asia/Manila). Days range from {REVEAL_DAY_MIN} to {REVEAL_DAY_MAX}.
 				</p>
 			</div>
 
 			<div className="space-y-4 px-5 py-6 sm:px-8">
 				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
 					<div className="min-w-0">
-						<p className="text-sm font-medium text-foreground">Visibility mode</p>
-						<p className="text-xs text-muted-foreground">{MODE_DESCRIPTIONS[mode]}</p>
+						<p className="text-sm font-medium text-foreground">Reveal from day</p>
+						<p className="text-xs text-muted-foreground">
+							First day of the month the previous month's winners appear.
+						</p>
 					</div>
-					<Select
-						value={mode}
-						onValueChange={(val) => handleModeChange(val as LeaderboardVisibilityMode)}
+					<Input
+						type="number"
+						min={REVEAL_DAY_MIN}
+						max={REVEAL_DAY_MAX}
+						value={startDay}
+						onChange={(e) => setStartDay(Number.parseInt(e.target.value, 10))}
+						onBlur={handleStartBlur}
 						disabled={isPending}
-					>
-						<SelectTrigger className="w-full shrink-0 rounded-full sm:w-56">
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value="always">{MODE_LABELS.always}</SelectItem>
-							<SelectItem value="last_n_days_of_month">
-								{MODE_LABELS.last_n_days_of_month}
-							</SelectItem>
-							<SelectItem value="custom_range">{MODE_LABELS.custom_range}</SelectItem>
-						</SelectContent>
-					</Select>
+						className="w-full shrink-0 sm:w-24"
+					/>
 				</div>
 
-				{mode === "last_n_days_of_month" && (
-					<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
-						<div className="min-w-0">
-							<p className="text-sm font-medium text-foreground">Reveal days</p>
-							<p className="text-xs text-muted-foreground">
-								How many days before month-end to reveal the leaderboard.
-							</p>
-						</div>
-						<Input
-							type="number"
-							min={REVEAL_DAYS_MIN}
-							max={REVEAL_DAYS_MAX}
-							value={days}
-							onChange={(e) => setDays(Number.parseInt(e.target.value, 10))}
-							onBlur={handleDaysBlur}
-							disabled={isPending}
-							className="w-full shrink-0 sm:w-24"
-						/>
+				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+					<div className="min-w-0">
+						<p className="text-sm font-medium text-foreground">Reveal until day</p>
+						<p className="text-xs text-muted-foreground">
+							Last day (inclusive) the winners stay visible before locking again.
+						</p>
 					</div>
-				)}
-
-				{mode === "custom_range" && (
-					<div className="space-y-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:p-5">
-						<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-							<div>
-								<Label
-									htmlFor="leaderboard-custom-start"
-									className="text-sm font-medium text-foreground"
-								>
-									Start date
-								</Label>
-								<p className="text-xs text-muted-foreground mt-0.5">Asia/Manila, inclusive.</p>
-							</div>
-							<Input
-								id="leaderboard-custom-start"
-								type="date"
-								value={customStart}
-								onChange={(e) => setCustomStart(e.target.value)}
-								onBlur={handleCustomStartBlur}
-								disabled={isPending}
-								className="w-full shrink-0 sm:w-48"
-							/>
-						</div>
-						<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-							<div>
-								<Label
-									htmlFor="leaderboard-custom-end"
-									className="text-sm font-medium text-foreground"
-								>
-									End date
-								</Label>
-								<p className="text-xs text-muted-foreground mt-0.5">Asia/Manila, inclusive.</p>
-							</div>
-							<Input
-								id="leaderboard-custom-end"
-								type="date"
-								value={customEnd}
-								onChange={(e) => setCustomEnd(e.target.value)}
-								onBlur={handleCustomEndBlur}
-								disabled={isPending}
-								className="w-full shrink-0 sm:w-48"
-							/>
-						</div>
-					</div>
-				)}
+					<Input
+						type="number"
+						min={REVEAL_DAY_MIN}
+						max={REVEAL_DAY_MAX}
+						value={endDay}
+						onChange={(e) => setEndDay(Number.parseInt(e.target.value, 10))}
+						onBlur={handleEndBlur}
+						disabled={isPending}
+						className="w-full shrink-0 sm:w-24"
+					/>
+				</div>
 			</div>
 		</div>
 	);

--- a/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
@@ -5,16 +5,11 @@ import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { updateLeaderboardVisibilitySettings } from "@/lib/actions/settings-actions";
-import { REVEAL_DAY_MAX, REVEAL_DAY_MIN } from "@/lib/leaderboard/visibility";
+import { clampDay, REVEAL_DAY_MAX, REVEAL_DAY_MIN } from "@/lib/leaderboard/visibility";
 
 export interface LeaderboardVisibilityPanelProps {
 	initialStartDay: number;
 	initialEndDay: number;
-}
-
-function clampDay(value: number): number {
-	const n = Number.isFinite(value) ? value : REVEAL_DAY_MIN;
-	return Math.min(Math.max(Math.trunc(n), REVEAL_DAY_MIN), REVEAL_DAY_MAX);
 }
 
 export function LeaderboardVisibilityPanel({
@@ -49,7 +44,9 @@ export function LeaderboardVisibilityPanel({
 
 	function handleStartBlur() {
 		const clamped = clampDay(startDay);
-		const nextEnd = Math.max(clamped, endDay);
+		// Clamp endDay too — it may be NaN if the user cleared it without blurring,
+		// which would otherwise send NaN to save() and trigger a generic error.
+		const nextEnd = Math.max(clamped, clampDay(endDay));
 		if (clamped !== startDay) setStartDay(clamped);
 		if (nextEnd !== endDay) setEndDay(nextEnd);
 		save(clamped, nextEnd);

--- a/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
@@ -92,7 +92,7 @@ export function LeaderboardVisibilityPanel({
 						type="number"
 						min={REVEAL_DAY_MIN}
 						max={REVEAL_DAY_MAX}
-						value={startDay}
+						value={Number.isFinite(startDay) ? startDay : ""}
 						onChange={(e) => setStartDay(Number.parseInt(e.target.value, 10))}
 						onBlur={handleStartBlur}
 						disabled={isPending}
@@ -111,7 +111,7 @@ export function LeaderboardVisibilityPanel({
 						type="number"
 						min={REVEAL_DAY_MIN}
 						max={REVEAL_DAY_MAX}
-						value={endDay}
+						value={Number.isFinite(endDay) ? endDay : ""}
 						onChange={(e) => setEndDay(Number.parseInt(e.target.value, 10))}
 						onBlur={handleEndBlur}
 						disabled={isPending}

--- a/app/(dashboard)/dashboard/admin-settings/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/page.tsx
@@ -29,10 +29,8 @@ export default async function AdminSettingsPage() {
 			<RecognitionSettingsPanel initialLimit={topLimit} />
 
 			<LeaderboardVisibilityPanel
-				initialMode={visibility.mode}
-				initialDays={visibility.revealDays}
-				initialCustomStart={visibility.customStart}
-				initialCustomEnd={visibility.customEnd}
+				initialStartDay={visibility.revealStartDay}
+				initialEndDay={visibility.revealEndDay}
 			/>
 
 			<HelpMeVisibilityPanel initialEnabled={helpMeEnabled} />

--- a/app/(dashboard)/dashboard/leaderboard/_components/leaderboard-list.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/_components/leaderboard-list.tsx
@@ -27,22 +27,10 @@ const PODIUM_STYLES = [
 	},
 ] as const;
 
-const REVEAL_DATE_FORMATTER = new Intl.DateTimeFormat("en-AU", {
-	timeZone: "Asia/Manila",
-	month: "short",
-	day: "numeric",
-});
-
 const SNAPSHOT_DATE_FORMATTER = new Intl.DateTimeFormat("en-AU", {
 	timeZone: "Asia/Manila",
 	dateStyle: "medium",
 });
-
-function formatRevealRange(start: Date, end: Date): string {
-	// revealEnd is exclusive — subtract 1ms to display the inclusive last day.
-	const lastDay = new Date(end.getTime() - 1);
-	return `${REVEAL_DATE_FORMATTER.format(start)} – ${REVEAL_DATE_FORMATTER.format(lastDay)}`;
-}
 
 function PanelShell({ children }: { children: React.ReactNode }) {
 	return (
@@ -77,20 +65,15 @@ export function LeaderboardList({ data }: { data: MonthLeaderboard }) {
 	}
 
 	if (data.kind === "locked") {
-		const { revealStart, revealEnd } = data.visibility;
-		const rangeLabel = revealStart && revealEnd ? formatRevealRange(revealStart, revealEnd) : null;
 		return (
 			<PanelShell>
 				<div className="flex flex-col items-center justify-center px-8 py-16 text-center">
 					<div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 mb-4">
 						<Lock size={22} className="text-primary" />
 					</div>
-					<p className="text-base font-medium text-foreground">
-						{rangeLabel ? "Rankings revealed" : "Rankings hidden"}
-					</p>
-					{rangeLabel && <p className="mt-1 text-sm text-muted-foreground">{rangeLabel}</p>}
-					<p className="mt-4 text-xs text-muted-foreground">
-						This month's leaderboard is not yet visible.
+					<p className="text-base font-medium text-foreground">Still being counted</p>
+					<p className="mt-1 text-sm text-muted-foreground">
+						{formatMonthLabel(data.monthKey)} rankings publish after the month ends.
 					</p>
 				</div>
 			</PanelShell>
@@ -98,16 +81,10 @@ export function LeaderboardList({ data }: { data: MonthLeaderboard }) {
 	}
 
 	const { recipients } = data;
-	const isLive = data.kind === "live";
-	const badge = isLive ? "Live" : `Archived ${SNAPSHOT_DATE_FORMATTER.format(data.snapshotAt)}`;
+	const badge = `Archived ${SNAPSHOT_DATE_FORMATTER.format(data.snapshotAt)}`;
 
 	if (recipients.length === 0) {
-		return (
-			<EmptyMessage
-				title={`No recognitions in ${formatMonthLabel(data.monthKey)}`}
-				body={isLive ? "Be the first to recognize a colleague this month!" : undefined}
-			/>
-		);
+		return <EmptyMessage title={`No recognitions in ${formatMonthLabel(data.monthKey)}`} />;
 	}
 
 	return (
@@ -118,12 +95,7 @@ export function LeaderboardList({ data }: { data: MonthLeaderboard }) {
 					<h2 className="text-[1.25rem] font-medium text-foreground tracking-tight">
 						Most Recognized — {formatMonthLabel(data.monthKey)}
 					</h2>
-					<span
-						className={cn(
-							"inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
-							isLive ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground",
-						)}
-					>
+					<span className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
 						{badge}
 					</span>
 				</div>

--- a/app/(dashboard)/dashboard/leaderboard/page.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/page.tsx
@@ -38,9 +38,11 @@ export default async function LeaderboardHistoryPage({ searchParams }: PageProps
 	const now = new Date();
 
 	// Self-heal the archive when a user lands here before anyone hits
-	// /dashboard post-rollover. Swallow errors so snapshot failures don't
-	// break the page render.
-	await maybeSnapshotPreviousMonth(now).catch(() => {});
+	// /dashboard post-rollover. A failure must not break the page render, but
+	// log it rather than swallowing silently.
+	await maybeSnapshotPreviousMonth(now).catch((err) => {
+		console.error("maybeSnapshotPreviousMonth failed", { error: err });
+	});
 
 	const [archivedKeys, topLimit] = await Promise.all([
 		getArchivedMonthKeys(),

--- a/app/(dashboard)/dashboard/leaderboard/page.tsx
+++ b/app/(dashboard)/dashboard/leaderboard/page.tsx
@@ -1,9 +1,6 @@
 import { redirect } from "next/navigation";
 import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
-import {
-	getLeaderboardVisibilitySettings,
-	getTopRecognizedLimit,
-} from "@/lib/actions/settings-actions";
+import { getTopRecognizedLimit } from "@/lib/actions/settings-actions";
 import { requireSession } from "@/lib/auth-utils";
 import {
 	formatMonthLabel,
@@ -13,7 +10,6 @@ import {
 } from "@/lib/leaderboard/history";
 import { getCurrentMonthBoundaries } from "@/lib/leaderboard/month";
 import { maybeSnapshotPreviousMonth } from "@/lib/leaderboard/snapshot";
-import { computeLeaderboardVisibility } from "@/lib/leaderboard/visibility";
 import { LeaderboardList } from "./_components/leaderboard-list";
 import { MonthPicker } from "./_components/month-picker";
 
@@ -46,26 +42,22 @@ export default async function LeaderboardHistoryPage({ searchParams }: PageProps
 	// break the page render.
 	await maybeSnapshotPreviousMonth(now).catch(() => {});
 
-	const [archivedKeys, settings, topLimit] = await Promise.all([
+	const [archivedKeys, topLimit] = await Promise.all([
 		getArchivedMonthKeys(),
-		getLeaderboardVisibilitySettings(),
 		getTopRecognizedLimit(),
 	]);
 
 	const currentMonthKey = getCurrentMonthBoundaries(now).monthKey;
-	const visibility = computeLeaderboardVisibility(settings, now);
 
-	// Archived list may include the current month if this process already wrote
-	// it (it shouldn't — we only snapshot the previous month — but filter defensively).
-	const archived = archivedKeys.filter((k) => k !== currentMonthKey);
-	const selectableKeys = visibility.visible ? [currentMonthKey, ...archived] : archived;
+	// Completed months are always browsable. The in-progress month is never
+	// listed (it's still being counted) — filter it out defensively.
+	const selectableKeys = archivedKeys.filter((k) => k !== currentMonthKey);
 
 	const requested = monthParam && isValidMonthKey(monthParam) ? monthParam : null;
 
-	// Generic empty state only when there's truly nothing to show AND the user
-	// didn't deep-link a specific month. A valid ?month= flows through below so
-	// locked/missing states surface for shared or bookmarked links even before
-	// the first archive exists.
+	// Generic empty state only when there's nothing archived AND the user didn't
+	// deep-link a specific month. A valid ?month= flows through so locked/missing
+	// states surface for shared or bookmarked links even before any archive exists.
 	if (selectableKeys.length === 0 && !requested) {
 		return (
 			<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
@@ -73,8 +65,7 @@ export default async function LeaderboardHistoryPage({ searchParams }: PageProps
 				<div className="rounded-[2rem] border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-8 py-16 text-center">
 					<p className="text-base font-medium text-foreground">No leaderboards to show yet</p>
 					<p className="mt-1 text-sm text-muted-foreground">
-						Archives appear here after each month ends. The current month becomes available when its
-						reveal window opens.
+						Archives appear here after each month ends.
 					</p>
 				</div>
 			</div>
@@ -82,17 +73,13 @@ export default async function LeaderboardHistoryPage({ searchParams }: PageProps
 	}
 
 	// Honor a valid requested month even if it isn't in the selectable list
-	// (e.g. pre-archive months, the just-finished month before its snapshot
-	// lands, or the current month while hidden). This lets locked/missing
-	// states surface for shared/bookmarked links instead of silently falling
-	// back to selectableKeys[0].
+	// (e.g. the current in-progress month, or a pre-archive month) so locked /
+	// missing states surface for shared or bookmarked links instead of silently
+	// falling back to selectableKeys[0].
 	const selectedKey = requested ?? selectableKeys[0];
 	const baseItems = selectableKeys.map((key) => ({
 		key,
-		label:
-			key === currentMonthKey && visibility.visible
-				? `${formatMonthLabel(key)} (live)`
-				: formatMonthLabel(key),
+		label: formatMonthLabel(key),
 	}));
 	const items = selectableKeys.includes(selectedKey)
 		? baseItems

--- a/app/(dashboard)/dashboard/super-admin/_components/leaderboard-preview.tsx
+++ b/app/(dashboard)/dashboard/super-admin/_components/leaderboard-preview.tsx
@@ -6,9 +6,18 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 function firstOfNextMonth(): string {
-	const now = new Date();
-	const next = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
-	return next.toISOString().slice(0, 10);
+	// Derive "now" in Asia/Manila so the default lands on the right month even
+	// near UTC boundaries, then return the 1st of the following month.
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZone: "Asia/Manila",
+		year: "numeric",
+		month: "numeric",
+	}).formatToParts(new Date());
+	const year = Number(parts.find((p) => p.type === "year")?.value);
+	const month = Number(parts.find((p) => p.type === "month")?.value); // 1-12
+	const nextYear = month === 12 ? year + 1 : year;
+	const nextMonth = month === 12 ? 1 : month + 1;
+	return `${nextYear}-${String(nextMonth).padStart(2, "0")}-01`;
 }
 
 export function LeaderboardPreviewPanel() {

--- a/app/(dashboard)/dashboard/super-admin/_components/leaderboard-preview.tsx
+++ b/app/(dashboard)/dashboard/super-admin/_components/leaderboard-preview.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { ExternalLink } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+function firstOfNextMonth(): string {
+	const now = new Date();
+	const next = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+	return next.toISOString().slice(0, 10);
+}
+
+export function LeaderboardPreviewPanel() {
+	const [date, setDate] = useState<string>(firstOfNextMonth());
+
+	function openPreview() {
+		if (!date) return;
+		window.open(`/dashboard?previewNow=${encodeURIComponent(date)}`, "_blank", "noopener");
+	}
+
+	return (
+		<div className="overflow-hidden rounded-[2rem] border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.05)] dark:border-white/10">
+			<div className="px-5 pt-6 pb-2 sm:px-8 sm:pt-8">
+				<h3 className="text-[1.5rem] leading-tight font-medium text-foreground tracking-tight">
+					Leaderboard Preview
+				</h3>
+				<p className="mt-2 text-sm text-muted-foreground">
+					Preview how the dashboard "Most Recognized" panel looks on a chosen date — useful for
+					checking the reveal window before it opens. Pick a date inside the reveal window (e.g. the
+					1st of next month) to see the previous month's winners. Only super admins can use this;
+					the date is interpreted in Asia/Manila.
+				</p>
+			</div>
+
+			<div className="px-5 py-6 sm:px-8">
+				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+					<div className="flex-1">
+						<p className="text-sm font-medium text-foreground">Preview date</p>
+						<p className="text-xs text-muted-foreground">
+							Opens the dashboard in a new tab as if it were this date.
+						</p>
+					</div>
+
+					<div className="flex w-full items-center gap-2 sm:w-auto">
+						<Input
+							type="date"
+							value={date}
+							onChange={(e) => setDate(e.target.value)}
+							className="w-full sm:w-44"
+						/>
+						<Button onClick={openPreview} disabled={!date} className="shrink-0 gap-1.5">
+							<ExternalLink size={16} />
+							Open preview
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/super-admin/page.tsx
+++ b/app/(dashboard)/dashboard/super-admin/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/actions/settings-actions";
 import { requireRoleOrRedirect } from "@/lib/auth-utils";
 import { ActivityLogRetentionPanel } from "./_components/activity-log-retention";
+import { LeaderboardPreviewPanel } from "./_components/leaderboard-preview";
 import { OAuthSettingsPanel } from "./_components/oauth-settings";
 
 export default async function SuperAdminPage() {
@@ -31,6 +32,8 @@ export default async function SuperAdminPage() {
 			/>
 
 			<ActivityLogRetentionPanel initialDays={retentionDays} />
+
+			<LeaderboardPreviewPanel />
 		</div>
 	);
 }

--- a/app/api/recognition/stats/route.test.ts
+++ b/app/api/recognition/stats/route.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/lib/actions/settings-actions", () => ({
 
 vi.mock("@/lib/leaderboard/snapshot", () => ({
 	maybeSnapshotPreviousMonth: vi.fn().mockResolvedValue(undefined),
+	computeMonthRecipients: vi.fn(),
 }));
 
 vi.mock("@/lib/leaderboard/history", () => ({
@@ -40,6 +41,7 @@ import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { getArchivedRecipients } from "@/lib/leaderboard/history";
 import { getCurrentMonthBoundaries } from "@/lib/leaderboard/month";
+import { computeMonthRecipients, maybeSnapshotPreviousMonth } from "@/lib/leaderboard/snapshot";
 import { computeLeaderboardVisibility } from "@/lib/leaderboard/visibility";
 import { GET } from "./route";
 
@@ -83,6 +85,7 @@ beforeEach(() => {
 	vi.mocked(getTopRecognizedLimit).mockResolvedValue(5);
 	vi.mocked(prisma.recognitionCard.count).mockResolvedValue(0);
 	vi.mocked(getArchivedRecipients).mockResolvedValue([]);
+	vi.mocked(computeMonthRecipients).mockResolvedValue([]);
 });
 
 describe("GET /api/recognition/stats", () => {
@@ -165,17 +168,47 @@ describe("GET /api/recognition/stats", () => {
 		expect(getArchivedRecipients).not.toHaveBeenCalled();
 	});
 
-	test("honors ?previewNow for a super admin", async () => {
+	test("honors ?previewNow for a super admin but still snapshots with the real clock", async () => {
 		mockVisible(true);
 		vi.mocked(requireSession).mockResolvedValue({
 			user: { id: USER_ID, role: "SUPERADMIN" },
 			session: { id: "sess_1" },
 		} as unknown as Awaited<ReturnType<typeof requireSession>>);
 
+		const before = Date.now();
 		await GET(new Request("http://localhost/api/recognition/stats?previewNow=2026-06-01"));
 
+		// Display/visibility use the preview clock…
 		const passedNow = vi.mocked(computeLeaderboardVisibility).mock.calls[0]?.[1];
 		expect(passedNow?.toISOString()).toBe(new Date("2026-06-01").toISOString());
+
+		// …but snapshotting must use the real clock, never the simulated date,
+		// or a partial month could be frozen permanently.
+		const snapshotNow = vi.mocked(maybeSnapshotPreviousMonth).mock.calls[0]?.[0];
+		expect(snapshotNow?.getTime()).toBeGreaterThanOrEqual(before);
+		expect(snapshotNow?.toISOString()).not.toBe(new Date("2026-06-01").toISOString());
+	});
+
+	test("falls back to a live computation when previewing an unarchived month", async () => {
+		mockVisible(true);
+		vi.mocked(requireSession).mockResolvedValue({
+			user: { id: USER_ID, role: "SUPERADMIN" },
+			session: { id: "sess_1" },
+		} as unknown as Awaited<ReturnType<typeof requireSession>>);
+		vi.mocked(getArchivedRecipients).mockResolvedValue(null);
+		vi.mocked(computeMonthRecipients).mockResolvedValue([
+			{ userId: "u1", firstName: "Grace", lastName: "Hopper", avatar: null, count: 9, rank: 1 },
+		]);
+
+		const res = await GET(
+			new Request("http://localhost/api/recognition/stats?previewNow=2026-06-01"),
+		);
+		const body = await res.json();
+
+		expect(computeMonthRecipients).toHaveBeenCalledWith(SOURCE_MONTH_KEY, 5);
+		expect(body.data.topRecipients).toEqual([
+			{ firstName: "Grace", lastName: "Hopper", avatar: null, count: 9 },
+		]);
 	});
 
 	test("ignores ?previewNow for a non-super-admin", async () => {

--- a/app/api/recognition/stats/route.test.ts
+++ b/app/api/recognition/stats/route.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/lib/leaderboard/visibility", () => ({
 
 vi.mock("@/lib/leaderboard/month", () => ({
 	getCurrentMonthBoundaries: vi.fn(),
+	manilaDateStringToUtc: vi.fn(),
 }));
 
 import {
@@ -40,10 +41,13 @@ import {
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { getArchivedRecipients } from "@/lib/leaderboard/history";
-import { getCurrentMonthBoundaries } from "@/lib/leaderboard/month";
+import { getCurrentMonthBoundaries, manilaDateStringToUtc } from "@/lib/leaderboard/month";
 import { computeMonthRecipients, maybeSnapshotPreviousMonth } from "@/lib/leaderboard/snapshot";
 import { computeLeaderboardVisibility } from "@/lib/leaderboard/visibility";
 import { GET } from "./route";
+
+// "2026-06-01" parsed as Asia/Manila midnight.
+const PREVIEW_MANILA = new Date("2026-05-31T16:00:00.000Z");
 
 const USER_ID = "user_123";
 const START = new Date("2026-05-01T00:00:00Z");
@@ -174,40 +178,52 @@ describe("GET /api/recognition/stats", () => {
 			user: { id: USER_ID, role: "SUPERADMIN" },
 			session: { id: "sess_1" },
 		} as unknown as Awaited<ReturnType<typeof requireSession>>);
+		vi.mocked(manilaDateStringToUtc).mockReturnValue(PREVIEW_MANILA);
 
 		const before = Date.now();
 		await GET(new Request("http://localhost/api/recognition/stats?previewNow=2026-06-01"));
 
-		// Display/visibility use the preview clock…
+		// Display/visibility use the preview clock (parsed as Manila midnight)…
 		const passedNow = vi.mocked(computeLeaderboardVisibility).mock.calls[0]?.[1];
-		expect(passedNow?.toISOString()).toBe(new Date("2026-06-01").toISOString());
+		expect(passedNow?.toISOString()).toBe(PREVIEW_MANILA.toISOString());
 
 		// …but snapshotting must use the real clock, never the simulated date,
 		// or a partial month could be frozen permanently.
 		const snapshotNow = vi.mocked(maybeSnapshotPreviousMonth).mock.calls[0]?.[0];
 		expect(snapshotNow?.getTime()).toBeGreaterThanOrEqual(before);
-		expect(snapshotNow?.toISOString()).not.toBe(new Date("2026-06-01").toISOString());
+		expect(snapshotNow?.toISOString()).not.toBe(PREVIEW_MANILA.toISOString());
 	});
 
-	test("falls back to a live computation when previewing an unarchived month", async () => {
+	test("falls back to a live computation when the archive is missing for a regular user", async () => {
 		mockVisible(true);
-		vi.mocked(requireSession).mockResolvedValue({
-			user: { id: USER_ID, role: "SUPERADMIN" },
-			session: { id: "sess_1" },
-		} as unknown as Awaited<ReturnType<typeof requireSession>>);
+		// Default beforeEach session has no super-admin role and there is no
+		// previewNow — this is the plain production path.
 		vi.mocked(getArchivedRecipients).mockResolvedValue(null);
 		vi.mocked(computeMonthRecipients).mockResolvedValue([
 			{ userId: "u1", firstName: "Grace", lastName: "Hopper", avatar: null, count: 9, rank: 1 },
 		]);
 
-		const res = await GET(
-			new Request("http://localhost/api/recognition/stats?previewNow=2026-06-01"),
-		);
+		const res = await GET(REQUEST);
 		const body = await res.json();
 
 		expect(computeMonthRecipients).toHaveBeenCalledWith(SOURCE_MONTH_KEY, 5);
 		expect(body.data.topRecipients).toEqual([
 			{ firstName: "Grace", lastName: "Hopper", avatar: null, count: 9 },
+		]);
+	});
+
+	test("prefers the archived snapshot over the live fallback", async () => {
+		mockVisible(true);
+		vi.mocked(getArchivedRecipients).mockResolvedValue([
+			{ userId: "u1", firstName: "Ada", lastName: "Lovelace", avatar: null, count: 5, rank: 1 },
+		]);
+
+		const res = await GET(REQUEST);
+		const body = await res.json();
+
+		expect(computeMonthRecipients).not.toHaveBeenCalled();
+		expect(body.data.topRecipients).toEqual([
+			{ firstName: "Ada", lastName: "Lovelace", avatar: null, count: 5 },
 		]);
 	});
 

--- a/app/api/recognition/stats/route.test.ts
+++ b/app/api/recognition/stats/route.test.ts
@@ -6,8 +6,7 @@ vi.mock("@/lib/auth-utils", () => ({
 
 vi.mock("@/lib/db", () => ({
 	prisma: {
-		recognitionCard: { count: vi.fn(), groupBy: vi.fn() },
-		user: { findMany: vi.fn() },
+		recognitionCard: { count: vi.fn() },
 	},
 }));
 
@@ -18,6 +17,11 @@ vi.mock("@/lib/actions/settings-actions", () => ({
 
 vi.mock("@/lib/leaderboard/snapshot", () => ({
 	maybeSnapshotPreviousMonth: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/leaderboard/history", () => ({
+	getArchivedRecipients: vi.fn(),
+	formatMonthLabel: vi.fn(() => "April 2026"),
 }));
 
 vi.mock("@/lib/leaderboard/visibility", () => ({
@@ -34,20 +38,27 @@ import {
 } from "@/lib/actions/settings-actions";
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
+import { getArchivedRecipients } from "@/lib/leaderboard/history";
 import { getCurrentMonthBoundaries } from "@/lib/leaderboard/month";
 import { computeLeaderboardVisibility } from "@/lib/leaderboard/visibility";
 import { GET } from "./route";
 
 const USER_ID = "user_123";
-const START = new Date("2026-04-01T00:00:00Z");
-const END = new Date("2026-05-01T00:00:00Z");
+const START = new Date("2026-05-01T00:00:00Z");
+const END = new Date("2026-06-01T00:00:00Z");
+const REVEAL_START = new Date("2026-05-01T00:00:00Z");
+const REVEAL_END = new Date("2026-05-21T00:00:00Z");
+const NEXT_REVEAL_START = new Date("2026-06-01T00:00:00Z");
+const SOURCE_MONTH_KEY = "2026-04";
+const REQUEST = new Request("http://localhost/api/recognition/stats");
 
 function mockVisible(visible: boolean) {
 	vi.mocked(computeLeaderboardVisibility).mockReturnValue({
 		visible,
-		mode: "always",
-		revealStart: null,
-		revealEnd: null,
+		revealStart: REVEAL_START,
+		revealEnd: REVEAL_END,
+		nextRevealStart: NEXT_REVEAL_START,
+		sourceMonthKey: SOURCE_MONTH_KEY,
 	});
 }
 
@@ -60,27 +71,25 @@ beforeEach(() => {
 	vi.mocked(getCurrentMonthBoundaries).mockReturnValue({
 		start: START,
 		end: END,
+		monthKey: "2026-05",
 		year: 2026,
-		month: 3,
-		daysInMonth: 30,
+		month: 4,
+		daysInMonth: 31,
 	});
 	vi.mocked(getLeaderboardVisibilitySettings).mockResolvedValue({
-		mode: "always",
-		revealDays: 3,
-		customStart: null,
-		customEnd: null,
+		revealStartDay: 1,
+		revealEndDay: 20,
 	});
 	vi.mocked(getTopRecognizedLimit).mockResolvedValue(5);
 	vi.mocked(prisma.recognitionCard.count).mockResolvedValue(0);
-	vi.mocked(prisma.recognitionCard.groupBy).mockResolvedValue([] as never);
-	vi.mocked(prisma.user.findMany).mockResolvedValue([]);
+	vi.mocked(getArchivedRecipients).mockResolvedValue([]);
 });
 
 describe("GET /api/recognition/stats", () => {
 	test("returns 401 when unauthenticated", async () => {
 		vi.mocked(requireSession).mockRejectedValueOnce(new Error("unauthorized"));
 
-		const res = await GET();
+		const res = await GET(REQUEST);
 
 		expect(res.status).toBe(401);
 		const body = await res.json();
@@ -94,7 +103,7 @@ describe("GET /api/recognition/stats", () => {
 			.mockResolvedValueOnce(4) // received
 			.mockResolvedValueOnce(42); // monthlyTotal
 
-		const res = await GET();
+		const res = await GET(REQUEST);
 		const body = await res.json();
 
 		expect(res.status).toBe(200);
@@ -119,35 +128,69 @@ describe("GET /api/recognition/stats", () => {
 		});
 	});
 
-	test("populates topRecipients when the leaderboard is visible", async () => {
+	test("reveals the previous month's archived winners when visible", async () => {
 		mockVisible(true);
-		vi.mocked(prisma.recognitionCard.groupBy).mockResolvedValue([
-			{ recipientId: "u1", _count: { recipientId: 5 } },
-			{ recipientId: "u2", _count: { recipientId: 3 } },
-		] as never);
-		vi.mocked(prisma.user.findMany).mockResolvedValue([
-			{ id: "u1", firstName: "Ada", lastName: "Lovelace", avatar: null },
-			{ id: "u2", firstName: "Alan", lastName: "Turing", avatar: "avatar.png" },
-		] as never);
+		vi.mocked(getArchivedRecipients).mockResolvedValue([
+			{ userId: "u1", firstName: "Ada", lastName: "Lovelace", avatar: null, count: 5, rank: 1 },
+			{
+				userId: "u2",
+				firstName: "Alan",
+				lastName: "Turing",
+				avatar: "avatar.png",
+				count: 3,
+				rank: 2,
+			},
+		]);
 
-		const res = await GET();
+		const res = await GET(REQUEST);
 		const body = await res.json();
 
+		expect(getArchivedRecipients).toHaveBeenCalledWith(SOURCE_MONTH_KEY, 5);
 		expect(body.data.topRecipients).toEqual([
 			{ firstName: "Ada", lastName: "Lovelace", avatar: null, count: 5 },
 			{ firstName: "Alan", lastName: "Turing", avatar: "avatar.png", count: 3 },
 		]);
 		expect(body.data.leaderboardVisibility.visible).toBe(true);
+		expect(body.data.leaderboardVisibility.sourceMonthKey).toBe(SOURCE_MONTH_KEY);
 	});
 
 	test("omits topRecipients when the leaderboard is hidden", async () => {
 		mockVisible(false);
 
-		const res = await GET();
+		const res = await GET(REQUEST);
 		const body = await res.json();
 
 		expect(body.data.topRecipients).toEqual([]);
 		expect(body.data.leaderboardVisibility.visible).toBe(false);
-		expect(prisma.recognitionCard.groupBy).not.toHaveBeenCalled();
+		expect(getArchivedRecipients).not.toHaveBeenCalled();
+	});
+
+	test("honors ?previewNow for a super admin", async () => {
+		mockVisible(true);
+		vi.mocked(requireSession).mockResolvedValue({
+			user: { id: USER_ID, role: "SUPERADMIN" },
+			session: { id: "sess_1" },
+		} as unknown as Awaited<ReturnType<typeof requireSession>>);
+
+		await GET(new Request("http://localhost/api/recognition/stats?previewNow=2026-06-01"));
+
+		const passedNow = vi.mocked(computeLeaderboardVisibility).mock.calls[0]?.[1];
+		expect(passedNow?.toISOString()).toBe(new Date("2026-06-01").toISOString());
+	});
+
+	test("ignores ?previewNow for a non-super-admin", async () => {
+		mockVisible(true);
+		vi.mocked(requireSession).mockResolvedValue({
+			user: { id: USER_ID, role: "MEMBER" },
+			session: { id: "sess_1" },
+		} as unknown as Awaited<ReturnType<typeof requireSession>>);
+
+		const before = Date.now();
+		await GET(new Request("http://localhost/api/recognition/stats?previewNow=2026-06-01"));
+
+		const passedNow = vi.mocked(computeLeaderboardVisibility).mock.calls[0]?.[1];
+		// Falls back to real "now", not the preview date.
+		expect(passedNow?.getTime()).toBeGreaterThanOrEqual(before);
+		expect(passedNow?.toISOString()).not.toBe(new Date("2026-06-01").toISOString());
 	});
 });

--- a/app/api/recognition/stats/route.ts
+++ b/app/api/recognition/stats/route.ts
@@ -7,19 +7,19 @@ import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { formatMonthLabel, getArchivedRecipients } from "@/lib/leaderboard/history";
 import { getCurrentMonthBoundaries } from "@/lib/leaderboard/month";
-import { maybeSnapshotPreviousMonth } from "@/lib/leaderboard/snapshot";
+import { computeMonthRecipients, maybeSnapshotPreviousMonth } from "@/lib/leaderboard/snapshot";
 import { computeLeaderboardVisibility } from "@/lib/leaderboard/visibility";
 import { hasMinRole } from "@/lib/permissions";
 
 // Super-admin only: lets them preview a future/past date
 // (e.g. ?previewNow=2026-06-01) to see the reveal window without waiting for
-// the real calendar. The param is ignored for everyone else.
-function resolveNow(request: Request, allowPreview: boolean): Date {
-	if (!allowPreview) return new Date();
+// the real calendar. Returns null (real clock) for everyone else.
+function resolvePreviewNow(request: Request, allowPreview: boolean): Date | null {
+	if (!allowPreview) return null;
 	const preview = new URL(request.url).searchParams.get("previewNow");
-	if (!preview) return new Date();
+	if (!preview) return null;
 	const parsed = new Date(preview);
-	return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
 export async function GET(request: Request) {
@@ -33,10 +33,15 @@ export async function GET(request: Request) {
 	try {
 		const userId = session.user.id;
 		const isSuperAdmin = hasMinRole(session.user.role as Role, "SUPERADMIN");
-		const now = resolveNow(request, isSuperAdmin);
+		const realNow = new Date();
+		const previewNow = resolvePreviewNow(request, isSuperAdmin);
+		const now = previewNow ?? realNow;
 		const { start: startOfMonth, end: endOfMonth } = getCurrentMonthBoundaries(now);
 
-		await maybeSnapshotPreviousMonth(now).catch(() => {
+		// Always snapshot against the real clock. Archiving with a simulated
+		// preview date would freeze a partial month — the unique-month upsert's
+		// empty update never corrects it, permanently corrupting the winners.
+		await maybeSnapshotPreviousMonth(realNow).catch(() => {
 			// Snapshot failures must not break the stats response.
 		});
 
@@ -75,7 +80,13 @@ export async function GET(request: Request) {
 		// During the reveal window we show the previous (completed) month's
 		// finalized winners, read from its archived snapshot — never a live tally.
 		if (visibility.visible) {
-			const recipients = await getArchivedRecipients(visibility.sourceMonthKey, topLimit);
+			let recipients = await getArchivedRecipients(visibility.sourceMonthKey, topLimit);
+			// When previewing a future date the source month may not be archived
+			// yet (it hasn't ended in real time). Compute it live so the preview is
+			// populated — this never persists a snapshot.
+			if (!recipients && previewNow) {
+				recipients = await computeMonthRecipients(visibility.sourceMonthKey, topLimit);
+			}
 			topRecipients = (recipients ?? []).map((r) => ({
 				firstName: r.firstName,
 				lastName: r.lastName,

--- a/app/api/recognition/stats/route.ts
+++ b/app/api/recognition/stats/route.ts
@@ -1,14 +1,28 @@
+import type { Role } from "@/app/generated/prisma/client";
 import {
 	getLeaderboardVisibilitySettings,
 	getTopRecognizedLimit,
 } from "@/lib/actions/settings-actions";
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
+import { formatMonthLabel, getArchivedRecipients } from "@/lib/leaderboard/history";
 import { getCurrentMonthBoundaries } from "@/lib/leaderboard/month";
 import { maybeSnapshotPreviousMonth } from "@/lib/leaderboard/snapshot";
 import { computeLeaderboardVisibility } from "@/lib/leaderboard/visibility";
+import { hasMinRole } from "@/lib/permissions";
 
-export async function GET() {
+// Super-admin only: lets them preview a future/past date
+// (e.g. ?previewNow=2026-06-01) to see the reveal window without waiting for
+// the real calendar. The param is ignored for everyone else.
+function resolveNow(request: Request, allowPreview: boolean): Date {
+	if (!allowPreview) return new Date();
+	const preview = new URL(request.url).searchParams.get("previewNow");
+	if (!preview) return new Date();
+	const parsed = new Date(preview);
+	return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+export async function GET(request: Request) {
 	let session: Awaited<ReturnType<typeof requireSession>>;
 	try {
 		session = await requireSession();
@@ -18,7 +32,8 @@ export async function GET() {
 
 	try {
 		const userId = session.user.id;
-		const now = new Date();
+		const isSuperAdmin = hasMinRole(session.user.role as Role, "SUPERADMIN");
+		const now = resolveNow(request, isSuperAdmin);
 		const { start: startOfMonth, end: endOfMonth } = getCurrentMonthBoundaries(now);
 
 		await maybeSnapshotPreviousMonth(now).catch(() => {
@@ -57,30 +72,16 @@ export async function GET() {
 			count: number;
 		}> = [];
 
+		// During the reveal window we show the previous (completed) month's
+		// finalized winners, read from its archived snapshot — never a live tally.
 		if (visibility.visible) {
-			const grouped = await prisma.recognitionCard.groupBy({
-				by: ["recipientId"],
-				where: { createdAt: { gte: startOfMonth, lt: endOfMonth } },
-				_count: { recipientId: true },
-				orderBy: { _count: { recipientId: "desc" } },
-				take: topLimit,
-			});
-
-			if (grouped.length > 0) {
-				const recipients = await prisma.user.findMany({
-					where: { id: { in: grouped.map((g) => g.recipientId) } },
-					select: { id: true, firstName: true, lastName: true, avatar: true },
-				});
-				topRecipients = grouped.map((g) => {
-					const user = recipients.find((u) => u.id === g.recipientId);
-					return {
-						firstName: user?.firstName ?? "",
-						lastName: user?.lastName ?? "",
-						avatar: user?.avatar ?? null,
-						count: g._count.recipientId,
-					};
-				});
-			}
+			const recipients = await getArchivedRecipients(visibility.sourceMonthKey, topLimit);
+			topRecipients = (recipients ?? []).map((r) => ({
+				firstName: r.firstName,
+				lastName: r.lastName,
+				avatar: r.avatar,
+				count: r.count,
+			}));
 		}
 
 		return Response.json({
@@ -92,9 +93,11 @@ export async function GET() {
 				topRecipients,
 				leaderboardVisibility: {
 					visible: visibility.visible,
-					mode: visibility.mode,
-					revealStart: visibility.revealStart?.toISOString() ?? null,
-					revealEnd: visibility.revealEnd?.toISOString() ?? null,
+					sourceMonthKey: visibility.sourceMonthKey,
+					sourceMonthLabel: formatMonthLabel(visibility.sourceMonthKey),
+					revealStart: visibility.revealStart.toISOString(),
+					revealEnd: visibility.revealEnd.toISOString(),
+					nextRevealStart: visibility.nextRevealStart.toISOString(),
 				},
 			},
 		});

--- a/app/api/recognition/stats/route.ts
+++ b/app/api/recognition/stats/route.ts
@@ -6,18 +6,22 @@ import {
 import { requireSession } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { formatMonthLabel, getArchivedRecipients } from "@/lib/leaderboard/history";
-import { getCurrentMonthBoundaries } from "@/lib/leaderboard/month";
+import { getCurrentMonthBoundaries, manilaDateStringToUtc } from "@/lib/leaderboard/month";
 import { computeMonthRecipients, maybeSnapshotPreviousMonth } from "@/lib/leaderboard/snapshot";
 import { computeLeaderboardVisibility } from "@/lib/leaderboard/visibility";
 import { hasMinRole } from "@/lib/permissions";
 
 // Super-admin only: lets them preview a future/past date
 // (e.g. ?previewNow=2026-06-01) to see the reveal window without waiting for
-// the real calendar. Returns null (real clock) for everyone else.
+// the real calendar. Returns null (real clock) for everyone else. The date is
+// interpreted as Asia/Manila midnight so it lines up with the visibility math.
 function resolvePreviewNow(request: Request, allowPreview: boolean): Date | null {
 	if (!allowPreview) return null;
 	const preview = new URL(request.url).searchParams.get("previewNow");
 	if (!preview) return null;
+	const manila = manilaDateStringToUtc(preview);
+	if (manila) return manila;
+	// Accept full timestamps too, but never an invalid date.
 	const parsed = new Date(preview);
 	return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
@@ -41,8 +45,10 @@ export async function GET(request: Request) {
 		// Always snapshot against the real clock. Archiving with a simulated
 		// preview date would freeze a partial month — the unique-month upsert's
 		// empty update never corrects it, permanently corrupting the winners.
-		await maybeSnapshotPreviousMonth(realNow).catch(() => {
-			// Snapshot failures must not break the stats response.
+		await maybeSnapshotPreviousMonth(realNow).catch((err) => {
+			// A snapshot failure must not break the stats response, but it must
+			// not be silent either — the live fallback below covers the read.
+			console.error("maybeSnapshotPreviousMonth failed", { error: err });
 		});
 
 		const [visibilitySettings, topLimit] = await Promise.all([
@@ -81,10 +87,11 @@ export async function GET(request: Request) {
 		// finalized winners, read from its archived snapshot — never a live tally.
 		if (visibility.visible) {
 			let recipients = await getArchivedRecipients(visibility.sourceMonthKey, topLimit);
-			// When previewing a future date the source month may not be archived
-			// yet (it hasn't ended in real time). Compute it live so the preview is
-			// populated — this never persists a snapshot.
-			if (!recipients && previewNow) {
+			// Fall back to a live computation when the archive is missing or invalid
+			// (snapshot not yet written, swallowed failure, or corrupt JSON), so the
+			// reveal window never shows a false "no winners" state. Safe for everyone:
+			// the source month is closed, so counts are stable, and this never writes.
+			if (!recipients) {
 				recipients = await computeMonthRecipients(visibility.sourceMonthKey, topLimit);
 			}
 			topRecipients = (recipients ?? []).map((r) => ({

--- a/lib/actions/settings-actions.test.ts
+++ b/lib/actions/settings-actions.test.ts
@@ -12,8 +12,10 @@ vi.mock("@/lib/db", () => ({
 	prisma: {
 		appSetting: {
 			findUnique: vi.fn(),
+			findMany: vi.fn(),
 			upsert: vi.fn(),
 		},
+		$transaction: vi.fn(),
 	},
 }));
 
@@ -29,7 +31,12 @@ vi.mock("@/lib/cache/settings-cache", () => ({
 import { requireRole } from "@/lib/auth-utils";
 import { invalidateEntry } from "@/lib/cache/settings-cache";
 import { prisma } from "@/lib/db";
-import { getHelpMeEnabled, updateHelpMeEnabled } from "./settings-actions";
+import {
+	getHelpMeEnabled,
+	getLeaderboardVisibilitySettings,
+	updateHelpMeEnabled,
+	updateLeaderboardVisibilitySettings,
+} from "./settings-actions";
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -92,6 +99,114 @@ describe("updateHelpMeEnabled", () => {
 			update: { value: "false" },
 			create: { key: "helpme_module_enabled", value: "false" },
 		});
+		expect(invalidateEntry).toHaveBeenCalledTimes(1);
+	});
+});
+
+type SettingRow = Awaited<ReturnType<typeof prisma.appSetting.findMany>>[number];
+
+function rows(map: Record<string, string>): SettingRow[] {
+	return Object.entries(map).map(
+		([key, value]) => ({ key, value, updatedAt: new Date() }) as SettingRow,
+	);
+}
+
+describe("getLeaderboardVisibilitySettings", () => {
+	test("defaults to days 1-20 when no rows exist", async () => {
+		vi.mocked(prisma.appSetting.findMany).mockResolvedValue([]);
+
+		await expect(getLeaderboardVisibilitySettings()).resolves.toEqual({
+			revealStartDay: 1,
+			revealEndDay: 20,
+		});
+	});
+
+	test("reads stored start/end days", async () => {
+		vi.mocked(prisma.appSetting.findMany).mockResolvedValue(
+			rows({ leaderboard_reveal_start_day: "5", leaderboard_reveal_end_day: "15" }),
+		);
+
+		await expect(getLeaderboardVisibilitySettings()).resolves.toEqual({
+			revealStartDay: 5,
+			revealEndDay: 15,
+		});
+	});
+
+	test("falls back to defaults for out-of-range values", async () => {
+		vi.mocked(prisma.appSetting.findMany).mockResolvedValue(
+			rows({ leaderboard_reveal_start_day: "40", leaderboard_reveal_end_day: "0" }),
+		);
+
+		await expect(getLeaderboardVisibilitySettings()).resolves.toEqual({
+			revealStartDay: 1,
+			revealEndDay: 20,
+		});
+	});
+
+	test("clamps the end day to be at least the start day", async () => {
+		vi.mocked(prisma.appSetting.findMany).mockResolvedValue(
+			rows({ leaderboard_reveal_start_day: "18", leaderboard_reveal_end_day: "5" }),
+		);
+
+		await expect(getLeaderboardVisibilitySettings()).resolves.toEqual({
+			revealStartDay: 18,
+			revealEndDay: 18,
+		});
+	});
+});
+
+describe("updateLeaderboardVisibilitySettings", () => {
+	test("rejects non-admins without writing", async () => {
+		vi.mocked(requireRole).mockRejectedValueOnce(new Error("Forbidden"));
+
+		const result = await updateLeaderboardVisibilitySettings({
+			revealStartDay: 1,
+			revealEndDay: 20,
+		});
+
+		expect(result).toEqual({ success: false, error: "Unauthorized" });
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("rejects out-of-range days", async () => {
+		vi.mocked(requireRole).mockResolvedValueOnce({} as Awaited<ReturnType<typeof requireRole>>);
+
+		const result = await updateLeaderboardVisibilitySettings({
+			revealStartDay: 0,
+			revealEndDay: 20,
+		});
+
+		expect(result.success).toBe(false);
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("rejects when start day is after end day", async () => {
+		vi.mocked(requireRole).mockResolvedValueOnce({} as Awaited<ReturnType<typeof requireRole>>);
+
+		const result = await updateLeaderboardVisibilitySettings({
+			revealStartDay: 15,
+			revealEndDay: 5,
+		});
+
+		expect(result).toEqual({
+			success: false,
+			error: "Reveal start day must be on or before the end day",
+		});
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("persists valid days and invalidates the cache", async () => {
+		vi.mocked(requireRole).mockResolvedValueOnce({} as Awaited<ReturnType<typeof requireRole>>);
+		vi.mocked(prisma.$transaction).mockResolvedValueOnce([] as never);
+
+		const result = await updateLeaderboardVisibilitySettings({
+			revealStartDay: 3,
+			revealEndDay: 18,
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(requireRole).toHaveBeenCalledWith("ADMIN");
+		expect(prisma.$transaction).toHaveBeenCalledTimes(1);
 		expect(invalidateEntry).toHaveBeenCalledTimes(1);
 	});
 });

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -20,12 +20,11 @@ import {
 	TOP_RECOGNIZED_MIN,
 } from "@/lib/leaderboard/constants";
 import {
-	LEADERBOARD_VISIBILITY_MODES,
-	type LeaderboardVisibilityMode,
 	type LeaderboardVisibilitySettings,
-	REVEAL_DAYS_DEFAULT,
-	REVEAL_DAYS_MAX,
-	REVEAL_DAYS_MIN,
+	REVEAL_DAY_MAX,
+	REVEAL_DAY_MIN,
+	REVEAL_END_DAY_DEFAULT,
+	REVEAL_START_DAY_DEFAULT,
 } from "@/lib/leaderboard/visibility";
 
 const OAUTH_KEYS = ["oauth_google_enabled", "oauth_microsoft_enabled"] as const;
@@ -222,30 +221,19 @@ export async function updateHelpMeEnabled(
 
 /* ── Leaderboard Visibility ──────────────────────────── */
 
-const LEADERBOARD_MODE_KEY = "leaderboard_visibility_mode";
-const LEADERBOARD_DAYS_KEY = "leaderboard_reveal_days";
-const LEADERBOARD_CUSTOM_START_KEY = "leaderboard_custom_start";
-const LEADERBOARD_CUSTOM_END_KEY = "leaderboard_custom_end";
-const LEADERBOARD_KEYS = [
-	LEADERBOARD_MODE_KEY,
-	LEADERBOARD_DAYS_KEY,
-	LEADERBOARD_CUSTOM_START_KEY,
-	LEADERBOARD_CUSTOM_END_KEY,
-];
+const LEADERBOARD_START_DAY_KEY = "leaderboard_reveal_start_day";
+const LEADERBOARD_END_DAY_KEY = "leaderboard_reveal_end_day";
+const LEADERBOARD_KEYS = [LEADERBOARD_START_DAY_KEY, LEADERBOARD_END_DAY_KEY];
 
 function invalidateLeaderboardCache() {
 	invalidateEntry(leaderboardCache);
 }
 
-function isValidIsoDate(value: string): boolean {
-	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
-	// Round-trip to reject impossible calendar dates like 2026-02-31.
-	const parsed = new Date(`${value}T00:00:00Z`);
-	return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(value);
-}
-
-function isLeaderboardMode(value: string): value is LeaderboardVisibilityMode {
-	return (LEADERBOARD_VISIBILITY_MODES as string[]).includes(value);
+function parseDay(raw: string | undefined, fallback: number): number {
+	const parsed = Number.parseInt(raw ?? "", 10);
+	return Number.isInteger(parsed) && parsed >= REVEAL_DAY_MIN && parsed <= REVEAL_DAY_MAX
+		? parsed
+		: fallback;
 }
 
 export async function getLeaderboardVisibilitySettings(): Promise<LeaderboardVisibilitySettings> {
@@ -255,32 +243,19 @@ export async function getLeaderboardVisibilitySettings(): Promise<LeaderboardVis
 		});
 		const map = new Map(rows.map((r) => [r.key, r.value]));
 
-		const rawMode = map.get(LEADERBOARD_MODE_KEY) ?? "always";
-		const mode: LeaderboardVisibilityMode = isLeaderboardMode(rawMode) ? rawMode : "always";
+		const revealStartDay = parseDay(map.get(LEADERBOARD_START_DAY_KEY), REVEAL_START_DAY_DEFAULT);
+		const revealEndDay = Math.max(
+			revealStartDay,
+			parseDay(map.get(LEADERBOARD_END_DAY_KEY), REVEAL_END_DAY_DEFAULT),
+		);
 
-		const parsedDays = Number.parseInt(map.get(LEADERBOARD_DAYS_KEY) ?? "", 10);
-		const revealDays =
-			Number.isFinite(parsedDays) && parsedDays >= REVEAL_DAYS_MIN && parsedDays <= REVEAL_DAYS_MAX
-				? parsedDays
-				: REVEAL_DAYS_DEFAULT;
-
-		const rawStart = map.get(LEADERBOARD_CUSTOM_START_KEY) ?? null;
-		const rawEnd = map.get(LEADERBOARD_CUSTOM_END_KEY) ?? null;
-
-		return {
-			mode,
-			revealDays,
-			customStart: rawStart && isValidIsoDate(rawStart) ? rawStart : null,
-			customEnd: rawEnd && isValidIsoDate(rawEnd) ? rawEnd : null,
-		};
+		return { revealStartDay, revealEndDay };
 	});
 }
 
 export interface UpdateLeaderboardVisibilityInput {
-	mode: LeaderboardVisibilityMode;
-	revealDays: number;
-	customStart: string | null;
-	customEnd: string | null;
+	revealStartDay: number;
+	revealEndDay: number;
 }
 
 export async function updateLeaderboardVisibilitySettings(
@@ -292,70 +267,33 @@ export async function updateLeaderboardVisibilitySettings(
 		return { success: false, error: "Unauthorized" };
 	}
 
-	if (!isLeaderboardMode(input.mode)) {
-		return { success: false, error: "Invalid visibility mode" };
-	}
+	const dayIsValid = (day: number) =>
+		Number.isInteger(day) && day >= REVEAL_DAY_MIN && day <= REVEAL_DAY_MAX;
 
-	const revealDaysIsValid =
-		Number.isInteger(input.revealDays) &&
-		input.revealDays >= REVEAL_DAYS_MIN &&
-		input.revealDays <= REVEAL_DAYS_MAX;
-
-	// Only block the save on revealDays errors when the chosen mode actually
-	// consumes that field. Otherwise an admin switching to `always` / `custom_range`
-	// with a still-editing Reveal days input would be blocked on a now-hidden field.
-	if (input.mode === "last_n_days_of_month" && !revealDaysIsValid) {
+	if (!dayIsValid(input.revealStartDay) || !dayIsValid(input.revealEndDay)) {
 		return {
 			success: false,
-			error: `Reveal days must be between ${REVEAL_DAYS_MIN} and ${REVEAL_DAYS_MAX}`,
+			error: `Reveal days must be between ${REVEAL_DAY_MIN} and ${REVEAL_DAY_MAX}`,
 		};
 	}
 
-	if (input.mode === "custom_range") {
-		if (
-			!input.customStart ||
-			!input.customEnd ||
-			!isValidIsoDate(input.customStart) ||
-			!isValidIsoDate(input.customEnd)
-		) {
-			return {
-				success: false,
-				error: "Custom range requires valid start and end dates",
-			};
-		}
-		if (input.customStart > input.customEnd) {
-			return {
-				success: false,
-				error: "Start date must be on or before end date",
-			};
-		}
+	if (input.revealStartDay > input.revealEndDay) {
+		return {
+			success: false,
+			error: "Reveal start day must be on or before the end day",
+		};
 	}
-
-	const normalizedDays = revealDaysIsValid ? input.revealDays : REVEAL_DAYS_DEFAULT;
-	const normalizedStart =
-		input.customStart && isValidIsoDate(input.customStart) ? input.customStart : "";
-	const normalizedEnd = input.customEnd && isValidIsoDate(input.customEnd) ? input.customEnd : "";
 
 	await prisma.$transaction([
 		prisma.appSetting.upsert({
-			where: { key: LEADERBOARD_MODE_KEY },
-			update: { value: input.mode },
-			create: { key: LEADERBOARD_MODE_KEY, value: input.mode },
+			where: { key: LEADERBOARD_START_DAY_KEY },
+			update: { value: String(input.revealStartDay) },
+			create: { key: LEADERBOARD_START_DAY_KEY, value: String(input.revealStartDay) },
 		}),
 		prisma.appSetting.upsert({
-			where: { key: LEADERBOARD_DAYS_KEY },
-			update: { value: String(normalizedDays) },
-			create: { key: LEADERBOARD_DAYS_KEY, value: String(normalizedDays) },
-		}),
-		prisma.appSetting.upsert({
-			where: { key: LEADERBOARD_CUSTOM_START_KEY },
-			update: { value: normalizedStart },
-			create: { key: LEADERBOARD_CUSTOM_START_KEY, value: normalizedStart },
-		}),
-		prisma.appSetting.upsert({
-			where: { key: LEADERBOARD_CUSTOM_END_KEY },
-			update: { value: normalizedEnd },
-			create: { key: LEADERBOARD_CUSTOM_END_KEY, value: normalizedEnd },
+			where: { key: LEADERBOARD_END_DAY_KEY },
+			update: { value: String(input.revealEndDay) },
+			create: { key: LEADERBOARD_END_DAY_KEY, value: String(input.revealEndDay) },
 		}),
 	]);
 

--- a/lib/leaderboard/history.test.ts
+++ b/lib/leaderboard/history.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		monthlyLeaderboardSnapshot: {
+			findUnique: vi.fn(),
+			findMany: vi.fn(),
+		},
+	},
+}));
+
+import { prisma } from "@/lib/db";
+import { getArchivedRecipients, getMonthLeaderboard, isValidMonthKey } from "./history";
+
+// Asia/Manila 2026-06-15 12:00 → current month key is 2026-06.
+const NOW = new Date("2026-06-15T04:00:00Z");
+
+function recipient(rank: number) {
+	return {
+		userId: `u${rank}`,
+		firstName: `First${rank}`,
+		lastName: `Last${rank}`,
+		avatar: null,
+		count: 10 - rank,
+		rank,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("isValidMonthKey", () => {
+	test("accepts well-formed keys and rejects malformed ones", () => {
+		expect(isValidMonthKey("2026-05")).toBe(true);
+		expect(isValidMonthKey("2026-13")).toBe(false);
+		expect(isValidMonthKey("2026-5")).toBe(false);
+		expect(isValidMonthKey("nope")).toBe(false);
+	});
+});
+
+describe("getMonthLeaderboard", () => {
+	test("returns locked for the in-progress current month without hitting the DB", async () => {
+		const result = await getMonthLeaderboard("2026-06", NOW);
+
+		expect(result).toEqual({ kind: "locked", monthKey: "2026-06" });
+		expect(prisma.monthlyLeaderboardSnapshot.findUnique).not.toHaveBeenCalled();
+	});
+
+	test("returns missing when no snapshot exists for a past month", async () => {
+		vi.mocked(prisma.monthlyLeaderboardSnapshot.findUnique).mockResolvedValue(null);
+
+		const result = await getMonthLeaderboard("2026-05", NOW);
+
+		expect(result).toEqual({ kind: "missing", monthKey: "2026-05" });
+	});
+
+	test("returns archived recipients trimmed to the limit", async () => {
+		const snapshotAt = new Date("2026-06-01T00:05:00Z");
+		vi.mocked(prisma.monthlyLeaderboardSnapshot.findUnique).mockResolvedValue({
+			month: "2026-05",
+			recipients: [recipient(1), recipient(2), recipient(3)],
+			snapshotAt,
+			topLimit: 50,
+			id: "snap_1",
+		} as never);
+
+		const result = await getMonthLeaderboard("2026-05", NOW, 2);
+
+		expect(result.kind).toBe("archived");
+		if (result.kind === "archived") {
+			expect(result.recipients).toHaveLength(2);
+			expect(result.recipients.map((r) => r.rank)).toEqual([1, 2]);
+			expect(result.snapshotAt).toBe(snapshotAt);
+		}
+	});
+
+	test("returns missing when the stored snapshot JSON is invalid", async () => {
+		vi.mocked(prisma.monthlyLeaderboardSnapshot.findUnique).mockResolvedValue({
+			month: "2026-05",
+			recipients: [{ bogus: true }],
+			snapshotAt: new Date(),
+			topLimit: 50,
+			id: "snap_1",
+		} as never);
+
+		const result = await getMonthLeaderboard("2026-05", NOW);
+
+		expect(result).toEqual({ kind: "missing", monthKey: "2026-05" });
+	});
+});
+
+describe("getArchivedRecipients", () => {
+	test("returns null when no snapshot exists", async () => {
+		vi.mocked(prisma.monthlyLeaderboardSnapshot.findUnique).mockResolvedValue(null);
+
+		await expect(getArchivedRecipients("2026-05", 10)).resolves.toBeNull();
+	});
+
+	test("returns null when the snapshot JSON is invalid", async () => {
+		vi.mocked(prisma.monthlyLeaderboardSnapshot.findUnique).mockResolvedValue({
+			recipients: [{ bogus: true }],
+		} as never);
+
+		await expect(getArchivedRecipients("2026-05", 10)).resolves.toBeNull();
+	});
+
+	test("returns recipients trimmed to the limit", async () => {
+		vi.mocked(prisma.monthlyLeaderboardSnapshot.findUnique).mockResolvedValue({
+			recipients: [recipient(1), recipient(2), recipient(3)],
+		} as never);
+
+		const result = await getArchivedRecipients("2026-05", 2);
+
+		expect(result).toHaveLength(2);
+		expect(result?.map((r) => r.rank)).toEqual([1, 2]);
+	});
+});

--- a/lib/leaderboard/history.ts
+++ b/lib/leaderboard/history.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
-import { getLeaderboardVisibilitySettings } from "@/lib/actions/settings-actions";
 import { prisma } from "@/lib/db";
 import { getCurrentMonthBoundaries, parseMonthKey } from "./month";
-import { computeMonthRecipients, type SnapshotRecipient } from "./snapshot";
-import { computeLeaderboardVisibility, type LeaderboardVisibilityState } from "./visibility";
+import type { SnapshotRecipient } from "./snapshot";
 
 const MONTH_KEY_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
 
@@ -29,22 +27,12 @@ const SnapshotPayloadSchema = z.array(SnapshotRecipientSchema);
 
 export type MonthLeaderboard =
 	| {
-			kind: "live";
-			monthKey: string;
-			recipients: SnapshotRecipient[];
-			visibility: LeaderboardVisibilityState;
-	  }
-	| {
-			kind: "locked";
-			monthKey: string;
-			visibility: LeaderboardVisibilityState;
-	  }
-	| {
 			kind: "archived";
 			monthKey: string;
 			recipients: SnapshotRecipient[];
 			snapshotAt: Date;
 	  }
+	| { kind: "locked"; monthKey: string }
 	| { kind: "missing"; monthKey: string };
 
 export async function getArchivedMonthKeys(): Promise<string[]> {
@@ -55,6 +43,26 @@ export async function getArchivedMonthKeys(): Promise<string[]> {
 	return rows.map((r) => r.month);
 }
 
+function parseSnapshotRecipients(value: unknown): SnapshotRecipient[] | null {
+	const parsed = SnapshotPayloadSchema.safeParse(value);
+	return parsed.success ? parsed.data : null;
+}
+
+// Reads a completed month's archived winners, trimmed to `limit`. Returns null
+// when no valid snapshot exists for the month.
+export async function getArchivedRecipients(
+	monthKey: string,
+	limit: number,
+): Promise<SnapshotRecipient[] | null> {
+	const snapshot = await prisma.monthlyLeaderboardSnapshot.findUnique({
+		where: { month: monthKey },
+		select: { recipients: true },
+	});
+	if (!snapshot) return null;
+	const recipients = parseSnapshotRecipients(snapshot.recipients);
+	return recipients ? recipients.slice(0, limit) : null;
+}
+
 export async function getMonthLeaderboard(
 	monthKey: string,
 	now: Date = new Date(),
@@ -62,14 +70,9 @@ export async function getMonthLeaderboard(
 ): Promise<MonthLeaderboard> {
 	const currentKey = getCurrentMonthBoundaries(now).monthKey;
 
+	// The in-progress month is never shown — its data is still being counted.
 	if (monthKey === currentKey) {
-		const settings = await getLeaderboardVisibilitySettings();
-		const visibility = computeLeaderboardVisibility(settings, now);
-		if (!visibility.visible) {
-			return { kind: "locked", monthKey, visibility };
-		}
-		const recipients = await computeMonthRecipients(monthKey, limit);
-		return { kind: "live", monthKey, recipients, visibility };
+		return { kind: "locked", monthKey };
 	}
 
 	const snapshot = await prisma.monthlyLeaderboardSnapshot.findUnique({
@@ -79,8 +82,8 @@ export async function getMonthLeaderboard(
 		return { kind: "missing", monthKey };
 	}
 
-	const parsed = SnapshotPayloadSchema.safeParse(snapshot.recipients);
-	if (!parsed.success) {
+	const recipients = parseSnapshotRecipients(snapshot.recipients);
+	if (!recipients) {
 		return { kind: "missing", monthKey };
 	}
 
@@ -89,7 +92,7 @@ export async function getMonthLeaderboard(
 	return {
 		kind: "archived",
 		monthKey,
-		recipients: parsed.data.slice(0, limit),
+		recipients: recipients.slice(0, limit),
 		snapshotAt: snapshot.snapshotAt,
 	};
 }

--- a/lib/leaderboard/month.ts
+++ b/lib/leaderboard/month.ts
@@ -36,6 +36,22 @@ function manilaMidnightToUtc(year: number, monthIndex: number, day: number): Dat
 	return new Date(Date.UTC(year, monthIndex, day, 0, 0, 0, 0) - TZ_OFFSET_MS);
 }
 
+// Parses a "YYYY-MM-DD" string as Asia/Manila midnight, returned as the
+// equivalent UTC instant. Returns null for malformed or impossible dates.
+export function manilaDateStringToUtc(dateStr: string): Date | null {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+	if (!match) return null;
+	const year = Number.parseInt(match[1] ?? "", 10);
+	const monthIndex = Number.parseInt(match[2] ?? "", 10) - 1;
+	const day = Number.parseInt(match[3] ?? "", 10);
+	if (Number.isNaN(year) || Number.isNaN(monthIndex) || Number.isNaN(day)) return null;
+	const utc = manilaMidnightToUtc(year, monthIndex, day);
+	// Reject impossible calendar dates (e.g. 2026-02-31 would roll over).
+	const shifted = new Date(utc.getTime() + TZ_OFFSET_MS);
+	if (shifted.getUTCMonth() !== monthIndex || shifted.getUTCDate() !== day) return null;
+	return utc;
+}
+
 export function getMonthBoundariesForKey(monthKey: string): MonthBoundaries {
 	const { year, month } = parseMonthKey(monthKey);
 	const start = manilaMidnightToUtc(year, month, 1);

--- a/lib/leaderboard/visibility.test.ts
+++ b/lib/leaderboard/visibility.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { computeLeaderboardVisibility } from "./visibility";
+
+// Asia/Manila is UTC+8 with no DST, so Manila midnight on day D is UTC (D-1) 16:00.
+const WINDOW_1_TO_20 = { revealStartDay: 1, revealEndDay: 20 };
+
+describe("computeLeaderboardVisibility", () => {
+	test("is visible inside the window and points at the previous month", () => {
+		// 2026-06-05 12:00 Manila
+		const now = new Date("2026-06-05T04:00:00Z");
+		const state = computeLeaderboardVisibility(WINDOW_1_TO_20, now);
+
+		expect(state.visible).toBe(true);
+		expect(state.sourceMonthKey).toBe("2026-05");
+		// Window start = 2026-06-01 Manila, end exclusive = 2026-06-21 Manila.
+		expect(state.revealStart.toISOString()).toBe("2026-05-31T16:00:00.000Z");
+		expect(state.revealEnd.toISOString()).toBe("2026-06-20T16:00:00.000Z");
+	});
+
+	test("is locked before the window opens; next opening is this month", () => {
+		// 2026-06-03 12:00 Manila, window opens day 5
+		const now = new Date("2026-06-03T04:00:00Z");
+		const state = computeLeaderboardVisibility({ revealStartDay: 5, revealEndDay: 20 }, now);
+
+		expect(state.visible).toBe(false);
+		// 2026-06-05 Manila
+		expect(state.nextRevealStart.toISOString()).toBe("2026-06-04T16:00:00.000Z");
+		expect(state.nextRevealStart.getTime()).toBe(state.revealStart.getTime());
+	});
+
+	test("is locked after the window closes; next opening rolls to next month", () => {
+		// 2026-06-25 12:00 Manila, window already closed (ended day 20)
+		const now = new Date("2026-06-25T04:00:00Z");
+		const state = computeLeaderboardVisibility(WINDOW_1_TO_20, now);
+
+		expect(state.visible).toBe(false);
+		// 2026-07-01 Manila
+		expect(state.nextRevealStart.toISOString()).toBe("2026-06-30T16:00:00.000Z");
+	});
+
+	test("rolls the year over when locked in December", () => {
+		// 2026-12-25 12:00 Manila
+		const now = new Date("2026-12-25T04:00:00Z");
+		const state = computeLeaderboardVisibility(WINDOW_1_TO_20, now);
+
+		expect(state.visible).toBe(false);
+		expect(state.sourceMonthKey).toBe("2026-11");
+		// 2027-01-01 Manila
+		expect(state.nextRevealStart.toISOString()).toBe("2026-12-31T16:00:00.000Z");
+	});
+
+	test("clamps out-of-range days into 1..28 and keeps start <= end", () => {
+		const now = new Date("2026-06-05T04:00:00Z");
+		const state = computeLeaderboardVisibility({ revealStartDay: 40, revealEndDay: 0 }, now);
+
+		// start clamps to 28, end = max(28, clamp(0->1)) = 28 → window is day 28 only.
+		expect(state.revealStart.toISOString()).toBe("2026-06-27T16:00:00.000Z");
+		expect(state.revealEnd.toISOString()).toBe("2026-06-28T16:00:00.000Z");
+	});
+});

--- a/lib/leaderboard/visibility.ts
+++ b/lib/leaderboard/visibility.ts
@@ -28,7 +28,7 @@ function manilaMidnightToUtc(year: number, monthIndex: number, day: number): Dat
 	return new Date(Date.UTC(year, monthIndex, day, 0, 0, 0, 0) - TZ_OFFSET_MS);
 }
 
-function clampDay(value: number): number {
+export function clampDay(value: number): number {
 	if (!Number.isFinite(value)) return REVEAL_DAY_MIN;
 	return Math.min(Math.max(Math.trunc(value), REVEAL_DAY_MIN), REVEAL_DAY_MAX);
 }

--- a/lib/leaderboard/visibility.ts
+++ b/lib/leaderboard/visibility.ts
@@ -1,95 +1,64 @@
-import { getCurrentMonthBoundaries } from "./month";
+import { getCurrentMonthBoundaries, getPreviousMonthKey } from "./month";
 
-export type LeaderboardVisibilityMode = "always" | "last_n_days_of_month" | "custom_range";
-
-export const LEADERBOARD_VISIBILITY_MODES: LeaderboardVisibilityMode[] = [
-	"always",
-	"last_n_days_of_month",
-	"custom_range",
-];
-
-export const REVEAL_DAYS_MIN = 1;
-export const REVEAL_DAYS_MAX = 14;
-export const REVEAL_DAYS_DEFAULT = 7;
+export const REVEAL_DAY_MIN = 1;
+// Cap at 28 so the reveal window always exists in every month (February-safe).
+export const REVEAL_DAY_MAX = 28;
+export const REVEAL_START_DAY_DEFAULT = 1;
+export const REVEAL_END_DAY_DEFAULT = 20;
 
 export interface LeaderboardVisibilitySettings {
-	mode: LeaderboardVisibilityMode;
-	revealDays: number;
-	customStart: string | null;
-	customEnd: string | null;
+	revealStartDay: number;
+	revealEndDay: number;
 }
 
 export interface LeaderboardVisibilityState {
 	visible: boolean;
-	revealStart: Date | null;
-	revealEnd: Date | null;
-	mode: LeaderboardVisibilityMode;
+	revealStart: Date;
+	revealEnd: Date;
+	// The next window opening — this month's if we haven't reached it yet,
+	// otherwise next month's. Used for the "reveals in…" countdown when locked.
+	nextRevealStart: Date;
+	// The completed month whose winners the window reveals (previous calendar month).
+	sourceMonthKey: string;
 }
 
 const TZ_OFFSET_MS = 8 * 60 * 60 * 1000;
 
-function manilaIsoDateToUtcStart(dateStr: string): Date | null {
-	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
-	if (!match) return null;
-	const year = Number.parseInt(match[1] ?? "", 10);
-	const month = Number.parseInt(match[2] ?? "", 10) - 1;
-	const day = Number.parseInt(match[3] ?? "", 10);
-	if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
-		return null;
-	}
-	return new Date(Date.UTC(year, month, day, 0, 0, 0, 0) - TZ_OFFSET_MS);
+function manilaMidnightToUtc(year: number, monthIndex: number, day: number): Date {
+	return new Date(Date.UTC(year, monthIndex, day, 0, 0, 0, 0) - TZ_OFFSET_MS);
 }
 
-function manilaIsoDateToUtcEndExclusive(dateStr: string): Date | null {
-	const start = manilaIsoDateToUtcStart(dateStr);
-	if (!start) return null;
-	return new Date(start.getTime() + 24 * 60 * 60 * 1000);
+function clampDay(value: number): number {
+	if (!Number.isFinite(value)) return REVEAL_DAY_MIN;
+	return Math.min(Math.max(Math.trunc(value), REVEAL_DAY_MIN), REVEAL_DAY_MAX);
 }
 
 export function computeLeaderboardVisibility(
 	settings: LeaderboardVisibilitySettings,
 	now: Date = new Date(),
 ): LeaderboardVisibilityState {
-	if (settings.mode === "always") {
-		return {
-			visible: true,
-			revealStart: null,
-			revealEnd: null,
-			mode: "always",
-		};
-	}
+	const { year, month } = getCurrentMonthBoundaries(now);
 
-	if (settings.mode === "last_n_days_of_month") {
-		const { end: monthEnd, year, month, daysInMonth } = getCurrentMonthBoundaries(now);
-		const clampedDays = Math.min(Math.max(settings.revealDays, REVEAL_DAYS_MIN), REVEAL_DAYS_MAX);
-		const firstRevealDay = Math.max(1, daysInMonth - clampedDays + 1);
-		const revealStart = new Date(Date.UTC(year, month, firstRevealDay, 0, 0, 0, 0) - TZ_OFFSET_MS);
-		const visible = now.getTime() >= revealStart.getTime() && now.getTime() < monthEnd.getTime();
-		return {
-			visible,
-			revealStart,
-			revealEnd: monthEnd,
-			mode: "last_n_days_of_month",
-		};
-	}
+	const startDay = clampDay(settings.revealStartDay);
+	const endDay = Math.max(startDay, clampDay(settings.revealEndDay));
 
-	const start = settings.customStart ? manilaIsoDateToUtcStart(settings.customStart) : null;
-	const end = settings.customEnd ? manilaIsoDateToUtcEndExclusive(settings.customEnd) : null;
+	const revealStart = manilaMidnightToUtc(year, month, startDay);
+	// Exclusive upper bound: midnight after the inclusive end day.
+	const revealEnd = manilaMidnightToUtc(year, month, endDay + 1);
 
-	if (!start || !end || end.getTime() <= start.getTime()) {
-		return {
-			visible: false,
-			revealStart: null,
-			revealEnd: null,
-			mode: "custom_range",
-		};
-	}
+	const t = now.getTime();
+	const visible = t >= revealStart.getTime() && t < revealEnd.getTime();
 
-	const visible = now.getTime() >= start.getTime() && now.getTime() < end.getTime();
+	// Before this month's window → it's still the next opening. At or after it
+	// → the next opening is next month (Date.UTC rolls the year over).
+	const nextRevealStart =
+		t < revealStart.getTime() ? revealStart : manilaMidnightToUtc(year, month + 1, startDay);
+
 	return {
 		visible,
-		revealStart: start,
-		revealEnd: end,
-		mode: "custom_range",
+		revealStart,
+		revealEnd,
+		nextRevealStart,
+		sourceMonthKey: getPreviousMonthKey(now),
 	};
 }


### PR DESCRIPTION
## Summary

Reworks the "Most Recognized" leaderboard from a **live current-month tally** to the **previous completed month's finalized winners**, revealed on the dashboard only during a configurable day-of-month window (default days 1–20, Asia/Manila). Outside the window the panel is locked with a countdown to the next reveal.

- **Visibility config:** replaced the 3-mode system (`always` / `last_n_days_of_month` / `custom_range`) with two day inputs — **reveal start day** / **reveal end day** (1–28). Counting always covers the full calendar month.
- **Dashboard widget:** shows the previous-month snapshot during the window (heading `Most Recognized — May 2026` + a `Final results` badge); locked state reads "This month's winners · Revealed June 1" with a countdown.
- **History page:** all completed months browsable forever; the in-progress month is never shown (still being counted) — removed the old "live" current-month branch.
- **Preview tool:** added a super-admin-only `?previewNow=<date>` override (gated by `SUPERADMIN` role, ignored for everyone else) and a **Leaderboard Preview** panel on the Super Admin page to check the revealed state before the window opens.

## Migration / ops notes

- Settings are KV rows — **no Prisma migration needed**. New keys (`leaderboard_reveal_start_day` / `_end_day`) default to 1/20 until an admin saves.
- Orphaned old `leaderboard_*` rows were deleted on local. **Run on prod when merging:**
  \`\`\`sql
  DELETE FROM app_settings WHERE key IN ('leaderboard_visibility_mode','leaderboard_reveal_days','leaderboard_custom_start','leaderboard_custom_end');
  \`\`\`

## Test plan

- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bunx biome check\` — clean
- [x] \`bun run test:unit\` — 313 passing (new \`visibility.test.ts\` for the day-window + super-admin preview gate tests)
- [ ] Manual: dashboard locked state (no preview) shows "This month's winners · Revealed <date>" + countdown
- [ ] Manual: \`/dashboard?previewNow=2026-06-01\` shows May's winners with the "Final results" badge
- [ ] Manual: Super Admin → Leaderboard Preview panel opens the dashboard at the chosen date
- [ ] Manual: admin settings reveal start/end day inputs save and reflect on the dashboard

Closes #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added leaderboard preview capability enabling administrators to view and test leaderboards as they appear on specific dates.

* **Improvements**
  * Simplified leaderboard visibility settings configuration interface.
  * Updated leaderboard messaging to better distinguish current month from archived months.
  * Refined month labeling, date formatting, and recognition status displays across leaderboard views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisgen19/access-group-staff/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core leaderboard visibility, month-boundary math (Asia/Manila), and stats API data sourcing; incorrect snapshot/preview timing could show wrong winners, though preview is gated and snapshots use the real clock.
> 
> **Overview**
> Reworks **Most Recognized** from a live current-month tally to **last month’s finalized winners**, shown on the dashboard only during a configurable **day-of-month window** (default days 1–20, Asia/Manila). Outside the window the panel stays locked with a countdown to the next reveal.
> 
> **Visibility & settings:** The old three-mode config (`always` / `last N days` / custom dates) is replaced by **reveal start day** and **reveal end day** (1–28) stored in new app-setting keys. Admin UI is two numeric fields with validation/clamping.
> 
> **Data & API:** During the reveal window, `/api/recognition/stats` loads winners from the **archived snapshot** for `sourceMonthKey` (previous calendar month), with a **read-only live fallback** if the archive is missing. Sent/received/company totals still use the **current** month. Snapshotting always runs on the **real clock** so super-admin `?previewNow=` cannot corrupt archives; preview is **SUPERADMIN-only** and wired through the stats widget query key plus a new **Leaderboard Preview** panel on Super Admin.
> 
> **History UI:** The leaderboard history page drops the live current-month path—only completed archived months are selectable; the in-progress month deep-links to a **“Still being counted”** locked state. Dashboard copy updates (e.g. **Final results**, empty state for no recognitions last month).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d95c3ed0e1f48b562bd127ba43699ad2b1aeb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->