### PR TITLE
All Teams page + team leader per sub-department (Phase 1)

### DIFF
--- a/app/(dashboard)/dashboard/departments/_components/department-table.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/department-table.tsx
@@ -9,9 +9,11 @@ import {
 	Pencil,
 	Plus,
 	Trash2,
+	UserCog,
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { UserAvatar } from "@/components/shared/user-avatar";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import {
 	deleteDepartmentAction,
@@ -19,11 +21,21 @@ import {
 } from "@/lib/actions/department-actions";
 import { DepartmentFormDialog } from "./department-form";
 import { SubDepartmentFormDialog } from "./sub-department-form";
+import { TeamLeaderPicker } from "./team-leader-picker";
+
+interface TeamLeader {
+	id: string;
+	firstName: string;
+	lastName: string;
+	avatar: string | null;
+	image: string | null;
+}
 
 interface SubDepartment {
 	id: string;
 	name: string;
 	_count: { users: number };
+	teamLeader: TeamLeader | null;
 }
 
 interface Department {
@@ -53,6 +65,10 @@ export function DepartmentTable({
 	} | null>(null);
 	const [subDeleteTarget, setSubDeleteTarget] = useState<SubDepartment | null>(null);
 	const [isDeletingSub, setIsDeletingSub] = useState(false);
+	const [leaderTarget, setLeaderTarget] = useState<{
+		dept: Department;
+		sub: SubDepartment;
+	} | null>(null);
 
 	function toggleExpanded(id: string) {
 		setExpanded((prev) => {
@@ -231,6 +247,31 @@ export function DepartmentTable({
 																				{sub._count.users}{" "}
 																				{sub._count.users === 1 ? "user" : "users"}
 																			</p>
+																			<button
+																				type="button"
+																				onClick={() => setLeaderTarget({ dept, sub })}
+																				className="mt-1.5 inline-flex items-center gap-1.5 rounded-full text-xs text-muted-foreground transition-colors hover:text-primary"
+																				title="Assign team leader"
+																			>
+																				<UserCog size={13} className="shrink-0" />
+																				{sub.teamLeader ? (
+																					<span className="inline-flex min-w-0 items-center gap-1.5">
+																						<UserAvatar
+																							firstName={sub.teamLeader.firstName}
+																							lastName={sub.teamLeader.lastName}
+																							avatar={sub.teamLeader.avatar}
+																							image={sub.teamLeader.image}
+																							size="xs"
+																							className="border border-gray-100 bg-background text-primary dark:border-white/10"
+																						/>
+																						<span className="truncate font-medium text-foreground">
+																							{sub.teamLeader.firstName} {sub.teamLeader.lastName}
+																						</span>
+																					</span>
+																				) : (
+																					"Assign team leader"
+																				)}
+																			</button>
 																		</div>
 																		<div className="flex shrink-0 gap-1 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity [@media(hover:hover)]:group-hover/sub:opacity-100 focus-within:opacity-100">
 																			<button
@@ -383,6 +424,18 @@ export function DepartmentTable({
 					subDepartment={subEditTarget.sub}
 					open={!!subEditTarget}
 					onClose={() => setSubEditTarget(null)}
+					onSuccess={onMutate}
+				/>
+			)}
+
+			{leaderTarget && (
+				<TeamLeaderPicker
+					subDepartmentId={leaderTarget.sub.id}
+					subDepartmentName={leaderTarget.sub.name}
+					departmentId={leaderTarget.dept.id}
+					currentLeaderId={leaderTarget.sub.teamLeader?.id ?? null}
+					open={!!leaderTarget}
+					onClose={() => setLeaderTarget(null)}
 					onSuccess={onMutate}
 				/>
 			)}

--- a/app/(dashboard)/dashboard/departments/_components/department-table.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/department-table.tsx
@@ -10,6 +10,7 @@ import {
 	Plus,
 	Trash2,
 	UserCog,
+	Users2,
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -21,6 +22,7 @@ import {
 } from "@/lib/actions/department-actions";
 import { DepartmentFormDialog } from "./department-form";
 import { SubDepartmentFormDialog } from "./sub-department-form";
+import { SubDepartmentMembersDialog } from "./sub-department-members-dialog";
 import { TeamLeaderPicker } from "./team-leader-picker";
 
 interface TeamLeader {
@@ -69,6 +71,7 @@ export function DepartmentTable({
 		dept: Department;
 		sub: SubDepartment;
 	} | null>(null);
+	const [membersTarget, setMembersTarget] = useState<SubDepartment | null>(null);
 
 	function toggleExpanded(id: string) {
 		setExpanded((prev) => {
@@ -243,10 +246,17 @@ export function DepartmentTable({
 																			<p className="truncate text-sm font-medium text-foreground">
 																				{sub.name}
 																			</p>
-																			<p className="text-xs text-muted-foreground">
+																			<button
+																				type="button"
+																				onClick={() => setMembersTarget(sub)}
+																				className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-primary"
+																				title="Manage members"
+																			>
+																				<Users2 size={12} className="shrink-0" />
 																				{sub._count.users}{" "}
-																				{sub._count.users === 1 ? "user" : "users"}
-																			</p>
+																				{sub._count.users === 1 ? "member" : "members"}
+																				<span className="text-primary">· Manage</span>
+																			</button>
 																			<button
 																				type="button"
 																				onClick={() => setLeaderTarget({ dept, sub })}
@@ -436,6 +446,16 @@ export function DepartmentTable({
 					currentLeaderId={leaderTarget.sub.teamLeader?.id ?? null}
 					open={!!leaderTarget}
 					onClose={() => setLeaderTarget(null)}
+					onSuccess={onMutate}
+				/>
+			)}
+
+			{membersTarget && (
+				<SubDepartmentMembersDialog
+					subDepartmentId={membersTarget.id}
+					subDepartmentName={membersTarget.name}
+					open={!!membersTarget}
+					onClose={() => setMembersTarget(null)}
 					onSuccess={onMutate}
 				/>
 			)}

--- a/app/(dashboard)/dashboard/departments/_components/department-table.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/department-table.tsx
@@ -5,11 +5,12 @@ import {
 	Building2,
 	ChevronDown,
 	ChevronRight,
+	Crown,
 	Layers,
 	Pencil,
 	Plus,
 	Trash2,
-	UserCog,
+	UserPlus,
 	Users2,
 } from "lucide-react";
 import { useState } from "react";
@@ -20,6 +21,7 @@ import {
 	deleteDepartmentAction,
 	deleteSubDepartmentAction,
 } from "@/lib/actions/department-actions";
+import { cn } from "@/lib/utils";
 import { DepartmentFormDialog } from "./department-form";
 import { SubDepartmentFormDialog } from "./sub-department-form";
 import { SubDepartmentMembersDialog } from "./sub-department-members-dialog";
@@ -232,63 +234,74 @@ export function DepartmentTable({
 														</div>
 
 														{dept.subDepartments.length === 0 ? (
-															<p className="py-3 text-sm text-muted-foreground">
-																No sub-departments yet.
+															<p className="rounded-2xl border border-dashed border-gray-200 px-4 py-6 text-center text-sm text-muted-foreground dark:border-white/10">
+																No sub-departments yet. Add one to start building teams.
 															</p>
 														) : (
-															<ul className="divide-y divide-gray-200/60 dark:divide-white/10">
+															<ul className="space-y-2.5">
 																{dept.subDepartments.map((sub) => (
 																	<li
 																		key={sub.id}
-																		className="group/sub flex items-center justify-between gap-3 py-2.5"
+																		className="group/sub flex flex-wrap items-center gap-x-4 gap-y-3 rounded-2xl border border-gray-200/60 bg-card px-4 py-3 transition-colors hover:border-gray-300 dark:border-white/10 dark:hover:border-white/20"
 																	>
-																		<div className="min-w-0">
+																		<div className="min-w-0 flex-1">
 																			<p className="truncate text-sm font-medium text-foreground">
 																				{sub.name}
 																			</p>
 																			<button
 																				type="button"
 																				onClick={() => setMembersTarget(sub)}
-																				className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-primary"
 																				title="Manage members"
+																				className="mt-0.5 inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-primary"
 																			>
-																				<Users2 size={12} className="shrink-0" />
+																				<Users2 size={13} className="shrink-0" />
 																				{sub._count.users}{" "}
 																				{sub._count.users === 1 ? "member" : "members"}
-																				<span className="text-primary">· Manage</span>
-																			</button>
-																			<button
-																				type="button"
-																				onClick={() => setLeaderTarget({ dept, sub })}
-																				className="mt-1.5 inline-flex items-center gap-1.5 rounded-full text-xs text-muted-foreground transition-colors hover:text-primary"
-																				title="Assign team leader"
-																			>
-																				<UserCog size={13} className="shrink-0" />
-																				{sub.teamLeader ? (
-																					<span className="inline-flex min-w-0 items-center gap-1.5">
-																						<UserAvatar
-																							firstName={sub.teamLeader.firstName}
-																							lastName={sub.teamLeader.lastName}
-																							avatar={sub.teamLeader.avatar}
-																							image={sub.teamLeader.image}
-																							size="xs"
-																							className="border border-gray-100 bg-background text-primary dark:border-white/10"
-																						/>
-																						<span className="truncate font-medium text-foreground">
-																							{sub.teamLeader.firstName} {sub.teamLeader.lastName}
-																						</span>
-																					</span>
-																				) : (
-																					"Assign team leader"
-																				)}
 																			</button>
 																		</div>
-																		<div className="flex shrink-0 gap-1 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity [@media(hover:hover)]:group-hover/sub:opacity-100 focus-within:opacity-100">
+
+																		<button
+																			type="button"
+																			onClick={() => setLeaderTarget({ dept, sub })}
+																			title={
+																				sub.teamLeader ? "Change team leader" : "Assign team leader"
+																			}
+																			className={cn(
+																				"inline-flex max-w-[14rem] shrink-0 items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+																				sub.teamLeader
+																					? "bg-[oklch(0.96_0.03_18)] text-primary hover:bg-[oklch(0.94_0.04_18)] dark:bg-primary/15 dark:hover:bg-primary/20"
+																					: "border border-dashed border-gray-300 text-muted-foreground hover:border-primary/50 hover:text-primary dark:border-white/15",
+																			)}
+																		>
+																			{sub.teamLeader ? (
+																				<>
+																					<Crown size={13} className="shrink-0" />
+																					<UserAvatar
+																						firstName={sub.teamLeader.firstName}
+																						lastName={sub.teamLeader.lastName}
+																						avatar={sub.teamLeader.avatar}
+																						image={sub.teamLeader.image}
+																						size="xs"
+																						className="bg-background/70 text-primary"
+																					/>
+																					<span className="truncate">
+																						{sub.teamLeader.firstName} {sub.teamLeader.lastName}
+																					</span>
+																				</>
+																			) : (
+																				<>
+																					<UserPlus size={14} className="shrink-0" />
+																					Assign leader
+																				</>
+																			)}
+																		</button>
+
+																		<div className="flex shrink-0 items-center gap-1 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:transition-opacity [@media(hover:hover)]:group-hover/sub:opacity-100 focus-within:opacity-100">
 																			<button
 																				type="button"
 																				onClick={() => setSubEditTarget({ dept, sub })}
 																				aria-label={`Edit sub-department ${sub.name}`}
-																				className="rounded-full p-2 text-muted-foreground hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 transition-colors"
+																				className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10"
 																				title="Edit sub-department"
 																			>
 																				<Pencil size={16} />
@@ -297,7 +310,7 @@ export function DepartmentTable({
 																				type="button"
 																				onClick={() => setSubDeleteTarget(sub)}
 																				aria-label={`Delete sub-department ${sub.name}`}
-																				className="rounded-full p-2 text-muted-foreground hover:bg-[oklch(0.96_0.03_18)] hover:text-primary dark:hover:bg-primary/10 transition-colors"
+																				className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-[oklch(0.96_0.03_18)] hover:text-primary dark:hover:bg-primary/10"
 																				title="Delete sub-department"
 																			>
 																				<Trash2 size={16} />

--- a/app/(dashboard)/dashboard/departments/_components/departments-client.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/departments-client.tsx
@@ -8,10 +8,19 @@ import { getDepartmentsAction } from "@/lib/actions/department-actions";
 import { DepartmentFormDialog } from "./department-form";
 import { DepartmentTable } from "./department-table";
 
+interface TeamLeader {
+	id: string;
+	firstName: string;
+	lastName: string;
+	avatar: string | null;
+	image: string | null;
+}
+
 interface SubDepartment {
 	id: string;
 	name: string;
 	_count: { users: number };
+	teamLeader: TeamLeader | null;
 }
 
 interface Department {
@@ -44,8 +53,8 @@ export function DepartmentsClient() {
 		<div className="mx-auto max-w-7xl space-y-6 sm:space-y-8">
 			<DashboardPageHeader
 				eyebrow="Operations"
-				title="Departments"
-				description="Manage organizational departments and team structure."
+				title="All Teams"
+				description="Manage departments, their teams (sub-departments), and team leaders."
 				actions={
 					<button
 						type="button"

--- a/app/(dashboard)/dashboard/departments/_components/sub-department-members-dialog.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/sub-department-members-dialog.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { Loader2, Plus, Search, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { UserAvatar } from "@/components/shared/user-avatar";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+	addSubDepartmentMemberAction,
+	getSubDepartmentMembersDataAction,
+	removeSubDepartmentMemberAction,
+} from "@/lib/actions/department-actions";
+
+interface Person {
+	id: string;
+	firstName: string;
+	lastName: string;
+	avatar: string | null;
+	image: string | null;
+	position: string | null;
+	subDepartmentId: string | null;
+}
+
+interface SubDepartmentMembersDialogProps {
+	subDepartmentId: string;
+	subDepartmentName: string;
+	open: boolean;
+	onClose: () => void;
+	onSuccess?: () => void;
+}
+
+export function SubDepartmentMembersDialog({
+	subDepartmentId,
+	subDepartmentName,
+	open,
+	onClose,
+	onSuccess,
+}: SubDepartmentMembersDialogProps) {
+	const [members, setMembers] = useState<Person[]>([]);
+	const [assignable, setAssignable] = useState<Person[]>([]);
+	const [isLoading, setIsLoading] = useState(false);
+	const [search, setSearch] = useState("");
+	const [pendingId, setPendingId] = useState<string | null>(null);
+	const [mutated, setMutated] = useState(false);
+
+	const load = useCallback(async () => {
+		setIsLoading(true);
+		const result = await getSubDepartmentMembersDataAction(subDepartmentId);
+		if (result.success) {
+			setMembers(result.data.members);
+			setAssignable(result.data.assignable);
+		} else {
+			toast.error(typeof result.error === "string" ? result.error : "Failed to load members");
+		}
+		setIsLoading(false);
+	}, [subDepartmentId]);
+
+	useEffect(() => {
+		if (!open) return;
+		setSearch("");
+		setMutated(false);
+		load();
+	}, [open, load]);
+
+	const filteredAssignable = useMemo(() => {
+		const q = search.trim().toLowerCase();
+		if (!q) return assignable;
+		return assignable.filter((p) => `${p.firstName} ${p.lastName}`.toLowerCase().includes(q));
+	}, [assignable, search]);
+
+	function handleClose() {
+		if (mutated) onSuccess?.();
+		onClose();
+	}
+
+	async function add(userId: string) {
+		setPendingId(userId);
+		try {
+			const result = await addSubDepartmentMemberAction(subDepartmentId, userId);
+			if (!result.success) {
+				toast.error(typeof result.error === "string" ? result.error : "Failed to add member");
+				return;
+			}
+			toast.success("Member added");
+			setMutated(true);
+			await load();
+		} catch {
+			toast.error("Something went wrong");
+		} finally {
+			setPendingId(null);
+		}
+	}
+
+	async function remove(userId: string) {
+		setPendingId(userId);
+		try {
+			const result = await removeSubDepartmentMemberAction(subDepartmentId, userId);
+			if (!result.success) {
+				toast.error(typeof result.error === "string" ? result.error : "Failed to remove member");
+				return;
+			}
+			toast.success("Member removed");
+			setMutated(true);
+			await load();
+		} catch {
+			toast.error("Something went wrong");
+		} finally {
+			setPendingId(null);
+		}
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={handleClose}>
+			<DialogContent
+				className="max-w-lg gap-0 rounded-[2rem] p-0 ring-0 border border-gray-100 dark:border-white/5 shadow-2xl"
+				showCloseButton={false}
+			>
+				<DialogHeader className="px-8 pt-8 pb-2">
+					<DialogTitle className="text-[1.5rem] leading-tight font-medium tracking-tight">
+						Manage Members
+					</DialogTitle>
+					<p className="text-sm text-muted-foreground">{subDepartmentName}</p>
+				</DialogHeader>
+
+				{isLoading ? (
+					<div className="flex items-center justify-center py-16 text-muted-foreground">
+						<Loader2 className="h-5 w-5 animate-spin" />
+					</div>
+				) : (
+					<div className="max-h-[26rem] overflow-y-auto px-4 py-4 space-y-6">
+						<section>
+							<h3 className="px-4 pb-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+								Members ({members.length})
+							</h3>
+							{members.length === 0 ? (
+								<p className="px-4 py-3 text-sm text-muted-foreground">No members yet.</p>
+							) : (
+								<ul className="space-y-1">
+									{members.map((p) => (
+										<li
+											key={p.id}
+											className="flex items-center gap-3 rounded-xl px-4 py-2.5 hover:bg-gray-50 dark:hover:bg-white/5"
+										>
+											<UserAvatar
+												firstName={p.firstName}
+												lastName={p.lastName}
+												avatar={p.avatar}
+												image={p.image}
+												size="lg"
+												className="border border-gray-100 bg-background text-primary dark:border-white/10"
+											/>
+											<div className="min-w-0 flex-1">
+												<p className="truncate text-sm font-medium text-foreground">
+													{p.firstName} {p.lastName}
+												</p>
+												<p className="truncate text-xs text-muted-foreground">
+													{p.position ?? "—"}
+												</p>
+											</div>
+											<button
+												type="button"
+												onClick={() => remove(p.id)}
+												disabled={pendingId !== null}
+												aria-label={`Remove ${p.firstName} ${p.lastName}`}
+												className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-[oklch(0.96_0.03_18)] hover:text-primary disabled:opacity-50 dark:hover:bg-primary/10"
+											>
+												{pendingId === p.id ? (
+													<Loader2 className="h-4 w-4 animate-spin" />
+												) : (
+													<X className="h-4 w-4" />
+												)}
+											</button>
+										</li>
+									))}
+								</ul>
+							)}
+						</section>
+
+						<section>
+							<h3 className="px-4 pb-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+								Add member
+							</h3>
+							<div className="px-4 pb-2">
+								<div className="relative">
+									<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+									<input
+										type="text"
+										value={search}
+										onChange={(e) => setSearch(e.target.value)}
+										placeholder="Search department & unassigned staff…"
+										className="block w-full rounded-xl border border-gray-200 bg-gray-50/50 py-3 pl-10 pr-4 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:bg-card focus:outline-none focus:ring-4 focus:ring-primary/30 dark:border-white/10 dark:bg-white/5"
+									/>
+								</div>
+							</div>
+							{filteredAssignable.length === 0 ? (
+								<p className="px-4 py-3 text-sm text-muted-foreground">
+									{assignable.length === 0 ? "No eligible users to add." : "No matching users."}
+								</p>
+							) : (
+								<ul className="space-y-1">
+									{filteredAssignable.map((p) => (
+										<li
+											key={p.id}
+											className="flex items-center gap-3 rounded-xl px-4 py-2.5 hover:bg-gray-50 dark:hover:bg-white/5"
+										>
+											<UserAvatar
+												firstName={p.firstName}
+												lastName={p.lastName}
+												avatar={p.avatar}
+												image={p.image}
+												size="lg"
+												className="border border-gray-100 bg-background text-primary dark:border-white/10"
+											/>
+											<div className="min-w-0 flex-1">
+												<p className="truncate text-sm font-medium text-foreground">
+													{p.firstName} {p.lastName}
+												</p>
+												<p className="truncate text-xs text-muted-foreground">
+													{p.subDepartmentId ? "Another team" : (p.position ?? "Unassigned")}
+												</p>
+											</div>
+											<button
+												type="button"
+												onClick={() => add(p.id)}
+												disabled={pendingId !== null}
+												aria-label={`Add ${p.firstName} ${p.lastName}`}
+												className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-gray-200 bg-card px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-gray-50 disabled:opacity-50 dark:border-white/10 dark:hover:bg-white/5"
+											>
+												{pendingId === p.id ? (
+													<Loader2 className="h-3.5 w-3.5 animate-spin" />
+												) : (
+													<Plus className="h-3.5 w-3.5" />
+												)}
+												Add
+											</button>
+										</li>
+									))}
+								</ul>
+							)}
+						</section>
+					</div>
+				)}
+
+				<div className="flex justify-end border-t border-gray-200/60 bg-gray-50/50 px-8 py-5 rounded-b-[2rem] dark:border-white/10 dark:bg-white/[0.02]">
+					<button
+						type="button"
+						onClick={handleClose}
+						className="inline-flex justify-center rounded-full border border-gray-200 bg-card px-6 py-2.5 text-sm font-medium text-foreground transition-all duration-200 hover:bg-gray-50 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:border-white/10 dark:hover:bg-white/5 dark:focus:ring-white/10"
+					>
+						Done
+					</button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/app/(dashboard)/dashboard/departments/_components/team-leader-picker.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/team-leader-picker.tsx
@@ -49,14 +49,21 @@ export function TeamLeaderPicker({
 		let active = true;
 		setIsLoading(true);
 		setSearch("");
+		setMembers([]);
 		getDepartmentMembersAction(departmentId)
 			.then((result) => {
 				if (!active) return;
 				if (result.success) {
 					setMembers(result.data);
 				} else {
+					setMembers([]);
 					toast.error(typeof result.error === "string" ? result.error : "Failed to load members");
 				}
+			})
+			.catch(() => {
+				if (!active) return;
+				setMembers([]);
+				toast.error("Failed to load members");
 			})
 			.finally(() => {
 				if (active) setIsLoading(false);

--- a/app/(dashboard)/dashboard/departments/_components/team-leader-picker.tsx
+++ b/app/(dashboard)/dashboard/departments/_components/team-leader-picker.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { Check, Loader2, Search, UserMinus } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { UserAvatar } from "@/components/shared/user-avatar";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+	assignTeamLeaderAction,
+	getDepartmentMembersAction,
+} from "@/lib/actions/department-actions";
+import { cn } from "@/lib/utils";
+
+interface Member {
+	id: string;
+	firstName: string;
+	lastName: string;
+	avatar: string | null;
+	image: string | null;
+	position: string | null;
+}
+
+interface TeamLeaderPickerProps {
+	subDepartmentId: string;
+	subDepartmentName: string;
+	departmentId: string;
+	currentLeaderId: string | null;
+	open: boolean;
+	onClose: () => void;
+	onSuccess?: () => void;
+}
+
+export function TeamLeaderPicker({
+	subDepartmentId,
+	subDepartmentName,
+	departmentId,
+	currentLeaderId,
+	open,
+	onClose,
+	onSuccess,
+}: TeamLeaderPickerProps) {
+	const [members, setMembers] = useState<Member[]>([]);
+	const [isLoading, setIsLoading] = useState(false);
+	const [search, setSearch] = useState("");
+	const [pendingId, setPendingId] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!open) return;
+		let active = true;
+		setIsLoading(true);
+		setSearch("");
+		getDepartmentMembersAction(departmentId)
+			.then((result) => {
+				if (!active) return;
+				if (result.success) {
+					setMembers(result.data);
+				} else {
+					toast.error(typeof result.error === "string" ? result.error : "Failed to load members");
+				}
+			})
+			.finally(() => {
+				if (active) setIsLoading(false);
+			});
+		return () => {
+			active = false;
+		};
+	}, [open, departmentId]);
+
+	const filtered = useMemo(() => {
+		const q = search.trim().toLowerCase();
+		if (!q) return members;
+		return members.filter((m) => `${m.firstName} ${m.lastName}`.toLowerCase().includes(q));
+	}, [members, search]);
+
+	async function assign(userId: string | null) {
+		setPendingId(userId ?? "__remove__");
+		try {
+			const result = await assignTeamLeaderAction(subDepartmentId, userId);
+			if (!result.success) {
+				toast.error(typeof result.error === "string" ? result.error : "Failed to assign leader");
+				return;
+			}
+			toast.success(userId ? "Team leader assigned" : "Team leader removed");
+			onClose();
+			onSuccess?.();
+		} catch {
+			toast.error("Something went wrong");
+		} finally {
+			setPendingId(null);
+		}
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onClose}>
+			<DialogContent
+				className="max-w-lg gap-0 rounded-[2rem] p-0 ring-0 border border-gray-100 dark:border-white/5 shadow-2xl"
+				showCloseButton={false}
+			>
+				<DialogHeader className="px-8 pt-8 pb-2">
+					<DialogTitle className="text-[1.5rem] leading-tight font-medium tracking-tight">
+						Team Leader
+					</DialogTitle>
+					<p className="text-sm text-muted-foreground">{subDepartmentName}</p>
+				</DialogHeader>
+
+				<div className="px-8 pt-4">
+					<div className="relative">
+						<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+						<input
+							type="text"
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							placeholder="Search department members…"
+							className="block w-full rounded-xl border border-gray-200 bg-gray-50/50 py-3 pl-10 pr-4 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:bg-card focus:outline-none focus:ring-4 focus:ring-primary/30 dark:border-white/10 dark:bg-white/5"
+						/>
+					</div>
+				</div>
+
+				<div className="max-h-[22rem] overflow-y-auto px-4 py-4">
+					{currentLeaderId && (
+						<button
+							type="button"
+							onClick={() => assign(null)}
+							disabled={pendingId !== null}
+							className="mb-2 flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-medium text-muted-foreground transition-colors hover:bg-[oklch(0.96_0.03_18)] hover:text-primary disabled:opacity-50 dark:hover:bg-primary/10"
+						>
+							<span className="flex h-10 w-10 items-center justify-center rounded-full bg-background">
+								{pendingId === "__remove__" ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<UserMinus className="h-4 w-4" />
+								)}
+							</span>
+							Remove current leader
+						</button>
+					)}
+
+					{isLoading ? (
+						<div className="flex items-center justify-center py-12 text-muted-foreground">
+							<Loader2 className="h-5 w-5 animate-spin" />
+						</div>
+					) : filtered.length === 0 ? (
+						<p className="py-12 text-center text-sm text-muted-foreground">
+							{members.length === 0 ? "No members in this department." : "No matching members."}
+						</p>
+					) : (
+						<ul className="space-y-1">
+							{filtered.map((member) => {
+								const isCurrent = member.id === currentLeaderId;
+								return (
+									<li key={member.id}>
+										<button
+											type="button"
+											onClick={() => assign(member.id)}
+											disabled={pendingId !== null || isCurrent}
+											className={cn(
+												"flex w-full items-center gap-3 rounded-xl px-4 py-2.5 text-left transition-colors disabled:cursor-default",
+												isCurrent
+													? "bg-[oklch(0.96_0.03_18)] dark:bg-primary/10"
+													: "hover:bg-gray-100 disabled:opacity-50 dark:hover:bg-white/5",
+											)}
+										>
+											<UserAvatar
+												firstName={member.firstName}
+												lastName={member.lastName}
+												avatar={member.avatar}
+												image={member.image}
+												size="lg"
+												className="border border-gray-100 bg-background text-primary dark:border-white/10"
+											/>
+											<div className="min-w-0 flex-1">
+												<p className="truncate text-sm font-medium text-foreground">
+													{member.firstName} {member.lastName}
+												</p>
+												<p className="truncate text-xs text-muted-foreground">
+													{member.position ?? "—"}
+												</p>
+											</div>
+											{pendingId === member.id ? (
+												<Loader2 className="h-4 w-4 shrink-0 animate-spin text-primary" />
+											) : isCurrent ? (
+												<Check className="h-4 w-4 shrink-0 text-primary" />
+											) : null}
+										</button>
+									</li>
+								);
+							})}
+						</ul>
+					)}
+				</div>
+
+				<div className="flex justify-end border-t border-gray-200/60 bg-gray-50/50 px-8 py-5 rounded-b-[2rem] dark:border-white/10 dark:bg-white/[0.02]">
+					<button
+						type="button"
+						onClick={onClose}
+						className="inline-flex justify-center rounded-full border border-gray-200 bg-card px-6 py-2.5 text-sm font-medium text-foreground transition-all duration-200 hover:bg-gray-50 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:border-white/10 dark:hover:bg-white/5 dark:focus:ring-white/10"
+					>
+						Close
+					</button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/components/shared/dashboard-sidebar.test.tsx
+++ b/components/shared/dashboard-sidebar.test.tsx
@@ -73,6 +73,21 @@ describe("DashboardSidebar", () => {
 		expect(myTeamLink).toHaveAttribute("href", "/dashboard/my-team");
 		// Staff still must not see admin-only links.
 		expect(screen.queryByRole("link", { name: "Staff" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: "All Teams" })).not.toBeInTheDocument();
+	});
+
+	it("shows the All Teams admin link to admins", () => {
+		mockedUsePathname.mockReturnValue("/dashboard");
+		mockedUseRouter.mockReturnValue({
+			push: vi.fn(),
+			refresh: vi.fn(),
+		} as unknown as ReturnType<typeof useRouter>);
+		setSession({ role: "ADMIN" });
+
+		render(<DashboardSidebar helpMeEnabled initialUserRole="ADMIN" />);
+
+		const allTeamsLink = screen.getByRole("link", { name: "All Teams" });
+		expect(allTeamsLink).toHaveAttribute("href", "/dashboard/departments");
 	});
 
 	it("keeps the desktop rail width and exposes full nav labels via title", () => {

--- a/components/shared/dashboard-sidebar.tsx
+++ b/components/shared/dashboard-sidebar.tsx
@@ -74,7 +74,7 @@ const NAV_ITEMS: NavItem[] = [
 		minRole: "ADMIN",
 	},
 	{
-		label: "Departments",
+		label: "All Teams",
 		href: "/dashboard/departments",
 		icon: Building2,
 		minRole: "ADMIN",

--- a/lib/actions/department-actions.test.ts
+++ b/lib/actions/department-actions.test.ts
@@ -17,9 +17,11 @@ vi.mock("@/lib/db", () => ({
 			create: vi.fn(),
 			update: vi.fn(),
 			delete: vi.fn(),
+			findUnique: vi.fn(),
 		},
 		user: {
 			count: vi.fn(),
+			findUnique: vi.fn(),
 		},
 		$transaction: vi.fn(),
 	},
@@ -29,6 +31,7 @@ import { Prisma } from "@/app/generated/prisma/client";
 import { requireRole } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import {
+	assignTeamLeaderAction,
 	createSubDepartmentAction,
 	deleteSubDepartmentAction,
 	getDepartmentsAction,
@@ -145,7 +148,12 @@ describe("getDepartmentsAction", () => {
 			include: {
 				_count: { select: { users: true } },
 				subDepartments: {
-					include: { _count: { select: { users: true } } },
+					include: {
+						_count: { select: { users: true } },
+						teamLeader: {
+							select: { id: true, firstName: true, lastName: true, avatar: true, image: true },
+						},
+					},
 					orderBy: { name: "asc" },
 				},
 			},
@@ -171,5 +179,84 @@ describe("getDepartmentsWithSubDepartmentsAction", () => {
 			},
 			orderBy: { name: "asc" },
 		});
+	});
+});
+
+describe("assignTeamLeaderAction", () => {
+	test("assigns an active member of the parent department", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+		} as never);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+			deletedAt: null,
+		} as never);
+		vi.mocked(prisma.subDepartment.update).mockResolvedValue({ id: "sub_1" } as never);
+
+		const result = await assignTeamLeaderAction("sub_1", "user_1");
+
+		expect(result.success).toBe(true);
+		expect(prisma.subDepartment.update).toHaveBeenCalledWith({
+			where: { id: "sub_1" },
+			data: { teamLeaderId: "user_1" },
+		});
+	});
+
+	test("rejects a candidate from a different department", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+		} as never);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			departmentId: "dept_other",
+			deletedAt: null,
+		} as never);
+
+		const result = await assignTeamLeaderAction("sub_1", "user_1");
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/parent department/i);
+		}
+		expect(prisma.subDepartment.update).not.toHaveBeenCalled();
+	});
+
+	test("rejects a soft-deleted candidate", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+		} as never);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+			deletedAt: new Date(),
+		} as never);
+
+		const result = await assignTeamLeaderAction("sub_1", "user_1");
+
+		expect(result.success).toBe(false);
+		expect(prisma.subDepartment.update).not.toHaveBeenCalled();
+	});
+
+	test("clears the leader (null) without a membership check", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+		} as never);
+		vi.mocked(prisma.subDepartment.update).mockResolvedValue({ id: "sub_1" } as never);
+
+		const result = await assignTeamLeaderAction("sub_1", null);
+
+		expect(result.success).toBe(true);
+		expect(prisma.user.findUnique).not.toHaveBeenCalled();
+		expect(prisma.subDepartment.update).toHaveBeenCalledWith({
+			where: { id: "sub_1" },
+			data: { teamLeaderId: null },
+		});
+	});
+
+	test("rejects when the sub-department does not exist", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue(null as never);
+
+		const result = await assignTeamLeaderAction("missing", "user_1");
+
+		expect(result.success).toBe(false);
+		expect(prisma.subDepartment.update).not.toHaveBeenCalled();
 	});
 });

--- a/lib/actions/department-actions.test.ts
+++ b/lib/actions/department-actions.test.ts
@@ -22,6 +22,9 @@ vi.mock("@/lib/db", () => ({
 		user: {
 			count: vi.fn(),
 			findUnique: vi.fn(),
+			findMany: vi.fn(),
+			update: vi.fn(),
+			updateMany: vi.fn(),
 		},
 		$transaction: vi.fn(),
 	},
@@ -31,11 +34,14 @@ import { Prisma } from "@/app/generated/prisma/client";
 import { requireRole } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
 import {
+	addSubDepartmentMemberAction,
 	assignTeamLeaderAction,
 	createSubDepartmentAction,
 	deleteSubDepartmentAction,
 	getDepartmentsAction,
 	getDepartmentsWithSubDepartmentsAction,
+	getSubDepartmentMembersDataAction,
+	removeSubDepartmentMemberAction,
 	updateSubDepartmentAction,
 } from "./department-actions";
 
@@ -258,5 +264,124 @@ describe("assignTeamLeaderAction", () => {
 
 		expect(result.success).toBe(false);
 		expect(prisma.subDepartment.update).not.toHaveBeenCalled();
+	});
+});
+
+describe("getSubDepartmentMembersDataAction", () => {
+	test("splits the eligible pool into members and assignable", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+		} as never);
+		vi.mocked(prisma.user.findMany).mockResolvedValue([
+			{ id: "u1", subDepartmentId: "sub_1" },
+			{ id: "u2", subDepartmentId: "sub_2" },
+			{ id: "u3", subDepartmentId: null },
+		] as never);
+
+		const result = await getSubDepartmentMembersDataAction("sub_1");
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.members.map((m) => m.id)).toEqual(["u1"]);
+			expect(result.data.assignable.map((m) => m.id)).toEqual(["u2", "u3"]);
+		}
+	});
+});
+
+describe("addSubDepartmentMemberAction", () => {
+	test("assigns an existing department member without changing their department", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+		} as never);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+			deletedAt: null,
+		} as never);
+		vi.mocked(prisma.user.update).mockResolvedValue({ id: "u1" } as never);
+
+		const result = await addSubDepartmentMemberAction("sub_1", "u1");
+
+		expect(result.success).toBe(true);
+		expect(prisma.user.update).toHaveBeenCalledWith({
+			where: { id: "u1" },
+			data: { subDepartmentId: "sub_1", departmentId: "dept_1" },
+		});
+	});
+
+	test("assigns the parent department for an unassigned user", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+		} as never);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			departmentId: null,
+			deletedAt: null,
+		} as never);
+		vi.mocked(prisma.user.update).mockResolvedValue({ id: "u1" } as never);
+
+		const result = await addSubDepartmentMemberAction("sub_1", "u1");
+
+		expect(result.success).toBe(true);
+		expect(prisma.user.update).toHaveBeenCalledWith({
+			where: { id: "u1" },
+			data: { subDepartmentId: "sub_1", departmentId: "dept_1" },
+		});
+	});
+
+	test("rejects a user who belongs to another department", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+		} as never);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			departmentId: "dept_other",
+			deletedAt: null,
+		} as never);
+
+		const result = await addSubDepartmentMemberAction("sub_1", "u1");
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/another department/i);
+		}
+		expect(prisma.user.update).not.toHaveBeenCalled();
+	});
+
+	test("rejects a soft-deleted user", async () => {
+		vi.mocked(prisma.subDepartment.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+		} as never);
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			departmentId: "dept_1",
+			deletedAt: new Date(),
+		} as never);
+
+		const result = await addSubDepartmentMemberAction("sub_1", "u1");
+
+		expect(result.success).toBe(false);
+		expect(prisma.user.update).not.toHaveBeenCalled();
+	});
+});
+
+describe("removeSubDepartmentMemberAction", () => {
+	test("clears membership scoped to the team", async () => {
+		vi.mocked(prisma.user.updateMany).mockResolvedValue({ count: 1 } as never);
+
+		const result = await removeSubDepartmentMemberAction("sub_1", "u1");
+
+		expect(result.success).toBe(true);
+		expect(prisma.user.updateMany).toHaveBeenCalledWith({
+			where: { id: "u1", subDepartmentId: "sub_1" },
+			data: { subDepartmentId: null },
+		});
+	});
+
+	test("rejects when the user is not a member of the team", async () => {
+		vi.mocked(prisma.user.updateMany).mockResolvedValue({ count: 0 } as never);
+
+		const result = await removeSubDepartmentMemberAction("sub_1", "u1");
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/not a member/i);
+		}
 	});
 });

