### PR TITLE
My Team page + department sub-departments

### DIFF
--- a/app/(dashboard)/dashboard/departments/_components/department-table.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/department-table.tsx
@@ -177,6 +177,7 @@ export function DepartmentTable({
 														<button
 															type="button"
 															onClick={() => setEditTarget(dept)}
+															aria-label={`Edit department ${dept.name}`}
 															className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
 															title="Edit department"
 														>
@@ -185,6 +186,7 @@ export function DepartmentTable({
 														<button
 															type="button"
 															onClick={() => setDeleteTarget(dept)}
+															aria-label={`Delete department ${dept.name}`}
 															className="rounded-full p-2 text-muted-foreground hover:bg-[oklch(0.96_0.03_18)] hover:text-primary dark:hover:bg-primary/10 transition-colors"
 															title="Delete department"
 														>
@@ -234,6 +236,7 @@ export function DepartmentTable({
 																			<button
 																				type="button"
 																				onClick={() => setSubEditTarget({ dept, sub })}
+																				aria-label={`Edit sub-department ${sub.name}`}
 																				className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
 																				title="Edit sub-department"
 																			>
@@ -242,6 +245,7 @@ export function DepartmentTable({
 																			<button
 																				type="button"
 																				onClick={() => setSubDeleteTarget(sub)}
+																				aria-label={`Delete sub-department ${sub.name}`}
 																				className="rounded-full p-2 text-muted-foreground hover:bg-[oklch(0.96_0.03_18)] hover:text-primary dark:hover:bg-primary/10 transition-colors"
 																				title="Delete sub-department"
 																			>

--- a/app/(dashboard)/dashboard/departments/_components/department-table.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/department-table.tsx
@@ -1,17 +1,37 @@
 "use client";
 
-import { AlertCircle, Building2, Pencil, Trash2 } from "lucide-react";
+import {
+	AlertCircle,
+	Building2,
+	ChevronDown,
+	ChevronRight,
+	Layers,
+	Pencil,
+	Plus,
+	Trash2,
+} from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
-import { deleteDepartmentAction } from "@/lib/actions/department-actions";
+import {
+	deleteDepartmentAction,
+	deleteSubDepartmentAction,
+} from "@/lib/actions/department-actions";
 import { DepartmentFormDialog } from "./department-form";
+import { SubDepartmentFormDialog } from "./sub-department-form";
+
+interface SubDepartment {
+	id: string;
+	name: string;
+	_count: { users: number };
+}
 
 interface Department {
 	id: string;
 	name: string;
 	code: string;
 	_count: { users: number };
+	subDepartments: SubDepartment[];
 }
 
 export function DepartmentTable({
@@ -24,6 +44,27 @@ export function DepartmentTable({
 	const [deleteTarget, setDeleteTarget] = useState<Department | null>(null);
 	const [editTarget, setEditTarget] = useState<Department | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);
+	const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+	const [subCreateDept, setSubCreateDept] = useState<Department | null>(null);
+	const [subEditTarget, setSubEditTarget] = useState<{
+		dept: Department;
+		sub: SubDepartment;
+	} | null>(null);
+	const [subDeleteTarget, setSubDeleteTarget] = useState<SubDepartment | null>(null);
+	const [isDeletingSub, setIsDeletingSub] = useState(false);
+
+	function toggleExpanded(id: string) {
+		setExpanded((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) {
+				next.delete(id);
+			} else {
+				next.add(id);
+			}
+			return next;
+		});
+	}
 
 	async function handleDelete() {
 		if (!deleteTarget) return;
@@ -41,6 +82,25 @@ export function DepartmentTable({
 		} finally {
 			setIsDeleting(false);
 			setDeleteTarget(null);
+		}
+	}
+
+	async function handleDeleteSub() {
+		if (!subDeleteTarget) return;
+		setIsDeletingSub(true);
+		try {
+			const result = await deleteSubDepartmentAction(subDeleteTarget.id);
+			if (result.success) {
+				toast.success("Sub-department deleted");
+				onMutate?.();
+			} else {
+				toast.error(typeof result.error === "string" ? result.error : "Delete failed");
+			}
+		} catch {
+			toast.error("Something went wrong");
+		} finally {
+			setIsDeletingSub(false);
+			setSubDeleteTarget(null);
 		}
 	}
 
@@ -76,39 +136,128 @@ export function DepartmentTable({
 									</td>
 								</tr>
 							) : (
-								departments.map((dept) => (
-									<tr key={dept.id} className="group transition-colors hover:bg-background">
-										<td className="whitespace-nowrap px-8 py-5 text-sm font-medium text-foreground">
-											{dept.name}
-										</td>
-										<td className="whitespace-nowrap px-8 py-5 text-sm text-muted-foreground">
-											{dept.code}
-										</td>
-										<td className="whitespace-nowrap px-8 py-5 text-sm text-muted-foreground">
-											{dept._count.users}
-										</td>
-										<td className="whitespace-nowrap px-8 py-5 text-right text-sm">
-											<div className="flex justify-end gap-1 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity [@media(hover:hover)]:group-hover:opacity-100 focus-within:opacity-100">
-												<button
-													type="button"
-													onClick={() => setEditTarget(dept)}
-													className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
-													title="Edit"
-												>
-													<Pencil size={18} />
-												</button>
-												<button
-													type="button"
-													onClick={() => setDeleteTarget(dept)}
-													className="rounded-full p-2 text-muted-foreground hover:bg-[oklch(0.96_0.03_18)] hover:text-primary dark:hover:bg-primary/10 transition-colors"
-													title="Delete"
-												>
-													<Trash2 size={18} />
-												</button>
-											</div>
-										</td>
-									</tr>
-								))
+								departments.map((dept) => {
+									const isExpanded = expanded.has(dept.id);
+									return (
+										<tr
+											key={dept.id}
+											className="group align-top transition-colors hover:bg-background"
+										>
+											<td colSpan={4} className="p-0">
+												<div className="flex items-center">
+													<button
+														type="button"
+														onClick={() => toggleExpanded(dept.id)}
+														aria-expanded={isExpanded}
+														aria-label={
+															isExpanded ? "Collapse sub-departments" : "Expand sub-departments"
+														}
+														className="flex flex-1 items-center gap-3 px-8 py-5 text-left"
+													>
+														<span className="text-muted-foreground transition-transform">
+															{isExpanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
+														</span>
+														<span className="min-w-[12rem] flex-1 text-sm font-medium text-foreground">
+															{dept.name}
+															{dept.subDepartments.length > 0 && (
+																<span className="ml-2 text-xs font-normal text-muted-foreground">
+																	· {dept.subDepartments.length} sub-
+																	{dept.subDepartments.length === 1 ? "dept" : "depts"}
+																</span>
+															)}
+														</span>
+														<span className="hidden w-24 text-sm text-muted-foreground sm:inline">
+															{dept.code}
+														</span>
+														<span className="hidden w-16 text-sm text-muted-foreground sm:inline">
+															{dept._count.users}
+														</span>
+													</button>
+													<div className="flex justify-end gap-1 px-6 py-5 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity [@media(hover:hover)]:group-hover:opacity-100 focus-within:opacity-100">
+														<button
+															type="button"
+															onClick={() => setEditTarget(dept)}
+															className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
+															title="Edit department"
+														>
+															<Pencil size={18} />
+														</button>
+														<button
+															type="button"
+															onClick={() => setDeleteTarget(dept)}
+															className="rounded-full p-2 text-muted-foreground hover:bg-[oklch(0.96_0.03_18)] hover:text-primary dark:hover:bg-primary/10 transition-colors"
+															title="Delete department"
+														>
+															<Trash2 size={18} />
+														</button>
+													</div>
+												</div>
+
+												{isExpanded && (
+													<div className="border-t border-gray-200/60 bg-background/60 px-8 py-5 pl-16 dark:border-white/10">
+														<div className="mb-3 flex items-center justify-between gap-3">
+															<div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+																<Layers size={14} />
+																Sub-departments
+															</div>
+															<button
+																type="button"
+																onClick={() => setSubCreateDept(dept)}
+																className="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-gray-50 dark:border-white/10 dark:hover:bg-white/5"
+															>
+																<Plus size={14} />
+																Add
+															</button>
+														</div>
+
+														{dept.subDepartments.length === 0 ? (
+															<p className="py-3 text-sm text-muted-foreground">
+																No sub-departments yet.
+															</p>
+														) : (
+															<ul className="divide-y divide-gray-200/60 dark:divide-white/10">
+																{dept.subDepartments.map((sub) => (
+																	<li
+																		key={sub.id}
+																		className="group/sub flex items-center justify-between gap-3 py-2.5"
+																	>
+																		<div className="min-w-0">
+																			<p className="truncate text-sm font-medium text-foreground">
+																				{sub.name}
+																			</p>
+																			<p className="text-xs text-muted-foreground">
+																				{sub._count.users}{" "}
+																				{sub._count.users === 1 ? "user" : "users"}
+																			</p>
+																		</div>
+																		<div className="flex shrink-0 gap-1 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity [@media(hover:hover)]:group-hover/sub:opacity-100 focus-within:opacity-100">
+																			<button
+																				type="button"
+																				onClick={() => setSubEditTarget({ dept, sub })}
+																				className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
+																				title="Edit sub-department"
+																			>
+																				<Pencil size={16} />
+																			</button>
+																			<button
+																				type="button"
+																				onClick={() => setSubDeleteTarget(sub)}
+																				className="rounded-full p-2 text-muted-foreground hover:bg-[oklch(0.96_0.03_18)] hover:text-primary dark:hover:bg-primary/10 transition-colors"
+																				title="Delete sub-department"
+																			>
+																				<Trash2 size={16} />
+																			</button>
+																		</div>
+																	</li>
+																))}
+															</ul>
+														)}
+													</div>
+												)}
+											</td>
+										</tr>
+									);
+								})
 							)}
 						</tbody>
 					</table>
@@ -157,12 +306,79 @@ export function DepartmentTable({
 				</DialogContent>
 			</Dialog>
 
+			<Dialog open={!!subDeleteTarget} onOpenChange={() => setSubDeleteTarget(null)}>
+				<DialogContent
+					className="max-w-md gap-0 rounded-[2rem] p-0 ring-0 border border-gray-100 dark:border-white/5 shadow-2xl"
+					showCloseButton={false}
+				>
+					<div className="px-8 pt-8 pb-6">
+						<div className="flex flex-col items-center gap-5 sm:flex-row sm:items-start">
+							<div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-destructive/10 sm:h-12 sm:w-12">
+								<AlertCircle className="h-6 w-6 text-destructive" />
+							</div>
+							<div className="text-center sm:text-left">
+								<h3 className="text-[1.25rem] font-medium text-foreground">
+									Delete Sub-department
+								</h3>
+								<p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+									Are you sure you want to delete{" "}
+									<span className="font-medium text-foreground">
+										&quot;{subDeleteTarget?.name}&quot;
+									</span>
+									? This action cannot be undone.
+								</p>
+							</div>
+						</div>
+					</div>
+					<div className="flex flex-col-reverse gap-2 border-t border-gray-200/60 dark:border-white/10 bg-gray-50/50 dark:bg-white/[0.02] px-8 py-6 rounded-b-[2rem] sm:flex-row sm:justify-end">
+						<button
+							type="button"
+							onClick={() => setSubDeleteTarget(null)}
+							className="inline-flex w-full justify-center rounded-full border border-gray-200 dark:border-white/10 bg-card px-6 py-2.5 text-sm font-medium text-foreground hover:bg-gray-50 dark:hover:bg-white/5 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-white/10 transition-all duration-200 sm:w-auto"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							onClick={handleDeleteSub}
+							disabled={isDeletingSub}
+							className="inline-flex w-full justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50 sm:w-auto"
+						>
+							{isDeletingSub ? "Deleting..." : "Confirm Removal"}
+						</button>
+					</div>
+				</DialogContent>
+			</Dialog>
+
 			{editTarget && (
 				<DepartmentFormDialog
 					mode="edit"
 					department={editTarget}
 					open={!!editTarget}
 					onClose={() => setEditTarget(null)}
+					onSuccess={onMutate}
+				/>
+			)}
+
+			{subCreateDept && (
+				<SubDepartmentFormDialog
+					mode="create"
+					departmentId={subCreateDept.id}
+					departmentName={subCreateDept.name}
+					open={!!subCreateDept}
+					onClose={() => setSubCreateDept(null)}
+					onSuccess={onMutate}
+				/>
+			)}
+
+			{subEditTarget && (
+				<SubDepartmentFormDialog
+					mode="edit"
+					departmentId={subEditTarget.dept.id}
+					departmentName={subEditTarget.dept.name}
+					subDepartment={subEditTarget.sub}
+					open={!!subEditTarget}
+					onClose={() => setSubEditTarget(null)}
 					onSuccess={onMutate}
 				/>
 			)}

--- a/app/(dashboard)/dashboard/departments/_components/departments-client.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/departments-client.tsx
@@ -8,11 +8,18 @@ import { getDepartmentsAction } from "@/lib/actions/department-actions";
 import { DepartmentFormDialog } from "./department-form";
 import { DepartmentTable } from "./department-table";
 
+interface SubDepartment {
+	id: string;
+	name: string;
+	_count: { users: number };
+}
+
 interface Department {
 	id: string;
 	name: string;
 	code: string;
 	_count: { users: number };
+	subDepartments: SubDepartment[];
 }
 
 export function DepartmentsClient() {

--- a/app/(dashboard)/dashboard/departments/_components/sub-department-form.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/sub-department-form.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+	createSubDepartmentAction,
+	updateSubDepartmentAction,
+} from "@/lib/actions/department-actions";
+import { type SubDepartmentInput, subDepartmentSchema } from "@/lib/validations/department";
+
+const inputClass =
+	"block w-full rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50/50 dark:bg-white/5 px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:bg-card focus:ring-4 focus:ring-primary/30 focus:border-primary transition-all duration-200";
+
+interface SubDepartmentFormDialogProps {
+	mode: "create" | "edit";
+	departmentId: string;
+	departmentName: string;
+	subDepartment?: { id: string; name: string };
+	open: boolean;
+	onClose: () => void;
+	onSuccess?: () => void;
+}
+
+export function SubDepartmentFormDialog({
+	mode,
+	departmentId,
+	departmentName,
+	subDepartment,
+	open,
+	onClose,
+	onSuccess,
+}: SubDepartmentFormDialogProps) {
+	const [isLoading, setIsLoading] = useState(false);
+
+	const {
+		register,
+		handleSubmit,
+		reset,
+		formState: { errors },
+	} = useForm<SubDepartmentInput>({
+		resolver: zodResolver(subDepartmentSchema),
+		defaultValues: { name: subDepartment?.name ?? "" },
+	});
+
+	async function onSubmit(data: SubDepartmentInput) {
+		if (mode === "edit" && !subDepartment?.id) {
+			toast.error("Missing sub-department id");
+			return;
+		}
+		setIsLoading(true);
+		try {
+			const result =
+				mode === "create"
+					? await createSubDepartmentAction(departmentId, data)
+					: await updateSubDepartmentAction(subDepartment?.id as string, data);
+
+			if (!result.success) {
+				const errorMsg = typeof result.error === "string" ? result.error : "Validation failed";
+				toast.error(errorMsg);
+				return;
+			}
+
+			toast.success(mode === "create" ? "Sub-department created" : "Sub-department updated");
+			reset();
+			onClose();
+			onSuccess?.();
+		} catch {
+			toast.error("Something went wrong");
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onClose}>
+			<DialogContent
+				className="max-w-lg gap-0 rounded-[2rem] p-0 ring-0 border border-gray-100 dark:border-white/5 shadow-2xl"
+				showCloseButton={false}
+			>
+				<DialogHeader className="px-8 pt-8 pb-2">
+					<DialogTitle className="text-[1.5rem] leading-tight font-medium tracking-tight">
+						{mode === "create" ? "Add Sub-department" : "Edit Sub-department"}
+					</DialogTitle>
+					<p className="text-sm text-muted-foreground">{departmentName}</p>
+				</DialogHeader>
+
+				<form onSubmit={handleSubmit(onSubmit)}>
+					<div className="space-y-5 px-8 py-6">
+						<div>
+							<label
+								htmlFor="sub-dept-name"
+								className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+							>
+								Sub-department Name
+							</label>
+							<input
+								id="sub-dept-name"
+								placeholder="Team Power BI"
+								className={inputClass}
+								{...register("name")}
+							/>
+							{errors.name && (
+								<p className="mt-1 text-sm text-destructive">{errors.name.message}</p>
+							)}
+						</div>
+					</div>
+
+					<div className="flex flex-col-reverse gap-2 border-t border-gray-200/60 dark:border-white/10 bg-gray-50/50 dark:bg-white/[0.02] px-8 py-6 rounded-b-[2rem] sm:flex-row sm:justify-end">
+						<button
+							type="button"
+							onClick={onClose}
+							className="inline-flex w-full justify-center rounded-full border border-gray-200 dark:border-white/10 bg-card px-6 py-2.5 text-sm font-medium text-foreground hover:bg-gray-50 dark:hover:bg-white/5 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-white/10 transition-all duration-200 sm:w-auto"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							disabled={isLoading}
+							className="inline-flex w-full justify-center rounded-full bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-primary/30 transition-all duration-200 disabled:opacity-50 sm:w-auto"
+						>
+							{isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+							{mode === "create" ? "Add" : "Save"}
+						</button>
+					</div>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/app/(dashboard)/dashboard/my-team/_components/team-groups.tsx
+++ b/app/(dashboard)/dashboard/my-team/_components/team-groups.tsx
@@ -1,6 +1,24 @@
 import { UserAvatar } from "@/components/shared/user-avatar";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import type { TeamGroup } from "@/lib/team";
 import { cn } from "@/lib/utils";
+
+const BRANCH_LABELS: Record<string, string> = {
+	ISO: "ISO",
+	PERTH: "Perth",
+};
+
+function formatBranch(branch: string | null): string {
+	if (!branch) return "—";
+	return BRANCH_LABELS[branch] ?? branch;
+}
 
 export function TeamGroups({
 	groups,
@@ -10,18 +28,10 @@ export function TeamGroups({
 	viewerUserId: string;
 }) {
 	return (
-		<div className="space-y-6">
+		<div className="space-y-8">
 			{groups.map((group) => (
-				<section
-					key={group.subDepartmentId ?? "__none__"}
-					className={cn(
-						"overflow-hidden rounded-[2rem] border bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]",
-						group.isViewerTeam
-							? "border-primary/30 ring-1 ring-primary/15"
-							: "border-gray-200/60 dark:border-white/10",
-					)}
-				>
-					<div className="flex items-center justify-between gap-3 px-6 pt-6 pb-3 sm:px-8">
+				<section key={group.subDepartmentId ?? "__none__"} className="space-y-3">
+					<div className="flex items-center justify-between gap-3 px-1">
 						<div className="flex items-center gap-3">
 							<h2 className="text-[1.15rem] font-medium text-foreground">{group.name}</h2>
 							{group.isViewerTeam && (
@@ -35,36 +45,63 @@ export function TeamGroups({
 						</span>
 					</div>
 
-					<div className="grid grid-cols-1 gap-px bg-gray-200/60 dark:bg-white/10 sm:grid-cols-2 lg:grid-cols-3">
-						{group.members.map((member) => {
-							const fullName = `${member.firstName} ${member.lastName}`;
-							const isViewer = member.id === viewerUserId;
-							return (
-								<div key={member.id} className="flex items-center gap-3 bg-card px-6 py-4 sm:px-8">
-									<UserAvatar
-										firstName={member.firstName}
-										lastName={member.lastName}
-										avatar={member.avatar}
-										image={member.image}
-										size="lg"
-										className="border border-gray-100 bg-background text-primary dark:border-white/10"
-									/>
-									<div className="min-w-0">
-										<p className="truncate text-sm font-medium text-foreground">
-											{fullName}
-											{isViewer && (
-												<span className="ml-2 text-xs font-normal text-muted-foreground">
-													(You)
+					<div
+						className={cn(
+							"overflow-hidden rounded-xl border bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]",
+							group.isViewerTeam
+								? "border-primary/30 ring-1 ring-primary/15"
+								: "border-gray-200/60 dark:border-white/10",
+						)}
+					>
+						<Table>
+							<TableHeader>
+								<TableRow className="bg-muted/30 hover:bg-muted/30">
+									<TableHead>Employee</TableHead>
+									<TableHead>Position</TableHead>
+									<TableHead>Branch</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{group.members.map((member) => {
+									const isViewer = member.id === viewerUserId;
+									return (
+										<TableRow key={member.id}>
+											<TableCell>
+												<div className="flex items-center gap-3">
+													<UserAvatar
+														firstName={member.firstName}
+														lastName={member.lastName}
+														avatar={member.avatar}
+														image={member.image}
+														size="lg"
+														className="border border-gray-100 bg-background text-primary dark:border-white/10"
+													/>
+													<div className="min-w-0">
+														<p className="truncate text-sm font-medium text-foreground">
+															{member.firstName} {member.lastName}
+															{isViewer && (
+																<span className="ml-2 text-xs font-normal text-muted-foreground">
+																	(You)
+																</span>
+															)}
+														</p>
+														<p className="truncate text-xs text-muted-foreground">{member.email}</p>
+													</div>
+												</div>
+											</TableCell>
+											<TableCell>
+												<span className="text-sm text-foreground">{member.position ?? "—"}</span>
+											</TableCell>
+											<TableCell>
+												<span className="text-sm text-foreground">
+													{formatBranch(member.branch)}
 												</span>
-											)}
-										</p>
-										<p className="truncate text-xs text-muted-foreground">
-											{member.position ?? member.email}
-										</p>
-									</div>
-								</div>
-							);
-						})}
+											</TableCell>
+										</TableRow>
+									);
+								})}
+							</TableBody>
+						</Table>
 					</div>
 				</section>
 			))}

--- a/app/(dashboard)/dashboard/my-team/_components/team-groups.tsx
+++ b/app/(dashboard)/dashboard/my-team/_components/team-groups.tsx
@@ -1,0 +1,73 @@
+import { UserAvatar } from "@/components/shared/user-avatar";
+import type { TeamGroup } from "@/lib/team";
+import { cn } from "@/lib/utils";
+
+export function TeamGroups({
+	groups,
+	viewerUserId,
+}: {
+	groups: TeamGroup[];
+	viewerUserId: string;
+}) {
+	return (
+		<div className="space-y-6">
+			{groups.map((group) => (
+				<section
+					key={group.subDepartmentId ?? "__none__"}
+					className={cn(
+						"overflow-hidden rounded-[2rem] border bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)]",
+						group.isViewerTeam
+							? "border-primary/30 ring-1 ring-primary/15"
+							: "border-gray-200/60 dark:border-white/10",
+					)}
+				>
+					<div className="flex items-center justify-between gap-3 px-6 pt-6 pb-3 sm:px-8">
+						<div className="flex items-center gap-3">
+							<h2 className="text-[1.15rem] font-medium text-foreground">{group.name}</h2>
+							{group.isViewerTeam && (
+								<span className="rounded-full bg-[oklch(0.96_0.03_18)] px-3 py-1 text-xs font-medium text-primary dark:bg-primary/15">
+									Your team
+								</span>
+							)}
+						</div>
+						<span className="text-sm text-muted-foreground">
+							{group.members.length} {group.members.length === 1 ? "member" : "members"}
+						</span>
+					</div>
+
+					<div className="grid grid-cols-1 gap-px bg-gray-200/60 dark:bg-white/10 sm:grid-cols-2 lg:grid-cols-3">
+						{group.members.map((member) => {
+							const fullName = `${member.firstName} ${member.lastName}`;
+							const isViewer = member.id === viewerUserId;
+							return (
+								<div key={member.id} className="flex items-center gap-3 bg-card px-6 py-4 sm:px-8">
+									<UserAvatar
+										firstName={member.firstName}
+										lastName={member.lastName}
+										avatar={member.avatar}
+										image={member.image}
+										size="lg"
+										className="border border-gray-100 bg-background text-primary dark:border-white/10"
+									/>
+									<div className="min-w-0">
+										<p className="truncate text-sm font-medium text-foreground">
+											{fullName}
+											{isViewer && (
+												<span className="ml-2 text-xs font-normal text-muted-foreground">
+													(You)
+												</span>
+											)}
+										</p>
+										<p className="truncate text-xs text-muted-foreground">
+											{member.position ?? member.email}
+										</p>
+									</div>
+								</div>
+							);
+						})}
+					</div>
+				</section>
+			))}
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/my-team/loading.tsx
+++ b/app/(dashboard)/dashboard/my-team/loading.tsx
@@ -1,0 +1,38 @@
+import {
+	SkeletonCard,
+	SkeletonLine,
+	SkeletonPageHeader,
+} from "@/components/shared/skeleton-primitives";
+
+export default function MyTeamLoading() {
+	return (
+		<div
+			className="mx-auto max-w-5xl space-y-6 animate-pulse sm:space-y-8"
+			role="status"
+			aria-busy="true"
+			aria-label="Loading team"
+		>
+			<SkeletonPageHeader />
+
+			{["g0", "g1"].map((group) => (
+				<SkeletonCard key={group} className="overflow-hidden">
+					<div className="flex items-center justify-between px-6 pt-6 pb-3 sm:px-8">
+						<SkeletonLine className="h-5 w-40" />
+						<SkeletonLine className="h-4 w-20" />
+					</div>
+					<div className="grid grid-cols-1 gap-px bg-gray-200/60 dark:bg-white/10 sm:grid-cols-2 lg:grid-cols-3">
+						{["m0", "m1", "m2"].map((member) => (
+							<div key={member} className="flex items-center gap-3 bg-card px-6 py-4 sm:px-8">
+								<SkeletonLine className="h-10 w-10 shrink-0 rounded-full" />
+								<div className="min-w-0 space-y-1.5">
+									<SkeletonLine className="h-4 w-28" />
+									<SkeletonLine className="h-3 w-20" />
+								</div>
+							</div>
+						))}
+					</div>
+				</SkeletonCard>
+			))}
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/my-team/loading.tsx
+++ b/app/(dashboard)/dashboard/my-team/loading.tsx
@@ -1,13 +1,17 @@
+import { SkeletonLine, SkeletonPageHeader } from "@/components/shared/skeleton-primitives";
 import {
-	SkeletonCard,
-	SkeletonLine,
-	SkeletonPageHeader,
-} from "@/components/shared/skeleton-primitives";
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 
 export default function MyTeamLoading() {
 	return (
 		<div
-			className="mx-auto max-w-5xl space-y-6 animate-pulse sm:space-y-8"
+			className="mx-auto max-w-5xl space-y-8 animate-pulse sm:space-y-8"
 			role="status"
 			aria-busy="true"
 			aria-label="Loading team"
@@ -15,23 +19,50 @@ export default function MyTeamLoading() {
 			<SkeletonPageHeader />
 
 			{["g0", "g1"].map((group) => (
-				<SkeletonCard key={group} className="overflow-hidden">
-					<div className="flex items-center justify-between px-6 pt-6 pb-3 sm:px-8">
+				<section key={group} className="space-y-3">
+					<div className="flex items-center justify-between px-1">
 						<SkeletonLine className="h-5 w-40" />
 						<SkeletonLine className="h-4 w-20" />
 					</div>
-					<div className="grid grid-cols-1 gap-px bg-gray-200/60 dark:bg-white/10 sm:grid-cols-2 lg:grid-cols-3">
-						{["m0", "m1", "m2"].map((member) => (
-							<div key={member} className="flex items-center gap-3 bg-card px-6 py-4 sm:px-8">
-								<SkeletonLine className="h-10 w-10 shrink-0 rounded-full" />
-								<div className="min-w-0 space-y-1.5">
-									<SkeletonLine className="h-4 w-28" />
-									<SkeletonLine className="h-3 w-20" />
-								</div>
-							</div>
-						))}
+					<div className="overflow-hidden rounded-xl border border-gray-200/60 bg-card shadow-[0_2px_20px_-4px_rgba(0,0,0,0.03)] dark:border-white/10">
+						<Table>
+							<TableHeader>
+								<TableRow className="bg-muted/30 hover:bg-muted/30">
+									<TableHead>
+										<SkeletonLine className="h-3 w-20" />
+									</TableHead>
+									<TableHead>
+										<SkeletonLine className="h-3 w-16" />
+									</TableHead>
+									<TableHead>
+										<SkeletonLine className="h-3 w-14" />
+									</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{["r0", "r1", "r2"].map((row) => (
+									<TableRow key={row}>
+										<TableCell>
+											<div className="flex items-center gap-3">
+												<SkeletonLine className="h-10 w-10 shrink-0 rounded-full" />
+												<div className="min-w-0 space-y-1.5">
+													<SkeletonLine className="h-4 w-32" />
+													<SkeletonLine className="h-3 w-40" />
+												</div>
+											</div>
+										</TableCell>
+										<TableCell>
+											<SkeletonLine className="h-4 w-24" />
+										</TableCell>
+										<TableCell>
+											<SkeletonLine className="h-4 w-16" />
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
 					</div>
-				</SkeletonCard>
+				</section>
 			))}
 		</div>
 	);

--- a/app/(dashboard)/dashboard/my-team/page.tsx
+++ b/app/(dashboard)/dashboard/my-team/page.tsx
@@ -1,0 +1,74 @@
+import { UsersRound } from "lucide-react";
+import { redirect } from "next/navigation";
+import { DashboardPageHeader } from "@/components/shared/dashboard-page-header";
+import { getServerSession } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+import { groupUsersBySubDepartment } from "@/lib/team";
+import { TeamGroups } from "./_components/team-groups";
+
+export default async function MyTeamPage() {
+	const session = await getServerSession();
+	if (!session) redirect("/login");
+
+	const viewer = await prisma.user.findUnique({
+		where: { id: session.user.id },
+		select: {
+			departmentId: true,
+			subDepartmentId: true,
+			department: { select: { name: true } },
+		},
+	});
+
+	if (!viewer?.departmentId) {
+		return (
+			<div className="mx-auto max-w-5xl space-y-6 sm:space-y-8">
+				<DashboardPageHeader
+					eyebrow="People"
+					title="My Team"
+					description="See the colleagues in your department, grouped by sub-department."
+				/>
+				<div className="flex flex-col items-center justify-center rounded-[2rem] border border-gray-200/60 bg-card p-16 text-center dark:border-white/10">
+					<div className="mb-6 rounded-full bg-background p-6">
+						<UsersRound size={48} className="text-muted-foreground opacity-40" />
+					</div>
+					<p className="text-[1.5rem] font-medium text-foreground">No department yet</p>
+					<p className="mt-2 max-w-md text-base text-muted-foreground">
+						You're not assigned to a department yet. Once an admin assigns you to one, your
+						teammates will show up here.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	const members = await prisma.user.findMany({
+		where: { departmentId: viewer.departmentId, deletedAt: null },
+		select: {
+			id: true,
+			firstName: true,
+			lastName: true,
+			displayName: true,
+			position: true,
+			avatar: true,
+			image: true,
+			email: true,
+			subDepartmentId: true,
+			subDepartment: { select: { id: true, name: true } },
+		},
+		orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+	});
+
+	const groups = groupUsersBySubDepartment(members, viewer.subDepartmentId);
+	const departmentName = viewer.department?.name ?? "Department";
+
+	return (
+		<div className="mx-auto max-w-5xl space-y-6 sm:space-y-8">
+			<DashboardPageHeader
+				eyebrow={departmentName}
+				title="My Team"
+				description={`Everyone in ${departmentName}, grouped by sub-department.`}
+			/>
+			<TeamGroups groups={groups} viewerUserId={session.user.id} />
+		</div>
+	);
+}

--- a/app/(dashboard)/dashboard/my-team/page.tsx
+++ b/app/(dashboard)/dashboard/my-team/page.tsx
@@ -52,6 +52,7 @@ export default async function MyTeamPage() {
 			avatar: true,
 			image: true,
 			email: true,
+			branch: true,
 			subDepartmentId: true,
 			subDepartment: { select: { id: true, name: true } },
 		},

--- a/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/edit/page.tsx
@@ -21,7 +21,10 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 			where: { id },
 			include: { shiftSchedule: { include: { days: { orderBy: { dayOfWeek: "asc" } } } } },
 		}),
-		prisma.department.findMany({ orderBy: { name: "asc" } }),
+		prisma.department.findMany({
+			include: { subDepartments: { select: { id: true, name: true }, orderBy: { name: "asc" } } },
+			orderBy: { name: "asc" },
+		}),
 	]);
 
 	if (!user) notFound();
@@ -75,6 +78,7 @@ export default async function EditUserPage({ params }: { params: Promise<{ id: s
 					branch: user.branch ?? null,
 					role: user.role,
 					departmentId: user.departmentId,
+					subDepartmentId: user.subDepartmentId,
 					hireDate: user.hireDate,
 					birthday: user.birthday,
 					shiftSchedule: scheduleDefault,

--- a/app/(dashboard)/dashboard/users/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/users/[id]/page.tsx
@@ -50,6 +50,7 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 		where: { id },
 		include: {
 			department: true,
+			subDepartment: true,
 			shiftSchedule: { include: { days: { orderBy: { dayOfWeek: "asc" } } } },
 		},
 	});
@@ -112,6 +113,7 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 					<div className="px-8 py-6 space-y-4">
 						<InfoRow label="Position" value={user.position} />
 						<InfoRow label="Department" value={user.department?.name} />
+						<InfoRow label="Sub-department" value={user.subDepartment?.name} />
 						<InfoRow label="Branch" value={formatBranch(user.branch)} />
 						<div className="flex justify-between items-center py-1">
 							<span className="text-sm text-muted-foreground">Role</span>

--- a/app/(dashboard)/dashboard/users/_components/user-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-form.tsx
@@ -30,6 +30,7 @@ interface Department {
 	id: string;
 	name: string;
 	code: string;
+	subDepartments: { id: string; name: string }[];
 }
 
 interface UserFormProps {
@@ -73,6 +74,11 @@ export function UserForm({
 	const hireDateValue = watch("hireDate");
 	const birthdayValue = watch("birthday");
 	const shiftScheduleValue = watch("shiftSchedule");
+	const departmentIdValue = watch("departmentId");
+	const subDepartmentIdValue = watch("subDepartmentId");
+
+	const subDepartmentOptions =
+		departments.find((dept) => dept.id === departmentIdValue)?.subDepartments ?? [];
 
 	const availableRoles =
 		currentUserRole === "SUPERADMIN" ? (["STAFF", "ADMIN"] as const) : (["STAFF"] as const);
@@ -86,6 +92,9 @@ export function UserForm({
 	useEffect(() => {
 		if (defaultValues?.departmentId) {
 			setValue("departmentId", defaultValues.departmentId);
+		}
+		if (defaultValues?.subDepartmentId) {
+			setValue("subDepartmentId", defaultValues.subDepartmentId);
 		}
 		if (defaultValues?.role) {
 			setValue("role", defaultValues.role);
@@ -264,16 +273,48 @@ export function UserForm({
 							</label>
 							<select
 								id="departmentId"
-								value={watch("departmentId") ?? "none"}
-								onChange={(e) =>
-									setValue("departmentId", e.target.value === "none" ? null : e.target.value)
-								}
+								value={departmentIdValue ?? "none"}
+								onChange={(e) => {
+									setValue("departmentId", e.target.value === "none" ? null : e.target.value);
+									setValue("subDepartmentId", null);
+								}}
 								className={selectClass}
 							>
 								<option value="none">No Department</option>
 								{departments.map((dept) => (
 									<option key={dept.id} value={dept.id}>
 										{dept.name} ({dept.code})
+									</option>
+								))}
+							</select>
+						</div>
+
+						<div>
+							<label
+								htmlFor="subDepartmentId"
+								className="block text-sm font-medium text-foreground/70 ml-1 mb-1.5"
+							>
+								Sub-department
+							</label>
+							<select
+								id="subDepartmentId"
+								value={subDepartmentIdValue ?? "none"}
+								onChange={(e) =>
+									setValue("subDepartmentId", e.target.value === "none" ? null : e.target.value)
+								}
+								className={selectClass}
+								disabled={!departmentIdValue || subDepartmentOptions.length === 0}
+							>
+								<option value="none">
+									{!departmentIdValue
+										? "Select a department first"
+										: subDepartmentOptions.length === 0
+											? "No sub-departments available"
+											: "No Sub-department"}
+								</option>
+								{subDepartmentOptions.map((sub) => (
+									<option key={sub.id} value={sub.id}>
+										{sub.name}
 									</option>
 								))}
 							</select>

--- a/app/(dashboard)/dashboard/users/_components/user-form.tsx
+++ b/app/(dashboard)/dashboard/users/_components/user-form.tsx
@@ -93,9 +93,7 @@ export function UserForm({
 		if (defaultValues?.departmentId) {
 			setValue("departmentId", defaultValues.departmentId);
 		}
-		if (defaultValues?.subDepartmentId) {
-			setValue("subDepartmentId", defaultValues.subDepartmentId);
-		}
+		setValue("subDepartmentId", defaultValues?.subDepartmentId ?? null);
 		if (defaultValues?.role) {
 			setValue("role", defaultValues.role);
 		}

--- a/app/(dashboard)/dashboard/users/new/page.tsx
+++ b/app/(dashboard)/dashboard/users/new/page.tsx
@@ -12,7 +12,10 @@ export default async function NewUserPage() {
 		redirect("/dashboard");
 	}
 
-	const departments = await prisma.department.findMany({ orderBy: { name: "asc" } });
+	const departments = await prisma.department.findMany({
+		include: { subDepartments: { select: { id: true, name: true }, orderBy: { name: "asc" } } },
+		orderBy: { name: "asc" },
+	});
 
 	return (
 		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">

--- a/components/shared/dashboard-sidebar.test.tsx
+++ b/components/shared/dashboard-sidebar.test.tsx
@@ -59,6 +59,22 @@ describe("DashboardSidebar", () => {
 		vi.clearAllMocks();
 	});
 
+	it("shows the My Team link to staff users", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
+		mockedUseRouter.mockReturnValue({
+			push: vi.fn(),
+			refresh: vi.fn(),
+		} as unknown as ReturnType<typeof useRouter>);
+		setSession({ role: "STAFF" });
+
+		render(<DashboardSidebar helpMeEnabled initialUserRole="STAFF" />);
+
+		const myTeamLink = screen.getByRole("link", { name: "My Team" });
+		expect(myTeamLink).toHaveAttribute("href", "/dashboard/my-team");
+		// Staff still must not see admin-only links.
+		expect(screen.queryByRole("link", { name: "Staff" })).not.toBeInTheDocument();
+	});
+
 	it("keeps the desktop rail width and exposes full nav labels via title", () => {
 		mockedUsePathname.mockReturnValue("/dashboard");
 		mockedUseRouter.mockReturnValue({

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -13,6 +13,7 @@ import {
 	Trophy,
 	UserCircle,
 	Users,
+	UsersRound,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -58,6 +59,12 @@ const NAV_ITEMS: NavItem[] = [
 		label: "Leaderboard",
 		href: "/dashboard/leaderboard",
 		icon: Trophy,
+		minRole: "STAFF",
+	},
+	{
+		label: "My Team",
+		href: "/dashboard/my-team",
+		icon: UsersRound,
 		minRole: "STAFF",
 	},
 	{

--- a/lib/actions/department-actions.test.ts
+++ b/lib/actions/department-actions.test.ts
@@ -10,6 +10,9 @@ vi.mock("@/lib/auth-utils", () => ({
 
 vi.mock("@/lib/db", () => ({
 	prisma: {
+		department: {
+			findMany: vi.fn(),
+		},
 		subDepartment: {
 			create: vi.fn(),
 			update: vi.fn(),
@@ -18,6 +21,7 @@ vi.mock("@/lib/db", () => ({
 		user: {
 			count: vi.fn(),
 		},
+		$transaction: vi.fn(),
 	},
 }));
 
@@ -27,6 +31,8 @@ import { prisma } from "@/lib/db";
 import {
 	createSubDepartmentAction,
 	deleteSubDepartmentAction,
+	getDepartmentsAction,
+	getDepartmentsWithSubDepartmentsAction,
 	updateSubDepartmentAction,
 } from "./department-actions";
 
@@ -92,8 +98,18 @@ describe("updateSubDepartmentAction", () => {
 });
 
 describe("deleteSubDepartmentAction", () => {
+	function mockTransaction(userCount: number) {
+		const tx = {
+			user: { count: vi.fn().mockResolvedValue(userCount) },
+			subDepartment: { delete: vi.fn().mockResolvedValue({ id: "sub_1" }) },
+		};
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (client: unknown) => unknown) =>
+			cb(tx)) as never);
+		return tx;
+	}
+
 	test("blocks deletion while users are still assigned", async () => {
-		vi.mocked(prisma.user.count).mockResolvedValue(3 as never);
+		const tx = mockTransaction(3);
 
 		const result = await deleteSubDepartmentAction("sub_1");
 
@@ -101,16 +117,59 @@ describe("deleteSubDepartmentAction", () => {
 		if (!result.success) {
 			expect(result.error).toMatch(/reassign users/i);
 		}
-		expect(prisma.subDepartment.delete).not.toHaveBeenCalled();
+		expect(tx.subDepartment.delete).not.toHaveBeenCalled();
 	});
 
-	test("deletes when no users are assigned", async () => {
-		vi.mocked(prisma.user.count).mockResolvedValue(0 as never);
-		vi.mocked(prisma.subDepartment.delete).mockResolvedValue({ id: "sub_1" } as never);
+	test("deletes within a serializable transaction when no users are assigned", async () => {
+		const tx = mockTransaction(0);
 
 		const result = await deleteSubDepartmentAction("sub_1");
 
 		expect(result.success).toBe(true);
-		expect(prisma.subDepartment.delete).toHaveBeenCalledWith({ where: { id: "sub_1" } });
+		expect(tx.subDepartment.delete).toHaveBeenCalledWith({ where: { id: "sub_1" } });
+		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+			isolationLevel: "Serializable",
+		});
+	});
+});
+
+describe("getDepartmentsAction", () => {
+	test("returns departments with sub-departments and user counts", async () => {
+		const departments = [{ id: "dept_1", name: "IT", subDepartments: [] }];
+		vi.mocked(prisma.department.findMany).mockResolvedValue(departments as never);
+
+		const result = await getDepartmentsAction();
+
+		expect(result).toEqual({ success: true, data: departments });
+		expect(prisma.department.findMany).toHaveBeenCalledWith({
+			include: {
+				_count: { select: { users: true } },
+				subDepartments: {
+					include: { _count: { select: { users: true } } },
+					orderBy: { name: "asc" },
+				},
+			},
+			orderBy: { name: "asc" },
+		});
+	});
+});
+
+describe("getDepartmentsWithSubDepartmentsAction", () => {
+	test("selects only id/name for sub-departments, ordered by name", async () => {
+		const departments = [{ id: "dept_1", name: "IT", subDepartments: [] }];
+		vi.mocked(prisma.department.findMany).mockResolvedValue(departments as never);
+
+		const result = await getDepartmentsWithSubDepartmentsAction();
+
+		expect(result).toEqual(departments);
+		expect(prisma.department.findMany).toHaveBeenCalledWith({
+			include: {
+				subDepartments: {
+					select: { id: true, name: true },
+					orderBy: { name: "asc" },
+				},
+			},
+			orderBy: { name: "asc" },
+		});
 	});
 });

--- a/lib/actions/department-actions.test.ts
+++ b/lib/actions/department-actions.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+	revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-utils", () => ({
+	requireRole: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+	prisma: {
+		subDepartment: {
+			create: vi.fn(),
+			update: vi.fn(),
+			delete: vi.fn(),
+		},
+		user: {
+			count: vi.fn(),
+		},
+	},
+}));
+
+import { Prisma } from "@/app/generated/prisma/client";
+import { requireRole } from "@/lib/auth-utils";
+import { prisma } from "@/lib/db";
+import {
+	createSubDepartmentAction,
+	deleteSubDepartmentAction,
+	updateSubDepartmentAction,
+} from "./department-actions";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(requireRole).mockResolvedValue({
+		user: { id: "admin_1", role: "ADMIN" as const },
+	} as unknown as Awaited<ReturnType<typeof requireRole>>);
+});
+
+describe("createSubDepartmentAction", () => {
+	test("creates a sub-department under the department", async () => {
+		vi.mocked(prisma.subDepartment.create).mockResolvedValue({
+			id: "sub_1",
+			name: "Team Power BI",
+			departmentId: "dept_1",
+		} as never);
+
+		const result = await createSubDepartmentAction("dept_1", { name: "Team Power BI" });
+
+		expect(result.success).toBe(true);
+		expect(prisma.subDepartment.create).toHaveBeenCalledWith({
+			data: { name: "Team Power BI", departmentId: "dept_1" },
+		});
+	});
+
+	test("rejects an empty name without touching the database", async () => {
+		const result = await createSubDepartmentAction("dept_1", { name: "   " });
+
+		expect(result.success).toBe(false);
+		expect(prisma.subDepartment.create).not.toHaveBeenCalled();
+	});
+
+	test("returns a friendly error on a duplicate name (P2002)", async () => {
+		vi.mocked(prisma.subDepartment.create).mockRejectedValue(
+			new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+				code: "P2002",
+				clientVersion: "test",
+			}),
+		);
+
+		const result = await createSubDepartmentAction("dept_1", { name: "Team Power BI" });
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/already exists/i);
+		}
+	});
+});
+
+describe("updateSubDepartmentAction", () => {
+	test("updates the sub-department name", async () => {
+		vi.mocked(prisma.subDepartment.update).mockResolvedValue({ id: "sub_1" } as never);
+
+		const result = await updateSubDepartmentAction("sub_1", { name: "Renamed" });
+
+		expect(result.success).toBe(true);
+		expect(prisma.subDepartment.update).toHaveBeenCalledWith({
+			where: { id: "sub_1" },
+			data: { name: "Renamed" },
+		});
+	});
+});
+
+describe("deleteSubDepartmentAction", () => {
+	test("blocks deletion while users are still assigned", async () => {
+		vi.mocked(prisma.user.count).mockResolvedValue(3 as never);
+
+		const result = await deleteSubDepartmentAction("sub_1");
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/reassign users/i);
+		}
+		expect(prisma.subDepartment.delete).not.toHaveBeenCalled();
+	});
+
+	test("deletes when no users are assigned", async () => {
+		vi.mocked(prisma.user.count).mockResolvedValue(0 as never);
+		vi.mocked(prisma.subDepartment.delete).mockResolvedValue({ id: "sub_1" } as never);
+
+		const result = await deleteSubDepartmentAction("sub_1");
+
+		expect(result.success).toBe(true);
+		expect(prisma.subDepartment.delete).toHaveBeenCalledWith({ where: { id: "sub_1" } });
+	});
+});

--- a/lib/actions/department-actions.ts
+++ b/lib/actions/department-actions.ts
@@ -1,15 +1,22 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { Prisma } from "@/app/generated/prisma/client";
 import { requireRole } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
-import { departmentSchema } from "@/lib/validations/department";
+import { departmentSchema, subDepartmentSchema } from "@/lib/validations/department";
 
 export async function getDepartmentsAction() {
 	try {
 		await requireRole("ADMIN");
 		const departments = await prisma.department.findMany({
-			include: { _count: { select: { users: true } } },
+			include: {
+				_count: { select: { users: true } },
+				subDepartments: {
+					include: { _count: { select: { users: true } } },
+					orderBy: { name: "asc" },
+				},
+			},
 			orderBy: { name: "asc" },
 		});
 		return { success: true as const, data: departments };
@@ -24,6 +31,18 @@ export async function getAllDepartmentsAction() {
 		orderBy: { name: "asc" },
 	});
 	return departments;
+}
+
+export async function getDepartmentsWithSubDepartmentsAction() {
+	return prisma.department.findMany({
+		include: {
+			subDepartments: {
+				select: { id: true, name: true },
+				orderBy: { name: "asc" },
+			},
+		},
+		orderBy: { name: "asc" },
+	});
 }
 
 export async function createDepartmentAction(formData: unknown) {
@@ -86,6 +105,83 @@ export async function deleteDepartmentAction(id: string) {
 		return { success: true as const, data: null };
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "Failed to delete department";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function createSubDepartmentAction(departmentId: string, formData: unknown) {
+	try {
+		await requireRole("ADMIN");
+		const parsed = subDepartmentSchema.safeParse(formData);
+
+		if (!parsed.success) {
+			return { success: false as const, error: parsed.error.flatten().fieldErrors };
+		}
+
+		const subDepartment = await prisma.subDepartment.create({
+			data: { name: parsed.data.name, departmentId },
+		});
+		revalidatePath("/dashboard/departments");
+		return { success: true as const, data: subDepartment };
+	} catch (error) {
+		if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+			return {
+				success: false as const,
+				error: "A sub-department with this name already exists in this department.",
+			};
+		}
+		const message = error instanceof Error ? error.message : "Failed to create sub-department";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function updateSubDepartmentAction(id: string, formData: unknown) {
+	try {
+		await requireRole("ADMIN");
+		const parsed = subDepartmentSchema.safeParse(formData);
+
+		if (!parsed.success) {
+			return { success: false as const, error: parsed.error.flatten().fieldErrors };
+		}
+
+		const subDepartment = await prisma.subDepartment.update({
+			where: { id },
+			data: { name: parsed.data.name },
+		});
+		revalidatePath("/dashboard/departments");
+		return { success: true as const, data: subDepartment };
+	} catch (error) {
+		if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+			return {
+				success: false as const,
+				error: "A sub-department with this name already exists in this department.",
+			};
+		}
+		const message = error instanceof Error ? error.message : "Failed to update sub-department";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function deleteSubDepartmentAction(id: string) {
+	try {
+		await requireRole("ADMIN");
+		// Block deletion while users are still assigned. The User → SubDepartment
+		// relation is ON DELETE SET NULL, so deleting anyway would silently strip
+		// the team from those users. Make admins reassign them first.
+		const userCount = await prisma.user.count({ where: { subDepartmentId: id } });
+
+		if (userCount > 0) {
+			return {
+				success: false as const,
+				error: "Cannot delete sub-department with assigned users. Reassign users first.",
+			};
+		}
+
+		await prisma.subDepartment.delete({ where: { id } });
+		revalidatePath("/dashboard/departments");
+		return { success: true as const, data: null };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to delete sub-department";
 		return { success: false as const, error: message };
 	}
 }

--- a/lib/actions/department-actions.ts
+++ b/lib/actions/department-actions.ts
@@ -6,6 +6,13 @@ import { requireRole } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import { departmentSchema, subDepartmentSchema } from "@/lib/validations/department";
 
+class SubDepartmentInUseError extends Error {
+	constructor() {
+		super("Cannot delete sub-department with assigned users. Reassign users first.");
+		this.name = "SubDepartmentInUseError";
+	}
+}
+
 export async function getDepartmentsAction() {
 	try {
 		await requireRole("ADMIN");
@@ -168,19 +175,27 @@ export async function deleteSubDepartmentAction(id: string) {
 		// Block deletion while users are still assigned. The User → SubDepartment
 		// relation is ON DELETE SET NULL, so deleting anyway would silently strip
 		// the team from those users. Make admins reassign them first.
-		const userCount = await prisma.user.count({ where: { subDepartmentId: id } });
+		//
+		// Count + delete run inside one Serializable transaction so a concurrent
+		// reassignment can't slip between the guard and the delete — any such race
+		// turns into a serialization failure on one of the transactions.
+		await prisma.$transaction(
+			async (tx) => {
+				const userCount = await tx.user.count({ where: { subDepartmentId: id } });
+				if (userCount > 0) {
+					throw new SubDepartmentInUseError();
+				}
+				await tx.subDepartment.delete({ where: { id } });
+			},
+			{ isolationLevel: "Serializable" },
+		);
 
-		if (userCount > 0) {
-			return {
-				success: false as const,
-				error: "Cannot delete sub-department with assigned users. Reassign users first.",
-			};
-		}
-
-		await prisma.subDepartment.delete({ where: { id } });
 		revalidatePath("/dashboard/departments");
 		return { success: true as const, data: null };
 	} catch (error) {
+		if (error instanceof SubDepartmentInUseError) {
+			return { success: false as const, error: error.message };
+		}
 		const message = error instanceof Error ? error.message : "Failed to delete sub-department";
 		return { success: false as const, error: message };
 	}

--- a/lib/actions/user-actions.test.ts
+++ b/lib/actions/user-actions.test.ts
@@ -29,6 +29,9 @@ vi.mock("@/lib/db", () => ({
 		user: {
 			findUnique: vi.fn(),
 		},
+		subDepartment: {
+			findUnique: vi.fn(),
+		},
 		$transaction: vi.fn(),
 	},
 }));
@@ -47,7 +50,7 @@ import { Prisma } from "@/app/generated/prisma/client";
 import { logActivity } from "@/lib/activity-log";
 import { requireRole } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
-import { adminResetPasswordAction } from "./user-actions";
+import { adminResetPasswordAction, updateUserAction } from "./user-actions";
 
 const ADMIN_ID = "admin_1";
 const TARGET_ID = "user_1";
@@ -228,5 +231,72 @@ describe("adminResetPasswordAction", () => {
 		} finally {
 			consoleErrorSpy.mockRestore();
 		}
+	});
+});
+
+describe("updateUserAction sub-department guard", () => {
+	beforeEach(() => {
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			role: "STAFF",
+			deletedAt: null,
+			departmentId: "dept_a",
+		} as never);
+	});
+
+	test("rejects a sub-department that does not belong to the chosen department", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_other",
+		} as never);
+
+		const result = await updateUserAction(TARGET_ID, {
+			firstName: "Jane",
+			lastName: "Cruz",
+			departmentId: "dept_a",
+			subDepartmentId: "sub_1",
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/sub-department/i);
+		}
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("rejects a sub-department when no department is selected", async () => {
+		const result = await updateUserAction(TARGET_ID, {
+			firstName: "Jane",
+			lastName: "Cruz",
+			departmentId: null,
+			subDepartmentId: "sub_1",
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/department/i);
+		}
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	test("persists a valid sub-department assignment", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_a",
+		} as never);
+		const txUserUpdate = vi.fn().mockResolvedValue({ id: TARGET_ID });
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
+			cb({ user: { update: txUserUpdate } })) as never);
+
+		const result = await updateUserAction(TARGET_ID, {
+			firstName: "Jane",
+			lastName: "Cruz",
+			departmentId: "dept_a",
+			subDepartmentId: "sub_1",
+		});
+
+		expect(result.success).toBe(true);
+		expect(txUserUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({ subDepartmentId: "sub_1" }),
+			}),
+		);
 	});
 });

--- a/lib/actions/user-actions.test.ts
+++ b/lib/actions/user-actions.test.ts
@@ -320,4 +320,23 @@ describe("updateUserAction sub-department guard", () => {
 			}),
 		);
 	});
+
+	test("preserves the sub-department when the department is unchanged and none is submitted", async () => {
+		const txUserUpdate = vi.fn().mockResolvedValue({ id: TARGET_ID });
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
+			cb({ user: { update: txUserUpdate } })) as never);
+
+		const result = await updateUserAction(TARGET_ID, {
+			firstName: "Jane",
+			lastName: "Cruz",
+			// Same department as the target; subDepartmentId intentionally omitted.
+			departmentId: "dept_a",
+		});
+
+		expect(result.success).toBe(true);
+		expect(prisma.subDepartment.findUnique).not.toHaveBeenCalled();
+		// `undefined` leaves the column untouched, so the existing team stays.
+		const updateArg = txUserUpdate.mock.calls[0][0] as { data: { subDepartmentId?: unknown } };
+		expect(updateArg.data.subDepartmentId).toBeUndefined();
+	});
 });

--- a/lib/actions/user-actions.test.ts
+++ b/lib/actions/user-actions.test.ts
@@ -299,4 +299,25 @@ describe("updateUserAction sub-department guard", () => {
 			}),
 		);
 	});
+
+	test("clears the sub-department when the department changes and none is submitted", async () => {
+		const txUserUpdate = vi.fn().mockResolvedValue({ id: TARGET_ID });
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
+			cb({ user: { update: txUserUpdate } })) as never);
+
+		const result = await updateUserAction(TARGET_ID, {
+			firstName: "Jane",
+			lastName: "Cruz",
+			departmentId: "dept_b",
+		});
+
+		expect(result.success).toBe(true);
+		// No lookup needed when clearing — null short-circuits the guard.
+		expect(prisma.subDepartment.findUnique).not.toHaveBeenCalled();
+		expect(txUserUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({ subDepartmentId: null }),
+			}),
+		);
+	});
 });

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -23,6 +23,34 @@ class LastSuperadminError extends Error {
 	}
 }
 
+type SubDepartmentResolution = { ok: true; value: string | null } | { ok: false; error: string };
+
+/**
+ * Ensures a sub-department assignment is consistent with the user's department.
+ * Returns the value to persist (or null), or an error when the sub-department
+ * does not belong to the chosen department.
+ */
+async function resolveSubDepartmentId(
+	departmentId: string | null,
+	subDepartmentId: string | null,
+): Promise<SubDepartmentResolution> {
+	if (!subDepartmentId) return { ok: true, value: null };
+	if (!departmentId) {
+		return { ok: false, error: "Select a department before assigning a sub-department" };
+	}
+	const subDepartment = await prisma.subDepartment.findUnique({
+		where: { id: subDepartmentId },
+		select: { departmentId: true },
+	});
+	if (!subDepartment || subDepartment.departmentId !== departmentId) {
+		return {
+			ok: false,
+			error: "Selected sub-department does not belong to the chosen department",
+		};
+	}
+	return { ok: true, value: subDepartmentId };
+}
+
 async function upsertShiftSchedule(
 	tx: Prisma.TransactionClient,
 	userId: string,
@@ -74,6 +102,14 @@ export async function createUserAction(formData: unknown) {
 			return { success: false as const, error: "Insufficient permissions to assign this role" };
 		}
 
+		const subDept = await resolveSubDepartmentId(
+			rest.departmentId ?? null,
+			rest.subDepartmentId ?? null,
+		);
+		if (!subDept.ok) {
+			return { success: false as const, error: subDept.error };
+		}
+
 		const result = await auth.api.signUpEmail({
 			body: {
 				email,
@@ -99,6 +135,7 @@ export async function createUserAction(formData: unknown) {
 					position: rest.position,
 					branch: rest.branch ?? null,
 					departmentId: rest.departmentId ?? null,
+					subDepartmentId: subDept.value,
 					hireDate: rest.hireDate ?? null,
 					birthday: rest.birthday ?? null,
 				},
@@ -128,7 +165,7 @@ export async function updateUserAction(userId: string, formData: unknown) {
 
 		const targetUser = await prisma.user.findUnique({
 			where: { id: userId },
-			select: { role: true, deletedAt: true },
+			select: { role: true, deletedAt: true, departmentId: true },
 		});
 
 		if (!targetUser) {
@@ -148,13 +185,29 @@ export async function updateUserAction(userId: string, formData: unknown) {
 			return { success: false as const, error: "Insufficient permissions to assign this role" };
 		}
 
-		const { shiftSchedule, hireDate, birthday, ...userFields } = parsed.data;
+		const { shiftSchedule, hireDate, birthday, subDepartmentId, ...userFields } = parsed.data;
+
+		let resolvedSubDepartmentId: string | null | undefined;
+		if (subDepartmentId !== undefined) {
+			const effectiveDepartmentId =
+				parsed.data.departmentId !== undefined ? parsed.data.departmentId : targetUser.departmentId;
+			const subDept = await resolveSubDepartmentId(
+				effectiveDepartmentId ?? null,
+				subDepartmentId ?? null,
+			);
+			if (!subDept.ok) {
+				return { success: false as const, error: subDept.error };
+			}
+			resolvedSubDepartmentId = subDept.value;
+		}
+
 		const updated = await prisma.$transaction(async (tx) => {
 			const user = await tx.user.update({
 				where: { id: userId },
 				data: {
 					...userFields,
 					role: roleIsChanging ? (parsed.data.role as Role) : undefined,
+					subDepartmentId: resolvedSubDepartmentId,
 					hireDate: hireDate === undefined ? undefined : (hireDate ?? null),
 					birthday: birthday === undefined ? undefined : (birthday ?? null),
 					name:

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -187,8 +187,11 @@ export async function updateUserAction(userId: string, formData: unknown) {
 
 		const { shiftSchedule, hireDate, birthday, subDepartmentId, ...userFields } = parsed.data;
 
+		// Resolve when the sub-department is submitted OR the department changes.
+		// The latter guards against keeping a sub-department that belongs to the
+		// user's previous department when only `departmentId` is updated.
 		let resolvedSubDepartmentId: string | null | undefined;
-		if (subDepartmentId !== undefined) {
+		if (subDepartmentId !== undefined || parsed.data.departmentId !== undefined) {
 			const effectiveDepartmentId =
 				parsed.data.departmentId !== undefined ? parsed.data.departmentId : targetUser.departmentId;
 			const subDept = await resolveSubDepartmentId(

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -187,11 +187,17 @@ export async function updateUserAction(userId: string, formData: unknown) {
 
 		const { shiftSchedule, hireDate, birthday, subDepartmentId, ...userFields } = parsed.data;
 
-		// Resolve when the sub-department is submitted OR the department changes.
-		// The latter guards against keeping a sub-department that belongs to the
-		// user's previous department when only `departmentId` is updated.
+		// `undefined` leaves the column untouched. Only touch it when the caller
+		// explicitly submits a sub-department, or when the department actually
+		// changes (which would otherwise strand a sub-department from the old
+		// department). A partial update that re-sends the unchanged department
+		// must preserve the existing assignment.
+		const departmentChanging =
+			parsed.data.departmentId !== undefined &&
+			parsed.data.departmentId !== targetUser.departmentId;
+
 		let resolvedSubDepartmentId: string | null | undefined;
-		if (subDepartmentId !== undefined || parsed.data.departmentId !== undefined) {
+		if (subDepartmentId !== undefined) {
 			const effectiveDepartmentId =
 				parsed.data.departmentId !== undefined ? parsed.data.departmentId : targetUser.departmentId;
 			const subDept = await resolveSubDepartmentId(
@@ -202,6 +208,8 @@ export async function updateUserAction(userId: string, formData: unknown) {
 				return { success: false as const, error: subDept.error };
 			}
 			resolvedSubDepartmentId = subDept.value;
+		} else if (departmentChanging) {
+			resolvedSubDepartmentId = null;
 		}
 
 		const updated = await prisma.$transaction(async (tx) => {

--- a/lib/team.test.ts
+++ b/lib/team.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+import { groupUsersBySubDepartment, NO_SUB_DEPARTMENT_LABEL, type TeamMember } from "./team";
+
+function member(id: string, subId: string | null, subName: string | null): TeamMember {
+	return {
+		id,
+		firstName: id,
+		lastName: "Test",
+		displayName: null,
+		position: null,
+		avatar: null,
+		image: null,
+		email: `${id}@example.com`,
+		subDepartmentId: subId,
+		subDepartment: subId && subName ? { id: subId, name: subName } : null,
+	};
+}
+
+describe("groupUsersBySubDepartment", () => {
+	test("groups members by sub-department", () => {
+		const groups = groupUsersBySubDepartment(
+			[
+				member("a", "bi", "Team Power BI"),
+				member("b", "infra", "Infrastructure"),
+				member("c", "bi", "Team Power BI"),
+			],
+			null,
+		);
+
+		const bi = groups.find((g) => g.subDepartmentId === "bi");
+		expect(bi?.members.map((m) => m.id)).toEqual(["a", "c"]);
+		expect(groups.find((g) => g.subDepartmentId === "infra")?.members).toHaveLength(1);
+	});
+
+	test("puts the viewer's own sub-department first and flags it", () => {
+		const groups = groupUsersBySubDepartment(
+			[
+				member("a", "alpha", "Alpha"),
+				member("b", "infra", "Infrastructure"),
+				member("c", "bi", "Team Power BI"),
+			],
+			"infra",
+		);
+
+		expect(groups[0].subDepartmentId).toBe("infra");
+		expect(groups[0].isViewerTeam).toBe(true);
+		expect(groups.filter((g) => g.isViewerTeam)).toHaveLength(1);
+		// Remaining named groups stay alphabetical.
+		expect(groups.slice(1).map((g) => g.name)).toEqual(["Alpha", "Team Power BI"]);
+	});
+
+	test("always sorts the 'No sub-department' bucket last", () => {
+		const groups = groupUsersBySubDepartment(
+			[member("a", null, null), member("b", "bi", "Team Power BI")],
+			"bi",
+		);
+
+		expect(groups[0].subDepartmentId).toBe("bi");
+		expect(groups.at(-1)?.subDepartmentId).toBeNull();
+		expect(groups.at(-1)?.name).toBe(NO_SUB_DEPARTMENT_LABEL);
+	});
+
+	test("treats the 'No sub-department' bucket as the viewer's team when they have none", () => {
+		const groups = groupUsersBySubDepartment(
+			[member("a", "bi", "Team Power BI"), member("b", null, null)],
+			null,
+		);
+
+		expect(groups[0].subDepartmentId).toBeNull();
+		expect(groups[0].isViewerTeam).toBe(true);
+	});
+});

--- a/lib/team.test.ts
+++ b/lib/team.test.ts
@@ -11,6 +11,7 @@ function member(id: string, subId: string | null, subName: string | null): TeamM
 		avatar: null,
 		image: null,
 		email: `${id}@example.com`,
+		branch: null,
 		subDepartmentId: subId,
 		subDepartment: subId && subName ? { id: subId, name: subName } : null,
 	};

--- a/lib/team.ts
+++ b/lib/team.ts
@@ -51,6 +51,7 @@ export function groupUsersBySubDepartment(
 
 	return [...groups.values()].sort((a, b) => {
 		if (a.isViewerTeam !== b.isViewerTeam) return a.isViewerTeam ? -1 : 1;
+		if (a.subDepartmentId === null && b.subDepartmentId === null) return 0;
 		if (a.subDepartmentId === null) return 1;
 		if (b.subDepartmentId === null) return -1;
 		return a.name.localeCompare(b.name);

--- a/lib/team.ts
+++ b/lib/team.ts
@@ -7,6 +7,7 @@ export interface TeamMember {
 	avatar: string | null;
 	image: string | null;
 	email: string;
+	branch: string | null;
 	subDepartmentId: string | null;
 	subDepartment: { id: string; name: string } | null;
 }

--- a/lib/team.ts
+++ b/lib/team.ts
@@ -1,0 +1,58 @@
+export interface TeamMember {
+	id: string;
+	firstName: string;
+	lastName: string;
+	displayName: string | null;
+	position: string | null;
+	avatar: string | null;
+	image: string | null;
+	email: string;
+	subDepartmentId: string | null;
+	subDepartment: { id: string; name: string } | null;
+}
+
+export interface TeamGroup {
+	subDepartmentId: string | null;
+	name: string;
+	isViewerTeam: boolean;
+	members: TeamMember[];
+}
+
+export const NO_SUB_DEPARTMENT_LABEL = "No sub-department";
+
+/**
+ * Groups department members by sub-department for the "My Team" view.
+ *
+ * Ordering: the viewer's own sub-department comes first, remaining named
+ * sub-departments are sorted alphabetically, and the "No sub-department"
+ * bucket is always last (unless the viewer themselves has no sub-department,
+ * in which case that bucket is their team and leads).
+ */
+export function groupUsersBySubDepartment(
+	users: TeamMember[],
+	viewerSubDepartmentId: string | null,
+): TeamGroup[] {
+	const groups = new Map<string, TeamGroup>();
+
+	for (const user of users) {
+		const key = user.subDepartmentId ?? "__none__";
+		let group = groups.get(key);
+		if (!group) {
+			group = {
+				subDepartmentId: user.subDepartmentId,
+				name: user.subDepartment?.name ?? NO_SUB_DEPARTMENT_LABEL,
+				isViewerTeam: user.subDepartmentId === viewerSubDepartmentId,
+				members: [],
+			};
+			groups.set(key, group);
+		}
+		group.members.push(user);
+	}
+
+	return [...groups.values()].sort((a, b) => {
+		if (a.isViewerTeam !== b.isViewerTeam) return a.isViewerTeam ? -1 : 1;
+		if (a.subDepartmentId === null) return 1;
+		if (b.subDepartmentId === null) return -1;
+		return a.name.localeCompare(b.name);
+	});
+}

--- a/lib/validations/department.ts
+++ b/lib/validations/department.ts
@@ -10,3 +10,9 @@ export const departmentSchema = z.object({
 });
 
 export type DepartmentInput = z.infer<typeof departmentSchema>;
+
+export const subDepartmentSchema = z.object({
+	name: z.string().trim().min(1, "Sub-department name is required"),
+});
+
+export type SubDepartmentInput = z.infer<typeof subDepartmentSchema>;

--- a/lib/validations/user.ts
+++ b/lib/validations/user.ts
@@ -143,6 +143,7 @@ export const createUserSchema = z.object({
 	branch: z.enum(["ISO", "PERTH"]).nullable().optional(),
 	role: z.enum(["STAFF", "ADMIN", "SUPERADMIN"]),
 	departmentId: z.string().nullable().optional(),
+	subDepartmentId: z.string().nullable().optional(),
 	hireDate: z.coerce.date().nullable().optional(),
 	birthday: z.coerce.date().nullable().optional(),
 	shiftSchedule: shiftScheduleSchema.nullable().optional(),

--- a/prisma/migrations/0010_add_sub_departments/migration.sql
+++ b/prisma/migrations/0010_add_sub_departments/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "sub_department_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "sub_departments" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "department_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sub_departments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sub_departments_department_id_name_key" ON "sub_departments"("department_id", "name");
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_sub_department_id_fkey" FOREIGN KEY ("sub_department_id") REFERENCES "sub_departments"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sub_departments" ADD CONSTRAINT "sub_departments_department_id_fkey" FOREIGN KEY ("department_id") REFERENCES "departments"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/0011_index_user_sub_department_id/migration.sql
+++ b/prisma/migrations/0011_index_user_sub_department_id/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "users_sub_department_id_idx" ON "users"("sub_department_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,31 +65,33 @@ enum TicketStatus {
 }
 
 model User {
-  id            String    @id @default(cuid())
-  name          String?
-  email         String    @unique
-  emailVerified Boolean   @default(false) @map("email_verified")
-  image         String?
-  firstName     String    @map("first_name")
-  lastName      String    @map("last_name")
-  displayName   String?   @map("display_name")
-  phone         String?
-  position      String?
-  avatar        String?
-  role          Role      @default(STAFF)
-  branch        Branch?   @map("branch")
-  departmentId  String?   @map("department_id")
-  hireDate      DateTime? @map("hire_date") @db.Date
-  birthday      DateTime? @map("birthday") @db.Date
+  id              String    @id @default(cuid())
+  name            String?
+  email           String    @unique
+  emailVerified   Boolean   @default(false) @map("email_verified")
+  image           String?
+  firstName       String    @map("first_name")
+  lastName        String    @map("last_name")
+  displayName     String?   @map("display_name")
+  phone           String?
+  position        String?
+  avatar          String?
+  role            Role      @default(STAFF)
+  branch          Branch?   @map("branch")
+  departmentId    String?   @map("department_id")
+  subDepartmentId String?   @map("sub_department_id")
+  hireDate        DateTime? @map("hire_date") @db.Date
+  birthday        DateTime? @map("birthday") @db.Date
   /// Deprecated: superseded by deletedAt. Retained until a follow-up
   /// migration can drop the column after this release stabilises in prod.
-  isActive      Boolean   @default(true) @map("is_active")
-  deletedAt     DateTime? @map("deleted_at")
-  deletedById   String?   @map("deleted_by_id")
-  createdAt     DateTime  @default(now()) @map("created_at")
-  updatedAt     DateTime  @updatedAt @map("updated_at")
+  isActive        Boolean   @default(true) @map("is_active")
+  deletedAt       DateTime? @map("deleted_at")
+  deletedById     String?   @map("deleted_by_id")
+  createdAt       DateTime  @default(now()) @map("created_at")
+  updatedAt       DateTime  @updatedAt @map("updated_at")
 
   department           Department?       @relation(fields: [departmentId], references: [id])
+  subDepartment        SubDepartment?    @relation(fields: [subDepartmentId], references: [id], onDelete: SetNull)
   sessions             Session[]
   accounts             Account[]
   sentRecognitions     RecognitionCard[] @relation("sender")
@@ -187,9 +189,24 @@ model Department {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  users User[]
+  users          User[]
+  subDepartments SubDepartment[]
 
   @@map("departments")
+}
+
+model SubDepartment {
+  id           String   @id @default(uuid())
+  name         String
+  departmentId String   @map("department_id")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+
+  department Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+  users      User[]
+
+  @@unique([departmentId, name])
+  @@map("sub_departments")
 }
 
 model AppSetting {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,7 @@ model User {
   ticketsCreated       HelpMeTicket[]    @relation("ticketCreator")
   ticketReplies        TicketReply[]     @relation("ticketReplyAuthor")
 
+  @@index([subDepartmentId])
   @@map("users")
 }
 


### PR DESCRIPTION
## Summary

Adds a **sub-department** layer beneath departments and a new staff-facing **My Team** page.

- **IT** (department) › **Team Power BI** (sub-department) is now expressible end to end.
- Admins manage sub-departments inline on the Departments page.
- Admins assign a user's sub-department on the user create/edit form.
- Every staff member gets a **My Team** sidebar item listing their department's members grouped by sub-department, with their own team highlighted.

## Changes

### Data
- New `SubDepartment` model (`name`, `departmentId`; unique name per department; cascade-delete from its department) and `User.subDepartmentId` (`ON DELETE SET NULL`). Migration `0010_add_sub_departments`.

### Departments page
- Expandable rows: add / edit / delete a department's sub-departments inline.
- Delete is blocked while users are still assigned ("reassign users first"), mirroring the department guard; duplicate names return a friendly error.

### Users
- Dependent **Sub-department** select under Department (filters to the chosen department; clears when the department changes).
- Server-side guard in `createUserAction` / `updateUserAction` rejects a sub-department that doesn't belong to the selected department.
- Sub-department shown on the user detail page.

### My Team
- `/dashboard/my-team` (visible to all roles). Department members grouped by sub-department via the pure `groupUsersBySubDepartment` helper (viewer's team first + highlighted, "No sub-department" bucket last). Empty state when the viewer has no department. Cards are display-only (staff can't open admin user pages).

## Tests
- `lib/team.test.ts` — grouping/ordering helper.
- `lib/actions/department-actions.test.ts` — sub-department CRUD + delete guard.
- `lib/actions/user-actions.test.ts` — sub-dept/department consistency guard + persistence.
- `dashboard-sidebar.test.tsx` — My Team visible to staff.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun run test` — 311 passing

## Notes
- Migration was authored via `migrate diff` against committed history and applied additively to the local DB (no reset). The local DB has **pre-existing** drift from another branch (`external_sender_name` / a `0010_add_external_sender_name` row not in `main`'s migration folder) that is unrelated to this PR.
- `.env.example` / `package.json` dev-port edits already present in the working tree were intentionally left out of this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Requires DB migrations and touches user/org assignment logic; guards and delete blocking reduce data-integrity risk. My Team exposes colleague email/position within the viewer’s department only (session-scoped).
> 
> **Overview**
> Introduces **sub-departments** as a child of departments: schema/migrations add `SubDepartment`, `User.subDepartmentId`, unique name per department, and an index on the user FK.
> 
> **Departments admin** now loads nested sub-departments with user counts; the table uses **expandable rows** for inline add/edit/delete (with confirm dialogs), backed by new server actions and validation. Sub-department delete is **blocked when users are assigned** (serializable transaction) instead of relying on `ON DELETE SET NULL`.
> 
> **User create/edit** gains a dependent sub-department select (clears on department change), detail view shows sub-department, and **`createUserAction` / `updateUserAction`** validate that the sub-department belongs to the selected department, clear it when the department changes, and preserve it on partial updates when appropriate.
> 
> New **`/dashboard/my-team`** (sidebar link for all staff) lists same-department colleagues grouped by sub-department via `groupUsersBySubDepartment` (viewer’s team first and highlighted), with empty states when unassigned.
> 
> Tests cover grouping, department sub-dept actions, user sub-dept guards, and sidebar visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad437d114f68591f2c0dc596c0a4c73de14cf3f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sub-departments across department management, including create, edit, delete, and expandable department rows.
  * Added a new **My Team** page showing team members grouped by sub-department.
  * Added a sub-department field to user create/edit flows and displayed it on user details.
  * Added a **My Team** link in the dashboard sidebar for eligible staff users.

* **Bug Fixes**
  * Improved user assignment handling so sub-departments stay aligned with the selected department.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->