### PR TITLE
feat(leaderboard): add always-visible switch to visibility settings

### DIFF
--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -43,6 +43,7 @@ interface LeaderboardVisibility {
 	revealStart: string;
 	revealEnd: string;
 	nextRevealStart: string;
+	nextMonthStart: string;
 }
 
 interface StatsData {
@@ -314,10 +315,15 @@ export function StatsWidget() {
 	const visibility = data?.data?.leaderboardVisibility ?? null;
 	// Always watch the next boundary: revealEnd if the leaderboard is currently
 	// visible (so we lock it at window-end), otherwise the next window opening.
-	// "Always visible" has no boundary at all, so there is nothing to count to.
-	const nextBoundaryIso =
-		!visibility || visibility.alwaysVisible
-			? null
+	// In always-visible mode neither is ever reached, so watch the month rollover
+	// instead — the countdown drives the refetch that advances sourceMonthKey and
+	// the archived winners on a dashboard left open past Manila midnight. Nothing
+	// is rendered from it: the countdown text only lives in LockedLeaderboard,
+	// which never mounts while visible.
+	const nextBoundaryIso = !visibility
+		? null
+		: visibility.alwaysVisible
+			? visibility.nextMonthStart
 			: visibility.visible
 				? visibility.revealEnd
 				: visibility.nextRevealStart;

--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -37,6 +37,7 @@ const STATS_STICKY_BREAKPOINT_QUERY = "(min-width: 1024px)";
 
 interface LeaderboardVisibility {
 	visible: boolean;
+	alwaysVisible: boolean;
 	sourceMonthKey: string;
 	sourceMonthLabel: string;
 	revealStart: string;
@@ -313,11 +314,13 @@ export function StatsWidget() {
 	const visibility = data?.data?.leaderboardVisibility ?? null;
 	// Always watch the next boundary: revealEnd if the leaderboard is currently
 	// visible (so we lock it at window-end), otherwise the next window opening.
-	const nextBoundaryIso = visibility
-		? visibility.visible
-			? visibility.revealEnd
-			: visibility.nextRevealStart
-		: null;
+	// "Always visible" has no boundary at all, so there is nothing to count to.
+	const nextBoundaryIso =
+		!visibility || visibility.alwaysVisible
+			? null
+			: visibility.visible
+				? visibility.revealEnd
+				: visibility.nextRevealStart;
 	const msRemaining = useCountdown(nextBoundaryIso);
 
 	if (isPending) {

--- a/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
@@ -58,9 +58,12 @@ export function LeaderboardVisibilityPanel({
 	function handleAlwaysVisibleChange(next: boolean) {
 		const previous = alwaysVisible;
 		setAlwaysVisible(next);
-		// Send the clamped days so a half-edited input can't fail the save.
+		// Send the clamped days so a half-edited input can't fail the save, and
+		// mirror them into state so the inputs keep showing what was persisted.
 		const nextStart = clampDay(startDay);
 		const nextEnd = Math.max(nextStart, clampDay(endDay));
+		if (nextStart !== startDay) setStartDay(nextStart);
+		if (nextEnd !== endDay) setEndDay(nextEnd);
 		save(nextStart, nextEnd, next, () => setAlwaysVisible(previous));
 	}
 

--- a/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
@@ -4,32 +4,44 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { updateLeaderboardVisibilitySettings } from "@/lib/actions/settings-actions";
 import { clampDay, REVEAL_DAY_MAX, REVEAL_DAY_MIN } from "@/lib/leaderboard/visibility";
+import { cn } from "@/lib/utils";
 
 export interface LeaderboardVisibilityPanelProps {
 	initialStartDay: number;
 	initialEndDay: number;
+	initialAlwaysVisible: boolean;
 }
 
 export function LeaderboardVisibilityPanel({
 	initialStartDay,
 	initialEndDay,
+	initialAlwaysVisible,
 }: LeaderboardVisibilityPanelProps) {
 	const [startDay, setStartDay] = useState<number>(initialStartDay);
 	const [endDay, setEndDay] = useState<number>(initialEndDay);
+	const [alwaysVisible, setAlwaysVisible] = useState(initialAlwaysVisible);
 	const [isPending, startTransition] = useTransition();
 	const queryClient = useQueryClient();
 
-	function save(nextStart: number, nextEnd: number) {
+	function save(
+		nextStart: number,
+		nextEnd: number,
+		nextAlwaysVisible: boolean,
+		onError?: () => void,
+	) {
 		startTransition(async () => {
 			try {
 				const result = await updateLeaderboardVisibilitySettings({
 					revealStartDay: nextStart,
 					revealEndDay: nextEnd,
+					alwaysVisible: nextAlwaysVisible,
 				});
 
 				if (!result.success) {
+					onError?.();
 					toast.error(result.error ?? "Failed to update visibility settings");
 					return;
 				}
@@ -37,9 +49,19 @@ export function LeaderboardVisibilityPanel({
 				toast.success("Leaderboard visibility updated");
 				queryClient.invalidateQueries({ queryKey: ["recognition-stats"] });
 			} catch {
+				onError?.();
 				toast.error("Failed to update visibility settings");
 			}
 		});
+	}
+
+	function handleAlwaysVisibleChange(next: boolean) {
+		const previous = alwaysVisible;
+		setAlwaysVisible(next);
+		// Send the clamped days so a half-edited input can't fail the save.
+		const nextStart = clampDay(startDay);
+		const nextEnd = Math.max(nextStart, clampDay(endDay));
+		save(nextStart, nextEnd, next, () => setAlwaysVisible(previous));
 	}
 
 	function handleStartBlur() {
@@ -49,7 +71,7 @@ export function LeaderboardVisibilityPanel({
 		const nextEnd = Math.max(clamped, clampDay(endDay));
 		if (clamped !== startDay) setStartDay(clamped);
 		if (nextEnd !== endDay) setEndDay(nextEnd);
-		save(clamped, nextEnd);
+		save(clamped, nextEnd, alwaysVisible);
 	}
 
 	function handleEndBlur() {
@@ -57,11 +79,11 @@ export function LeaderboardVisibilityPanel({
 		if (clamped < startDay) {
 			toast.error("Reveal end day must be on or after the start day");
 			setEndDay(startDay);
-			save(startDay, startDay);
+			save(startDay, startDay, alwaysVisible);
 			return;
 		}
 		if (clamped !== endDay) setEndDay(clamped);
-		save(startDay, clamped);
+		save(startDay, clamped, alwaysVisible);
 	}
 
 	return (
@@ -80,6 +102,27 @@ export function LeaderboardVisibilityPanel({
 			<div className="space-y-4 px-5 py-6 sm:px-8">
 				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
 					<div className="min-w-0">
+						<p className="text-sm font-medium text-foreground">Always visible</p>
+						<p className="text-xs text-muted-foreground">
+							When on, the panel never locks and the reveal window below is ignored. Turn it off to
+							go back to the scheduled window.
+						</p>
+					</div>
+					<Switch
+						checked={alwaysVisible}
+						onCheckedChange={handleAlwaysVisibleChange}
+						disabled={isPending}
+						aria-label="Always show the leaderboard"
+					/>
+				</div>
+
+				<div
+					className={cn(
+						"flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 transition-opacity dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5",
+						alwaysVisible && "opacity-50",
+					)}
+				>
+					<div className="min-w-0">
 						<p className="text-sm font-medium text-foreground">Reveal from day</p>
 						<p className="text-xs text-muted-foreground">
 							First day of the month the previous month's winners appear.
@@ -92,12 +135,17 @@ export function LeaderboardVisibilityPanel({
 						value={Number.isFinite(startDay) ? startDay : ""}
 						onChange={(e) => setStartDay(Number.parseInt(e.target.value, 10))}
 						onBlur={handleStartBlur}
-						disabled={isPending}
+						disabled={isPending || alwaysVisible}
 						className="w-full shrink-0 sm:w-24"
 					/>
 				</div>
 
-				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+				<div
+					className={cn(
+						"flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 transition-opacity dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5",
+						alwaysVisible && "opacity-50",
+					)}
+				>
 					<div className="min-w-0">
 						<p className="text-sm font-medium text-foreground">Reveal until day</p>
 						<p className="text-xs text-muted-foreground">
@@ -111,7 +159,7 @@ export function LeaderboardVisibilityPanel({
 						value={Number.isFinite(endDay) ? endDay : ""}
 						onChange={(e) => setEndDay(Number.parseInt(e.target.value, 10))}
 						onBlur={handleEndBlur}
-						disabled={isPending}
+						disabled={isPending || alwaysVisible}
 						className="w-full shrink-0 sm:w-24"
 					/>
 				</div>

--- a/app/(dashboard)/dashboard/admin-settings/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/page.tsx
@@ -31,6 +31,7 @@ export default async function AdminSettingsPage() {
 			<LeaderboardVisibilityPanel
 				initialStartDay={visibility.revealStartDay}
 				initialEndDay={visibility.revealEndDay}
+				initialAlwaysVisible={visibility.alwaysVisible}
 			/>
 
 			<HelpMeVisibilityPanel initialEnabled={helpMeEnabled} />

--- a/app/api/recognition/stats/route.test.ts
+++ b/app/api/recognition/stats/route.test.ts
@@ -58,9 +58,10 @@ const NEXT_REVEAL_START = new Date("2026-06-01T00:00:00Z");
 const SOURCE_MONTH_KEY = "2026-04";
 const REQUEST = new Request("http://localhost/api/recognition/stats");
 
-function mockVisible(visible: boolean) {
+function mockVisible(visible: boolean, alwaysVisible = false) {
 	vi.mocked(computeLeaderboardVisibility).mockReturnValue({
 		visible,
+		alwaysVisible,
 		revealStart: REVEAL_START,
 		revealEnd: REVEAL_END,
 		nextRevealStart: NEXT_REVEAL_START,
@@ -85,6 +86,7 @@ beforeEach(() => {
 	vi.mocked(getLeaderboardVisibilitySettings).mockResolvedValue({
 		revealStartDay: 1,
 		revealEndDay: 20,
+		alwaysVisible: false,
 	});
 	vi.mocked(getTopRecognizedLimit).mockResolvedValue(5);
 	vi.mocked(prisma.recognitionCard.count).mockResolvedValue(0);
@@ -170,6 +172,19 @@ describe("GET /api/recognition/stats", () => {
 		expect(body.data.topRecipients).toEqual([]);
 		expect(body.data.leaderboardVisibility.visible).toBe(false);
 		expect(getArchivedRecipients).not.toHaveBeenCalled();
+	});
+
+	test("serves winners outside the window when always visible is on", async () => {
+		mockVisible(true, true);
+		vi.mocked(getArchivedRecipients).mockResolvedValue([
+			{ userId: "u1", firstName: "Ada", lastName: "Lovelace", avatar: null, count: 5, rank: 1 },
+		]);
+
+		const res = await GET(REQUEST);
+		const body = await res.json();
+
+		expect(body.data.leaderboardVisibility.alwaysVisible).toBe(true);
+		expect(body.data.topRecipients).toHaveLength(1);
 	});
 
 	test("honors ?previewNow for a super admin but still snapshots with the real clock", async () => {

--- a/app/api/recognition/stats/route.test.ts
+++ b/app/api/recognition/stats/route.test.ts
@@ -55,6 +55,7 @@ const END = new Date("2026-06-01T00:00:00Z");
 const REVEAL_START = new Date("2026-05-01T00:00:00Z");
 const REVEAL_END = new Date("2026-05-21T00:00:00Z");
 const NEXT_REVEAL_START = new Date("2026-06-01T00:00:00Z");
+const NEXT_MONTH_START = new Date("2026-05-31T16:00:00Z");
 const SOURCE_MONTH_KEY = "2026-04";
 const REQUEST = new Request("http://localhost/api/recognition/stats");
 
@@ -65,6 +66,7 @@ function mockVisible(visible: boolean, alwaysVisible = false) {
 		revealStart: REVEAL_START,
 		revealEnd: REVEAL_END,
 		nextRevealStart: NEXT_REVEAL_START,
+		nextMonthStart: NEXT_MONTH_START,
 		sourceMonthKey: SOURCE_MONTH_KEY,
 	});
 }
@@ -185,6 +187,9 @@ describe("GET /api/recognition/stats", () => {
 
 		expect(body.data.leaderboardVisibility.alwaysVisible).toBe(true);
 		expect(body.data.topRecipients).toHaveLength(1);
+		// Clients rely on this to refresh at the month rollover, since no reveal
+		// boundary is ever reached in always-visible mode.
+		expect(body.data.leaderboardVisibility.nextMonthStart).toBe(NEXT_MONTH_START.toISOString());
 	});
 
 	test("honors ?previewNow for a super admin but still snapshots with the real clock", async () => {

--- a/app/api/recognition/stats/route.ts
+++ b/app/api/recognition/stats/route.ts
@@ -117,6 +117,7 @@ export async function GET(request: Request) {
 					revealStart: visibility.revealStart.toISOString(),
 					revealEnd: visibility.revealEnd.toISOString(),
 					nextRevealStart: visibility.nextRevealStart.toISOString(),
+					nextMonthStart: visibility.nextMonthStart.toISOString(),
 				},
 			},
 		});

--- a/app/api/recognition/stats/route.ts
+++ b/app/api/recognition/stats/route.ts
@@ -111,6 +111,7 @@ export async function GET(request: Request) {
 				topRecipients,
 				leaderboardVisibility: {
 					visible: visibility.visible,
+					alwaysVisible: visibility.alwaysVisible,
 					sourceMonthKey: visibility.sourceMonthKey,
 					sourceMonthLabel: formatMonthLabel(visibility.sourceMonthKey),
 					revealStart: visibility.revealStart.toISOString(),

--- a/lib/actions/settings-actions.test.ts
+++ b/lib/actions/settings-actions.test.ts
@@ -118,6 +118,7 @@ describe("getLeaderboardVisibilitySettings", () => {
 		await expect(getLeaderboardVisibilitySettings()).resolves.toEqual({
 			revealStartDay: 1,
 			revealEndDay: 20,
+			alwaysVisible: false,
 		});
 	});
 
@@ -129,6 +130,7 @@ describe("getLeaderboardVisibilitySettings", () => {
 		await expect(getLeaderboardVisibilitySettings()).resolves.toEqual({
 			revealStartDay: 5,
 			revealEndDay: 15,
+			alwaysVisible: false,
 		});
 	});
 
@@ -140,6 +142,7 @@ describe("getLeaderboardVisibilitySettings", () => {
 		await expect(getLeaderboardVisibilitySettings()).resolves.toEqual({
 			revealStartDay: 1,
 			revealEndDay: 20,
+			alwaysVisible: false,
 		});
 	});
 
@@ -151,6 +154,23 @@ describe("getLeaderboardVisibilitySettings", () => {
 		await expect(getLeaderboardVisibilitySettings()).resolves.toEqual({
 			revealStartDay: 18,
 			revealEndDay: 18,
+			alwaysVisible: false,
+		});
+	});
+
+	test("reads the alwaysVisible flag", async () => {
+		vi.mocked(prisma.appSetting.findMany).mockResolvedValue(
+			rows({
+				leaderboard_reveal_start_day: "5",
+				leaderboard_reveal_end_day: "15",
+				leaderboard_always_visible: "true",
+			}),
+		);
+
+		await expect(getLeaderboardVisibilitySettings()).resolves.toEqual({
+			revealStartDay: 5,
+			revealEndDay: 15,
+			alwaysVisible: true,
 		});
 	});
 });
@@ -162,6 +182,7 @@ describe("updateLeaderboardVisibilitySettings", () => {
 		const result = await updateLeaderboardVisibilitySettings({
 			revealStartDay: 1,
 			revealEndDay: 20,
+			alwaysVisible: false,
 		});
 
 		expect(result).toEqual({ success: false, error: "Unauthorized" });
@@ -174,6 +195,7 @@ describe("updateLeaderboardVisibilitySettings", () => {
 		const result = await updateLeaderboardVisibilitySettings({
 			revealStartDay: 0,
 			revealEndDay: 20,
+			alwaysVisible: false,
 		});
 
 		expect(result.success).toBe(false);
@@ -186,6 +208,7 @@ describe("updateLeaderboardVisibilitySettings", () => {
 		const result = await updateLeaderboardVisibilitySettings({
 			revealStartDay: 15,
 			revealEndDay: 5,
+			alwaysVisible: false,
 		});
 
 		expect(result).toEqual({
@@ -202,11 +225,36 @@ describe("updateLeaderboardVisibilitySettings", () => {
 		const result = await updateLeaderboardVisibilitySettings({
 			revealStartDay: 3,
 			revealEndDay: 18,
+			alwaysVisible: false,
 		});
 
 		expect(result).toEqual({ success: true });
 		expect(requireRole).toHaveBeenCalledWith("ADMIN");
 		expect(prisma.$transaction).toHaveBeenCalledTimes(1);
 		expect(invalidateEntry).toHaveBeenCalledTimes(1);
+	});
+
+	test("persists the alwaysVisible flag alongside the days", async () => {
+		vi.mocked(requireRole).mockResolvedValueOnce({} as Awaited<ReturnType<typeof requireRole>>);
+		vi.mocked(prisma.$transaction).mockResolvedValueOnce([] as never);
+
+		const result = await updateLeaderboardVisibilitySettings({
+			revealStartDay: 3,
+			revealEndDay: 18,
+			alwaysVisible: true,
+		});
+
+		expect(result).toEqual({ success: true });
+		expect(prisma.appSetting.upsert).toHaveBeenCalledWith({
+			where: { key: "leaderboard_always_visible" },
+			update: { value: "true" },
+			create: { key: "leaderboard_always_visible", value: "true" },
+		});
+		// The window is still written so switching back off restores it.
+		expect(prisma.appSetting.upsert).toHaveBeenCalledWith({
+			where: { key: "leaderboard_reveal_start_day" },
+			update: { value: "3" },
+			create: { key: "leaderboard_reveal_start_day", value: "3" },
+		});
 	});
 });

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -223,7 +223,12 @@ export async function updateHelpMeEnabled(
 
 const LEADERBOARD_START_DAY_KEY = "leaderboard_reveal_start_day";
 const LEADERBOARD_END_DAY_KEY = "leaderboard_reveal_end_day";
-const LEADERBOARD_KEYS = [LEADERBOARD_START_DAY_KEY, LEADERBOARD_END_DAY_KEY];
+const LEADERBOARD_ALWAYS_VISIBLE_KEY = "leaderboard_always_visible";
+const LEADERBOARD_KEYS = [
+	LEADERBOARD_START_DAY_KEY,
+	LEADERBOARD_END_DAY_KEY,
+	LEADERBOARD_ALWAYS_VISIBLE_KEY,
+];
 
 function invalidateLeaderboardCache() {
 	invalidateEntry(leaderboardCache);
@@ -249,13 +254,17 @@ export async function getLeaderboardVisibilitySettings(): Promise<LeaderboardVis
 			parseDay(map.get(LEADERBOARD_END_DAY_KEY), REVEAL_END_DAY_DEFAULT),
 		);
 
-		return { revealStartDay, revealEndDay };
+		// Absent row means off, so existing installs keep the windowed behaviour.
+		const alwaysVisible = map.get(LEADERBOARD_ALWAYS_VISIBLE_KEY) === "true";
+
+		return { revealStartDay, revealEndDay, alwaysVisible };
 	});
 }
 
 export interface UpdateLeaderboardVisibilityInput {
 	revealStartDay: number;
 	revealEndDay: number;
+	alwaysVisible: boolean;
 }
 
 export async function updateLeaderboardVisibilitySettings(
@@ -284,6 +293,10 @@ export async function updateLeaderboardVisibilitySettings(
 		};
 	}
 
+	const alwaysVisible = String(input.alwaysVisible === true);
+
+	// The days are persisted even while "always visible" is on, so switching it
+	// back off restores the admin's configured window instead of the defaults.
 	await prisma.$transaction([
 		prisma.appSetting.upsert({
 			where: { key: LEADERBOARD_START_DAY_KEY },
@@ -294,6 +307,11 @@ export async function updateLeaderboardVisibilitySettings(
 			where: { key: LEADERBOARD_END_DAY_KEY },
 			update: { value: String(input.revealEndDay) },
 			create: { key: LEADERBOARD_END_DAY_KEY, value: String(input.revealEndDay) },
+		}),
+		prisma.appSetting.upsert({
+			where: { key: LEADERBOARD_ALWAYS_VISIBLE_KEY },
+			update: { value: alwaysVisible },
+			create: { key: LEADERBOARD_ALWAYS_VISIBLE_KEY, value: alwaysVisible },
 		}),
 	]);
 

--- a/lib/leaderboard/visibility.test.ts
+++ b/lib/leaderboard/visibility.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { computeLeaderboardVisibility } from "./visibility";
 
 // Asia/Manila is UTC+8 with no DST, so Manila midnight on day D is UTC (D-1) 16:00.
-const WINDOW_1_TO_20 = { revealStartDay: 1, revealEndDay: 20 };
+const WINDOW_1_TO_20 = { revealStartDay: 1, revealEndDay: 20, alwaysVisible: false };
 
 describe("computeLeaderboardVisibility", () => {
 	test("is visible inside the window and points at the previous month", () => {
@@ -20,7 +20,10 @@ describe("computeLeaderboardVisibility", () => {
 	test("is locked before the window opens; next opening is this month", () => {
 		// 2026-06-03 12:00 Manila, window opens day 5
 		const now = new Date("2026-06-03T04:00:00Z");
-		const state = computeLeaderboardVisibility({ revealStartDay: 5, revealEndDay: 20 }, now);
+		const state = computeLeaderboardVisibility(
+			{ revealStartDay: 5, revealEndDay: 20, alwaysVisible: false },
+			now,
+		);
 
 		expect(state.visible).toBe(false);
 		// 2026-06-05 Manila
@@ -51,10 +54,33 @@ describe("computeLeaderboardVisibility", () => {
 
 	test("clamps out-of-range days into 1..28 and keeps start <= end", () => {
 		const now = new Date("2026-06-05T04:00:00Z");
-		const state = computeLeaderboardVisibility({ revealStartDay: 40, revealEndDay: 0 }, now);
+		const state = computeLeaderboardVisibility(
+			{ revealStartDay: 40, revealEndDay: 0, alwaysVisible: false },
+			now,
+		);
 
 		// start clamps to 28, end = max(28, clamp(0->1)) = 28 → window is day 28 only.
 		expect(state.revealStart.toISOString()).toBe("2026-06-27T16:00:00.000Z");
 		expect(state.revealEnd.toISOString()).toBe("2026-06-28T16:00:00.000Z");
+	});
+
+	test("is visible outside the window when alwaysVisible is on", () => {
+		// 2026-06-25 12:00 Manila — well past the day 1-20 window.
+		const now = new Date("2026-06-25T04:00:00Z");
+		const state = computeLeaderboardVisibility({ ...WINDOW_1_TO_20, alwaysVisible: true }, now);
+
+		expect(state.visible).toBe(true);
+		expect(state.alwaysVisible).toBe(true);
+		// The window itself is still computed so turning the switch off restores it.
+		expect(state.revealStart.toISOString()).toBe("2026-05-31T16:00:00.000Z");
+		expect(state.sourceMonthKey).toBe("2026-05");
+	});
+
+	test("still honours the window when alwaysVisible is off", () => {
+		const now = new Date("2026-06-25T04:00:00Z");
+		const state = computeLeaderboardVisibility(WINDOW_1_TO_20, now);
+
+		expect(state.visible).toBe(false);
+		expect(state.alwaysVisible).toBe(false);
 	});
 });

--- a/lib/leaderboard/visibility.test.ts
+++ b/lib/leaderboard/visibility.test.ts
@@ -64,6 +64,22 @@ describe("computeLeaderboardVisibility", () => {
 		expect(state.revealEnd.toISOString()).toBe("2026-06-28T16:00:00.000Z");
 	});
 
+	test("exposes next month's Manila midnight as the rollover boundary", () => {
+		// 2026-06-25 12:00 Manila → rollover is 2026-07-01 Manila.
+		const now = new Date("2026-06-25T04:00:00Z");
+		const state = computeLeaderboardVisibility(WINDOW_1_TO_20, now);
+
+		expect(state.nextMonthStart.toISOString()).toBe("2026-06-30T16:00:00.000Z");
+	});
+
+	test("rolls the rollover boundary into the next year in December", () => {
+		const now = new Date("2026-12-25T04:00:00Z");
+		const state = computeLeaderboardVisibility(WINDOW_1_TO_20, now);
+
+		// 2027-01-01 Manila
+		expect(state.nextMonthStart.toISOString()).toBe("2026-12-31T16:00:00.000Z");
+	});
+
 	test("is visible outside the window when alwaysVisible is on", () => {
 		// 2026-06-25 12:00 Manila — well past the day 1-20 window.
 		const now = new Date("2026-06-25T04:00:00Z");
@@ -71,6 +87,8 @@ describe("computeLeaderboardVisibility", () => {
 
 		expect(state.visible).toBe(true);
 		expect(state.alwaysVisible).toBe(true);
+		// Still exposed so a long-open dashboard can refresh at the rollover.
+		expect(state.nextMonthStart.toISOString()).toBe("2026-06-30T16:00:00.000Z");
 		// The window itself is still computed so turning the switch off restores it.
 		expect(state.revealStart.toISOString()).toBe("2026-05-31T16:00:00.000Z");
 		expect(state.sourceMonthKey).toBe("2026-05");

--- a/lib/leaderboard/visibility.ts
+++ b/lib/leaderboard/visibility.ts
@@ -26,6 +26,10 @@ export interface LeaderboardVisibilityState {
 	// The next window opening — this month's if we haven't reached it yet,
 	// otherwise next month's. Used for the "reveals in…" countdown when locked.
 	nextRevealStart: Date;
+	// Manila midnight on the 1st of next month, i.e. when sourceMonthKey and the
+	// archived winners roll over. Clients watch this to refresh a long-open
+	// dashboard in always-visible mode, where no reveal boundary is ever hit.
+	nextMonthStart: Date;
 	// The completed month whose winners the window reveals (previous calendar month).
 	sourceMonthKey: string;
 }
@@ -69,6 +73,7 @@ export function computeLeaderboardVisibility(
 		revealStart,
 		revealEnd,
 		nextRevealStart,
+		nextMonthStart: manilaMidnightToUtc(year, month + 1, 1),
 		sourceMonthKey: getPreviousMonthKey(now),
 	};
 }

--- a/lib/leaderboard/visibility.ts
+++ b/lib/leaderboard/visibility.ts
@@ -5,14 +5,22 @@ export const REVEAL_DAY_MIN = 1;
 export const REVEAL_DAY_MAX = 28;
 export const REVEAL_START_DAY_DEFAULT = 1;
 export const REVEAL_END_DAY_DEFAULT = 20;
+export const ALWAYS_VISIBLE_DEFAULT = false;
 
 export interface LeaderboardVisibilitySettings {
 	revealStartDay: number;
 	revealEndDay: number;
+	// Master switch: when on, the reveal window is bypassed entirely and the
+	// panel stays unlocked. The days are still stored so turning it back off
+	// restores the configured window.
+	alwaysVisible: boolean;
 }
 
 export interface LeaderboardVisibilityState {
 	visible: boolean;
+	// Mirrors the setting so clients can skip the lock/unlock countdown, which
+	// has no meaning when there is no boundary to reach.
+	alwaysVisible: boolean;
 	revealStart: Date;
 	revealEnd: Date;
 	// The next window opening — this month's if we haven't reached it yet,
@@ -47,7 +55,8 @@ export function computeLeaderboardVisibility(
 	const revealEnd = manilaMidnightToUtc(year, month, endDay + 1);
 
 	const t = now.getTime();
-	const visible = t >= revealStart.getTime() && t < revealEnd.getTime();
+	const alwaysVisible = settings.alwaysVisible === true;
+	const visible = alwaysVisible || (t >= revealStart.getTime() && t < revealEnd.getTime());
 
 	// Before this month's window → it's still the next opening. At or after it
 	// → the next opening is next month (Date.UTC rolls the year over).
@@ -56,6 +65,7 @@ export function computeLeaderboardVisibility(
 
 	return {
 		visible,
+		alwaysVisible,
 		revealStart,
 		revealEnd,
 		nextRevealStart,


### PR DESCRIPTION
## Summary

Adds an **Always visible** switch to the Leaderboard Visibility panel in `/dashboard/admin-settings`. When on, the dashboard "Most Recognized" panel never locks and the monthly reveal window is bypassed. When off, the existing day-range behaviour is unchanged.

The configured reveal window is still persisted while the switch is on, so turning it back off restores the admin's schedule rather than falling back to the 1-20 defaults.

## Changes

| File | Change |
| --- | --- |
| `lib/leaderboard/visibility.ts` | `alwaysVisible` added to `LeaderboardVisibilitySettings` and `LeaderboardVisibilityState`; gate becomes `alwaysVisible \|\| inWindow`. All window dates are still computed unchanged. |
| `lib/actions/settings-actions.ts` | New `leaderboard_always_visible` app setting; read as `=== "true"`, written as a third upsert in the existing `$transaction`. |
| `app/api/recognition/stats/route.ts` | `alwaysVisible` added to the serialized `leaderboardVisibility` payload. |
| `app/(dashboard)/dashboard/_components/stats-widget.tsx` | Countdown suppressed when always-visible - there is no boundary to count toward. |
| `app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx` | `Switch` row; both day inputs disabled and dimmed when on. Optimistic toggle with rollback on failure. |
| `app/(dashboard)/dashboard/admin-settings/page.tsx` | `initialAlwaysVisible` wired through. |

## Notes

- **No migration needed.** `AppSetting` is a key/value table; the row is created on first save. An absent row reads as `false`, so existing environments keep current behaviour.
- **Scope:** always-visible removes the lock but still shows the **previous completed month's** archived winners - not a live current-month tally.
- **Untouched:** snapshotting, the `/dashboard/leaderboard` history page, and the super-admin `previewNow` preview (a no-op while the switch is on).
- **Revert without a deploy:** `UPDATE app_settings SET value='false' WHERE key='leaderboard_always_visible';`

## Testing

- `bun run lint` - 290 files, 0 issues
- `bunx tsc --noEmit` - clean
- `bun run test` - 39 files, 403 tests passed

New coverage: 2 tests in `visibility.test.ts` (visible outside the window when on; window still honoured when off), 2 in `settings-actions.test.ts` (reads the flag; persists it alongside the days), 1 in `route.test.ts` (winners served outside the window when on).

E2E was not run - no existing spec covers this panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Always visible” option for leaderboards.
  * Leaderboards can now remain visible outside scheduled reveal windows.
  * Scheduled reveal-day settings are preserved when always-visible mode is enabled.
  * Visibility settings and status responses now include the always-visible state.
  * Countdown behavior adapts when a leaderboard is permanently visible.

* **Bug Fixes**
  * Failed visibility-toggle saves now restore the previous setting.

* **Tests**
  * Added coverage for always-visible leaderboards and settings persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->