--- a/lib/actions/department-actions.test.ts
+++ b/lib/actions/department-actions.test.ts
@@ -38,6 +38,7 @@ import {
 	assignTeamLeaderAction,
 	createSubDepartmentAction,
 	deleteSubDepartmentAction,
+	getDepartmentMembersAction,
 	getDepartmentsAction,
 	getDepartmentsWithSubDepartmentsAction,
 	getSubDepartmentMembersDataAction,
@@ -50,6 +51,11 @@ beforeEach(() => {
 	vi.mocked(requireRole).mockResolvedValue({
 		user: { id: "admin_1", role: "ADMIN" as const },
 	} as unknown as Awaited<ReturnType<typeof requireRole>>);
+	// Default: run interactive transactions against the same mocked prisma, so
+	// `tx.*` calls hit the existing per-model mocks. Suites that need to assert
+	// on the transaction options (e.g. delete) override this.
+	vi.mocked(prisma.$transaction).mockImplementation((async (cb: (client: unknown) => unknown) =>
+		cb(prisma)) as never);
 });
 
 describe("createSubDepartmentAction", () => {
@@ -206,6 +212,10 @@ describe("assignTeamLeaderAction", () => {
 			where: { id: "sub_1" },
 			data: { teamLeaderId: "user_1" },
 		});
+		// Eligibility check + write run in one Serializable transaction.
+		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+			isolationLevel: "Serializable",
+		});
 	});
 
 	test("rejects a candidate from a different department", async () => {
@@ -264,6 +274,40 @@ describe("assignTeamLeaderAction", () => {
 
 		expect(result.success).toBe(false);
 		expect(prisma.subDepartment.update).not.toHaveBeenCalled();
+	});
+});
+
+describe("getDepartmentMembersAction", () => {
+	test("returns active department members ordered by name", async () => {
+		const members = [{ id: "u1", firstName: "Ana" }];
+		vi.mocked(prisma.user.findMany).mockResolvedValue(members as never);
+
+		const result = await getDepartmentMembersAction("dept_1");
+
+		expect(result).toEqual({ success: true, data: members });
+		expect(prisma.user.findMany).toHaveBeenCalledWith({
+			where: { departmentId: "dept_1", deletedAt: null },
+			select: {
+				id: true,
+				firstName: true,
+				lastName: true,
+				avatar: true,
+				image: true,
+				position: true,
+			},
+			orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+		});
+	});
+
+	test("returns a failure result when the query throws", async () => {
+		vi.mocked(prisma.user.findMany).mockRejectedValue(new Error("db down"));
+
+		const result = await getDepartmentMembersAction("dept_1");
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/db down/i);
+		}
 	});
 });
 

