### PR TITLE
fix(db): harden pg pool with keepalive and explicit timeouts

### DIFF
--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -6,12 +6,19 @@ const globalForPrisma = globalThis as unknown as {
 };
 
 function createPrismaClient() {
-	const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+	const adapter = new PrismaPg({
+		connectionString: process.env.DATABASE_URL,
+		// Recycle idle sockets before any NAT/proxy/server-side reaper closes them.
+		idleTimeoutMillis: 30_000,
+		keepAlive: true,
+		keepAliveInitialDelayMillis: 10_000,
+		// Fail fast instead of hanging when the database is unreachable.
+		connectionTimeoutMillis: 10_000,
+		max: 10,
+	});
 	return new PrismaClient({ adapter });
 }
 
 export const prisma = globalForPrisma.prisma ?? createPrismaClient();
 
-if (process.env.NODE_ENV !== "production") {
-	globalForPrisma.prisma = prisma;
-}
+globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## What

Configures the `pg` pool behind the Prisma driver adapter instead of relying on defaults:

- `keepAlive` + `keepAliveInitialDelayMillis` - TCP keepalive so silently dropped sockets are detected
- `idleTimeoutMillis: 30_000` - recycle idle connections before a NAT/proxy/server-side reaper closes them
- `connectionTimeoutMillis: 10_000` - fail fast instead of hanging when the DB is unreachable
- `max: 10` - explicit pool ceiling
- Caches the client singleton in production too, so a standalone build cannot end up with two pools

## Why

Production hit a burst of `Connection terminated unexpectedly` errors from better-auth. Root cause was server-side: the Coolify Postgres container was crash-looping because it could not read its TLS certificate (wrong file ownership), so every pooled connection died at once. That has been fixed on the host separately.

This change does not prevent that class of outage, but it shortens recovery: with default settings the pool keeps handing out dead sockets and requests hang. With keepalive and an explicit connection timeout, failures surface immediately and connections are re-established once the database is back.

## Notes

- Kept `process.env.DATABASE_URL` rather than `env.DATABASE_URL` here. Six seed/maintenance scripts import this singleton, and `env.ts` validates every server var, so switching would break `db:seed` in contexts that do not have the full env set.

## Verification

- `bunx tsc --noEmit` clean
- `bun run lint` (Biome) clean
- `bun run test` - 331 tests / 35 files pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection stability through automatic idle connection recycling and TCP keep-alive support.
  * Added faster failure handling when database connections cannot be established.
  * Optimized connection usage by enforcing a maximum connection limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->