### PR TITLE
feat(api): add liveness health endpoint for container healthchecks

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,11 @@
+export const dynamic = "force-dynamic";
+
+/**
+ * Container liveness probe. Deliberately does not touch the database or auth:
+ * a deep check would mark every replica unhealthy during a shared-Postgres
+ * blip and restart them all at once. This answers only "is the server
+ * serving HTTP?".
+ */
+export function GET() {
+	return Response.json({ success: true, data: { status: "ok" } }, { status: 200 });
+}


### PR DESCRIPTION
## What

Adds `GET /api/health`, a shallow liveness probe returning `{ success: true, data: { status: "ok" } }`.

## Why

Five Coolify containers crash-looped for roughly 11 hours after the shared Postgres failed to come up. Traefik served 503s the whole time with no signal, because no app container defines a healthcheck. This gives Coolify something to probe.

The probe deliberately does not touch the database or auth. A deep check would mark every replica unhealthy during a shared-Postgres blip and restart them all at once, which is a worse version of the outage it is meant to surface. It answers only "is the server serving HTTP?".

## Coolify configuration

To be set on the application after merge:

```
Path:          /api/health
Port:          3000
Interval:      30s
Timeout:       5s
Retries:       3
Start period:  40s
```

The 40s start period matters because the build runs `prisma migrate deploy` before Next starts listening.

## Verification

- Biome: clean
- `tsc --noEmit`: 0 errors
- Runtime: `HTTP 200` with `{"success":true,"data":{"status":"ok"}}`
- Warm latency: 12-22ms in dev
- Not matched by the `proxy.ts` matcher, so auth does not redirect it

## Cost

At 10 apps on a 30s interval this is roughly 0.3% of the server's 2 vCPU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health-check endpoint that reports whether the service is running.
  * Health checks now return a successful response with a clear “ok” status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->