--- a/lib/actions/department-actions.ts
+++ b/lib/actions/department-actions.ts
@@ -20,7 +20,12 @@ export async function getDepartmentsAction() {
 			include: {
 				_count: { select: { users: true } },
 				subDepartments: {
-					include: { _count: { select: { users: true } } },
+					include: {
+						_count: { select: { users: true } },
+						teamLeader: {
+							select: { id: true, firstName: true, lastName: true, avatar: true, image: true },
+						},
+					},
 					orderBy: { name: "asc" },
 				},
 			},
@@ -50,6 +55,71 @@ export async function getDepartmentsWithSubDepartmentsAction() {
 		},
 		orderBy: { name: "asc" },
 	});
+}
+
+export async function getDepartmentMembersAction(departmentId: string) {
+	try {
+		await requireRole("ADMIN");
+		const members = await prisma.user.findMany({
+			where: { departmentId, deletedAt: null },
+			select: {
+				id: true,
+				firstName: true,
+				lastName: true,
+				avatar: true,
+				image: true,
+				position: true,
+			},
+			orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+		});
+		return { success: true as const, data: members };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to fetch members";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function assignTeamLeaderAction(subDepartmentId: string, userId: string | null) {
+	try {
+		await requireRole("ADMIN");
+
+		const subDepartment = await prisma.subDepartment.findUnique({
+			where: { id: subDepartmentId },
+			select: { departmentId: true },
+		});
+		if (!subDepartment) {
+			return { success: false as const, error: "Sub-department not found" };
+		}
+
+		// Eligibility: a team leader must be an active member of the
+		// sub-department's parent department. Re-check server-side rather than
+		// trusting the submitted id.
+		if (userId !== null) {
+			const candidate = await prisma.user.findUnique({
+				where: { id: userId },
+				select: { departmentId: true, deletedAt: true },
+			});
+			if (!candidate || candidate.deletedAt !== null) {
+				return { success: false as const, error: "Selected user is not available" };
+			}
+			if (candidate.departmentId !== subDepartment.departmentId) {
+				return {
+					success: false as const,
+					error: "A team leader must belong to the parent department",
+				};
+			}
+		}
+
+		await prisma.subDepartment.update({
+			where: { id: subDepartmentId },
+			data: { teamLeaderId: userId },
+		});
+		revalidatePath("/dashboard/departments");
+		return { success: true as const, data: null };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to assign team leader";
+		return { success: false as const, error: message };
+	}
 }
 
 export async function createDepartmentAction(formData: unknown) {

--- a/lib/actions/department-actions.ts
+++ b/lib/actions/department-actions.ts
@@ -79,44 +79,60 @@ export async function getDepartmentMembersAction(departmentId: string) {
 	}
 }
 
+class TeamLeaderEligibilityError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "TeamLeaderEligibilityError";
+	}
+}
+
 export async function assignTeamLeaderAction(subDepartmentId: string, userId: string | null) {
 	try {
 		await requireRole("ADMIN");
 
-		const subDepartment = await prisma.subDepartment.findUnique({
-			where: { id: subDepartmentId },
-			select: { departmentId: true },
-		});
-		if (!subDepartment) {
-			return { success: false as const, error: "Sub-department not found" };
-		}
+		// Read the candidate's eligibility and write `teamLeaderId` in one
+		// Serializable transaction. Otherwise a concurrent department move or
+		// soft-delete (which clears existing leaderships) could interleave between
+		// the check and the write and reintroduce an invalid leader reference.
+		await prisma.$transaction(
+			async (tx) => {
+				const subDepartment = await tx.subDepartment.findUnique({
+					where: { id: subDepartmentId },
+					select: { departmentId: true },
+				});
+				if (!subDepartment) {
+					throw new TeamLeaderEligibilityError("Sub-department not found");
+				}
 
-		// Eligibility: a team leader must be an active member of the
-		// sub-department's parent department. Re-check server-side rather than
-		// trusting the submitted id.
-		if (userId !== null) {
-			const candidate = await prisma.user.findUnique({
-				where: { id: userId },
-				select: { departmentId: true, deletedAt: true },
-			});
-			if (!candidate || candidate.deletedAt !== null) {
-				return { success: false as const, error: "Selected user is not available" };
-			}
-			if (candidate.departmentId !== subDepartment.departmentId) {
-				return {
-					success: false as const,
-					error: "A team leader must belong to the parent department",
-				};
-			}
-		}
+				if (userId !== null) {
+					const candidate = await tx.user.findUnique({
+						where: { id: userId },
+						select: { departmentId: true, deletedAt: true },
+					});
+					if (!candidate || candidate.deletedAt !== null) {
+						throw new TeamLeaderEligibilityError("Selected user is not available");
+					}
+					if (candidate.departmentId !== subDepartment.departmentId) {
+						throw new TeamLeaderEligibilityError(
+							"A team leader must belong to the parent department",
+						);
+					}
+				}
 
-		await prisma.subDepartment.update({
-			where: { id: subDepartmentId },
-			data: { teamLeaderId: userId },
-		});
+				await tx.subDepartment.update({
+					where: { id: subDepartmentId },
+					data: { teamLeaderId: userId },
+				});
+			},
+			{ isolationLevel: "Serializable" },
+		);
+
 		revalidatePath("/dashboard/departments");
 		return { success: true as const, data: null };
 	} catch (error) {
+		if (error instanceof TeamLeaderEligibilityError) {
+			return { success: false as const, error: error.message };
+		}
 		const message = error instanceof Error ? error.message : "Failed to assign team leader";
 		return { success: false as const, error: message };
 	}
@@ -318,40 +334,53 @@ export async function getSubDepartmentMembersDataAction(subDepartmentId: string)
 export async function addSubDepartmentMemberAction(subDepartmentId: string, userId: string) {
 	try {
 		await requireRole("ADMIN");
-		const subDepartment = await prisma.subDepartment.findUnique({
-			where: { id: subDepartmentId },
-			select: { departmentId: true },
-		});
-		if (!subDepartment) {
-			return { success: false as const, error: "Sub-department not found" };
-		}
 
-		const user = await prisma.user.findUnique({
-			where: { id: userId },
-			select: { departmentId: true, deletedAt: true },
-		});
-		if (!user || user.deletedAt !== null) {
-			return { success: false as const, error: "Selected user is not available" };
-		}
-		// Only department members or unassigned users may be added here. Pulling a
-		// user out of another department is a department move — admin-only via the
-		// user edit page, not this team picker.
-		if (user.departmentId !== null && user.departmentId !== subDepartment.departmentId) {
-			return { success: false as const, error: "User belongs to another department" };
-		}
+		// Validate eligibility and write in one Serializable transaction so a
+		// concurrent department move can't slip between the check and the update
+		// and leave an inconsistent department/sub-department pairing.
+		await prisma.$transaction(
+			async (tx) => {
+				const subDepartment = await tx.subDepartment.findUnique({
+					where: { id: subDepartmentId },
+					select: { departmentId: true },
+				});
+				if (!subDepartment) {
+					throw new TeamLeaderEligibilityError("Sub-department not found");
+				}
 
-		await prisma.user.update({
-			where: { id: userId },
-			data: {
-				subDepartmentId,
-				// Previously unassigned users inherit the parent department so the
-				// department/sub-department pairing stays consistent.
-				departmentId: user.departmentId ?? subDepartment.departmentId,
+				const user = await tx.user.findUnique({
+					where: { id: userId },
+					select: { departmentId: true, deletedAt: true },
+				});
+				if (!user || user.deletedAt !== null) {
+					throw new TeamLeaderEligibilityError("Selected user is not available");
+				}
+				// Only department members or unassigned users may be added here.
+				// Pulling a user out of another department is a department move —
+				// admin-only via the user edit page, not this team picker.
+				if (user.departmentId !== null && user.departmentId !== subDepartment.departmentId) {
+					throw new TeamLeaderEligibilityError("User belongs to another department");
+				}
+
+				await tx.user.update({
+					where: { id: userId },
+					data: {
+						subDepartmentId,
+						// Previously unassigned users inherit the parent department so
+						// the department/sub-department pairing stays consistent.
+						departmentId: user.departmentId ?? subDepartment.departmentId,
+					},
+				});
 			},
-		});
+			{ isolationLevel: "Serializable" },
+		);
+
 		revalidatePath("/dashboard/departments");
 		return { success: true as const, data: null };
 	} catch (error) {
+		if (error instanceof TeamLeaderEligibilityError) {
+			return { success: false as const, error: error.message };
+		}
 		const message = error instanceof Error ? error.message : "Failed to add member";
 		return { success: false as const, error: message };
 	}

--- a/lib/actions/department-actions.ts
+++ b/lib/actions/department-actions.ts
@@ -270,3 +270,110 @@ export async function deleteSubDepartmentAction(id: string) {
 		return { success: false as const, error: message };
 	}
 }
+
+export async function getSubDepartmentMembersDataAction(subDepartmentId: string) {
+	try {
+		await requireRole("ADMIN");
+		const subDepartment = await prisma.subDepartment.findUnique({
+			where: { id: subDepartmentId },
+			select: { departmentId: true },
+		});
+		if (!subDepartment) {
+			return { success: false as const, error: "Sub-department not found" };
+		}
+
+		// Eligible pool: active users already in the parent department, plus users
+		// with no department at all. Members of this team and everyone else are
+		// split client-side from this single pool.
+		const eligible = await prisma.user.findMany({
+			where: {
+				deletedAt: null,
+				OR: [{ departmentId: subDepartment.departmentId }, { departmentId: null }],
+			},
+			select: {
+				id: true,
+				firstName: true,
+				lastName: true,
+				avatar: true,
+				image: true,
+				position: true,
+				subDepartmentId: true,
+			},
+			orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
+		});
+
+		return {
+			success: true as const,
+			data: {
+				members: eligible.filter((u) => u.subDepartmentId === subDepartmentId),
+				assignable: eligible.filter((u) => u.subDepartmentId !== subDepartmentId),
+			},
+		};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to load members";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function addSubDepartmentMemberAction(subDepartmentId: string, userId: string) {
+	try {
+		await requireRole("ADMIN");
+		const subDepartment = await prisma.subDepartment.findUnique({
+			where: { id: subDepartmentId },
+			select: { departmentId: true },
+		});
+		if (!subDepartment) {
+			return { success: false as const, error: "Sub-department not found" };
+		}
+
+		const user = await prisma.user.findUnique({
+			where: { id: userId },
+			select: { departmentId: true, deletedAt: true },
+		});
+		if (!user || user.deletedAt !== null) {
+			return { success: false as const, error: "Selected user is not available" };
+		}
+		// Only department members or unassigned users may be added here. Pulling a
+		// user out of another department is a department move — admin-only via the
+		// user edit page, not this team picker.
+		if (user.departmentId !== null && user.departmentId !== subDepartment.departmentId) {
+			return { success: false as const, error: "User belongs to another department" };
+		}
+
+		await prisma.user.update({
+			where: { id: userId },
+			data: {
+				subDepartmentId,
+				// Previously unassigned users inherit the parent department so the
+				// department/sub-department pairing stays consistent.
+				departmentId: user.departmentId ?? subDepartment.departmentId,
+			},
+		});
+		revalidatePath("/dashboard/departments");
+		return { success: true as const, data: null };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to add member";
+		return { success: false as const, error: message };
+	}
+}
+
+export async function removeSubDepartmentMemberAction(subDepartmentId: string, userId: string) {
+	try {
+		await requireRole("ADMIN");
+		// Scope the clear to this exact team so a stale client can't blank out a
+		// user who has since moved to a different sub-department. Keeps the
+		// department assignment intact.
+		const result = await prisma.user.updateMany({
+			where: { id: userId, subDepartmentId },
+			data: { subDepartmentId: null },
+		});
+		if (result.count === 0) {
+			return { success: false as const, error: "User is not a member of this team" };
+		}
+		revalidatePath("/dashboard/departments");
+		return { success: true as const, data: null };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to remove member";
+		return { success: false as const, error: message };
+	}
+}

--- a/lib/actions/user-actions.test.ts
+++ b/lib/actions/user-actions.test.ts
@@ -50,7 +50,7 @@ import { Prisma } from "@/app/generated/prisma/client";
 import { logActivity } from "@/lib/activity-log";
 import { requireRole } from "@/lib/auth-utils";
 import { prisma } from "@/lib/db";
-import { adminResetPasswordAction, updateUserAction } from "./user-actions";
+import { adminResetPasswordAction, softDeleteUserAction, updateUserAction } from "./user-actions";
 
 const ADMIN_ID = "admin_1";
 const TARGET_ID = "user_1";
@@ -300,10 +300,14 @@ describe("updateUserAction sub-department guard", () => {
 		);
 	});
 
-	test("clears the sub-department when the department changes and none is submitted", async () => {
+	test("clears the sub-department and team leaderships when the department changes", async () => {
 		const txUserUpdate = vi.fn().mockResolvedValue({ id: TARGET_ID });
+		const txSubUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
 		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
-			cb({ user: { update: txUserUpdate } })) as never);
+			cb({
+				user: { update: txUserUpdate },
+				subDepartment: { updateMany: txSubUpdateMany },
+			})) as never);
 
 		const result = await updateUserAction(TARGET_ID, {
 			firstName: "Jane",
@@ -319,6 +323,11 @@ describe("updateUserAction sub-department guard", () => {
 				data: expect.objectContaining({ subDepartmentId: null }),
 			}),
 		);
+		// Leaving the department relinquishes any team leaderships held there.
+		expect(txSubUpdateMany).toHaveBeenCalledWith({
+			where: { teamLeaderId: TARGET_ID },
+			data: { teamLeaderId: null },
+		});
 	});
 
 	test("preserves the sub-department when the department is unchanged and none is submitted", async () => {
@@ -338,5 +347,30 @@ describe("updateUserAction sub-department guard", () => {
 		// `undefined` leaves the column untouched, so the existing team stays.
 		const updateArg = txUserUpdate.mock.calls[0][0] as { data: { subDepartmentId?: unknown } };
 		expect(updateArg.data.subDepartmentId).toBeUndefined();
+	});
+});
+
+describe("softDeleteUserAction clears team leaderships", () => {
+	test("relinquishes the user's leaderships when soft-deleting", async () => {
+		vi.mocked(prisma.user.findUnique).mockResolvedValue({
+			id: TARGET_ID,
+			role: "STAFF",
+			deletedAt: null,
+		} as never);
+		const txSubUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+		vi.mocked(prisma.$transaction).mockImplementation((async (cb: (tx: unknown) => unknown) =>
+			cb({
+				user: { update: vi.fn().mockResolvedValue({ id: TARGET_ID }) },
+				session: { deleteMany: vi.fn() },
+				subDepartment: { updateMany: txSubUpdateMany },
+			})) as never);
+
+		const result = await softDeleteUserAction(TARGET_ID);
+
+		expect(result.success).toBe(true);
+		expect(txSubUpdateMany).toHaveBeenCalledWith({
+			where: { teamLeaderId: TARGET_ID },
+			data: { teamLeaderId: null },
+		});
 	});
 });

--- a/lib/actions/user-actions.test.ts
+++ b/lib/actions/user-actions.test.ts
@@ -328,6 +328,11 @@ describe("updateUserAction sub-department guard", () => {
 			where: { teamLeaderId: TARGET_ID },
 			data: { teamLeaderId: null },
 		});
+		// The cleanup races with assignTeamLeaderAction, so the department-change
+		// path must run Serializable to participate in the same SSI discipline.
+		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+			isolationLevel: "Serializable",
+		});
 	});
 
 	test("preserves the sub-department when the department is unchanged and none is submitted", async () => {
@@ -347,6 +352,9 @@ describe("updateUserAction sub-department guard", () => {
 		// `undefined` leaves the column untouched, so the existing team stays.
 		const updateArg = txUserUpdate.mock.calls[0][0] as { data: { subDepartmentId?: unknown } };
 		expect(updateArg.data.subDepartmentId).toBeUndefined();
+		// No leadership cleanup here, so the edit keeps default isolation rather
+		// than paying for Serializable on every ordinary user update.
+		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), undefined);
 	});
 });
 

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -212,35 +212,43 @@ export async function updateUserAction(userId: string, formData: unknown) {
 			resolvedSubDepartmentId = null;
 		}
 
-		const updated = await prisma.$transaction(async (tx) => {
-			const user = await tx.user.update({
-				where: { id: userId },
-				data: {
-					...userFields,
-					role: roleIsChanging ? (parsed.data.role as Role) : undefined,
-					subDepartmentId: resolvedSubDepartmentId,
-					hireDate: hireDate === undefined ? undefined : (hireDate ?? null),
-					birthday: birthday === undefined ? undefined : (birthday ?? null),
-					name:
-						parsed.data.firstName && parsed.data.lastName
-							? `${parsed.data.firstName} ${parsed.data.lastName}`
-							: undefined,
-				},
-			});
-			if (shiftSchedule !== undefined) {
-				await upsertShiftSchedule(tx, userId, shiftSchedule ?? null);
-			}
-			// Leaving a department invalidates any team leaderships held there
-			// (eligibility requires membership of the parent department), so clear
-			// them to avoid a leader stranded over a team they no longer belong to.
-			if (departmentChanging) {
-				await tx.subDepartment.updateMany({
-					where: { teamLeaderId: userId },
-					data: { teamLeaderId: null },
+		const updated = await prisma.$transaction(
+			async (tx) => {
+				const user = await tx.user.update({
+					where: { id: userId },
+					data: {
+						...userFields,
+						role: roleIsChanging ? (parsed.data.role as Role) : undefined,
+						subDepartmentId: resolvedSubDepartmentId,
+						hireDate: hireDate === undefined ? undefined : (hireDate ?? null),
+						birthday: birthday === undefined ? undefined : (birthday ?? null),
+						name:
+							parsed.data.firstName && parsed.data.lastName
+								? `${parsed.data.firstName} ${parsed.data.lastName}`
+								: undefined,
+					},
 				});
-			}
-			return user;
-		});
+				if (shiftSchedule !== undefined) {
+					await upsertShiftSchedule(tx, userId, shiftSchedule ?? null);
+				}
+				// Leaving a department invalidates any team leaderships held there
+				// (eligibility requires membership of the parent department), so clear
+				// them to avoid a leader stranded over a team they no longer belong to.
+				if (departmentChanging) {
+					await tx.subDepartment.updateMany({
+						where: { teamLeaderId: userId },
+						data: { teamLeaderId: null },
+					});
+				}
+				return user;
+			},
+			// When the department changes we clear team leaderships, which races
+			// with assignTeamLeaderAction. Postgres SSI only detects that anomaly
+			// when BOTH transactions are Serializable, so match the assign side
+			// here. Ordinary edits keep default isolation to avoid needless
+			// serialization failures.
+			departmentChanging ? { isolationLevel: "Serializable" } : undefined,
+		);
 
 		revalidatePath("/dashboard/users", "layout");
 		revalidatePath(`/dashboard/users/${userId}`);

--- a/lib/actions/user-actions.ts
+++ b/lib/actions/user-actions.ts
@@ -230,6 +230,15 @@ export async function updateUserAction(userId: string, formData: unknown) {
 			if (shiftSchedule !== undefined) {
 				await upsertShiftSchedule(tx, userId, shiftSchedule ?? null);
 			}
+			// Leaving a department invalidates any team leaderships held there
+			// (eligibility requires membership of the parent department), so clear
+			// them to avoid a leader stranded over a team they no longer belong to.
+			if (departmentChanging) {
+				await tx.subDepartment.updateMany({
+					where: { teamLeaderId: userId },
+					data: { teamLeaderId: null },
+				});
+			}
 			return user;
 		});
 
@@ -288,6 +297,12 @@ export async function softDeleteUserAction(userId: string) {
 					},
 				});
 				await tx.session.deleteMany({ where: { userId } });
+				// A deleted user can no longer lead any team — relinquish leaderships
+				// so teams aren't left pointing at a removed account.
+				await tx.subDepartment.updateMany({
+					where: { teamLeaderId: userId },
+					data: { teamLeaderId: null },
+				});
 				return user;
 			},
 			{ isolationLevel: "Serializable" },

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -26,6 +26,10 @@ export function canManageDepartments(role: Role): boolean {
 	return hasMinRole(role, "ADMIN");
 }
 
+export function canManageTeams(role: Role): boolean {
+	return hasMinRole(role, "ADMIN");
+}
+
 export function canAssignAdminRole(role: Role): boolean {
 	return hasMinRole(role, "SUPERADMIN");
 }

--- a/prisma/migrations/0012_add_team_leader/migration.sql
+++ b/prisma/migrations/0012_add_team_leader/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "sub_departments" ADD COLUMN     "team_leader_id" TEXT;
+
+-- CreateIndex
+CREATE INDEX "sub_departments_team_leader_id_idx" ON "sub_departments"("team_leader_id");
+
+-- AddForeignKey
+ALTER TABLE "sub_departments" ADD CONSTRAINT "sub_departments_team_leader_id_fkey" FOREIGN KEY ("team_leader_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,6 +103,7 @@ model User {
   activityLogs         ActivityLog[]     @relation("activityActor")
   ticketsCreated       HelpMeTicket[]    @relation("ticketCreator")
   ticketReplies        TicketReply[]     @relation("ticketReplyAuthor")
+  ledSubDepartments    SubDepartment[]   @relation("subDepartmentLeader")
 
   @@index([subDepartmentId])
   @@map("users")
@@ -200,13 +201,16 @@ model SubDepartment {
   id           String   @id @default(uuid())
   name         String
   departmentId String   @map("department_id")
+  teamLeaderId String?  @map("team_leader_id")
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
 
   department Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+  teamLeader User?      @relation("subDepartmentLeader", fields: [teamLeaderId], references: [id], onDelete: SetNull)
   users      User[]
 
   @@unique([departmentId, name])
+  @@index([teamLeaderId])
   @@map("sub_departments")
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of team leadership: an admin **All Teams** view and the ability to **assign one team leader per sub-department**. This phase is **assignment only** — it grants no new staff permissions (the leader permission tier is a planned follow-up PR).

## Decisions (from design discussion)
- **All Teams = the existing Departments page**, extended + relabeled (no duplicate page). Route `/dashboard/departments` is unchanged.
- A leader must be an **active member of the sub-department's parent department**.
- A user **may lead multiple** sub-departments (no uniqueness constraint).

## Changes
- **Schema:** `SubDepartment.teamLeaderId` (indexed, `ON DELETE SET NULL`, not unique) + `User.ledSubDepartments` back-relation. Migration `0012_add_team_leader`.
- **Nav/UI:** "Departments" → **"All Teams"** (label + page header). Each sub-department row shows its current leader with an **Assign/Change** picker (`team-leader-picker.tsx`) that lists active parent-department members and supports removing the leader.
- **Action:** `assignTeamLeaderAction(subDepartmentId, userId | null)` — admin-only; server-side validates the candidate is active and in the parent department; `getDepartmentMembersAction` powers the picker.
- **Stale-power guards (security, not cosmetic):** when a user's department changes or they're soft-deleted, every team leadership they hold is cleared inside the existing transactions.

## Loopholes addressed
- Eligibility re-checked server-side (never trusts the submitted id).
- Department-change / soft-delete can't leave a leader stranded over a team they left.
- Sub-department delete already cascades the FK; leader rides on the sub-dept row.

## Out of scope (Phase 2, follow-up PR)
The actual leader **capabilities** — view team details, edit limited member fields, manage membership, team-scoped insights — each behind a server-side `canActOnTeamMember` guard. Not in this PR.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun run test` — 356 passing (added: assign/clear/eligibility, leadership cleared on dept-change + soft-delete, All Teams nav label)
- Migration authored via `migrate diff` and applied additively to the local DB (no reset).

## Notes
- Pre-existing local `.env.example`/`package.json` (dev port) edits intentionally excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes org membership and leadership in the database with admin-only actions and transactional guards; incorrect eligibility or cleanup could leave inconsistent team/leader state, though tests cover main paths.
> 
> **Overview**
> This PR extends the admin **All Teams** page (formerly labeled Departments) with **team leadership** and **sub-department membership** management, plus the data model and server rules to keep assignments consistent.
> 
> **Schema & API:** Adds optional `teamLeaderId` on sub-departments (migration `0012`) and loads leader profile data with department listings. New admin actions assign or clear a leader (parent-department member, active user), list department members for the picker, and add/remove sub-department members with eligibility checks (same department or unassigned; unassigned users get the parent department on add). Serializable transactions guard leader assignment and member adds against races with department moves.
> 
> **UI:** Sub-department rows show member count (opens **Manage Members**), leader chip/avatar or **Assign leader** (opens searchable picker), and refreshed card styling. Sidebar and page copy use **All Teams** (admin-only).
> 
> **Stale leadership cleanup:** When a user’s department changes or they are soft-deleted, all `teamLeaderId` references pointing at them are cleared in the same transactions (Serializable on department change to match assign leader).
> 
> Leader **permissions/capabilities** are explicitly out of scope (assignment only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4b9d750e0668e48551e0868efb0ead572cdd2fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added team leader assignment for sub-departments, including a picker dialog to search members, assign or remove a leader, and display the leader’s avatar and name.
  * Updated the departments area header and sidebar label to **All Teams** for clearer navigation.

* **Bug Fixes**
  * Team leader assignments now stay in sync when a user changes departments or is deactivated, preventing stale leadership links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->