### PR TITLE
feat(leaderboard): let admins choose which month the panel shows

### DIFF
--- a/app/(dashboard)/dashboard/_components/stats-widget.tsx
+++ b/app/(dashboard)/dashboard/_components/stats-widget.tsx
@@ -40,6 +40,7 @@ interface LeaderboardVisibility {
 	alwaysVisible: boolean;
 	sourceMonthKey: string;
 	sourceMonthLabel: string;
+	monthSource: "previous" | "current";
 	revealStart: string;
 	revealEnd: string;
 	nextRevealStart: string;
@@ -348,6 +349,7 @@ export function StatsWidget() {
 
 	const stats = data.data;
 	const resolvedVisibility = stats.leaderboardVisibility;
+	const isLiveMonth = resolvedVisibility.monthSource === "current";
 	const showList = resolvedVisibility.visible && stats.topRecipients.length > 0;
 	const showLocked = !resolvedVisibility.visible;
 	const showEmpty = resolvedVisibility.visible && stats.topRecipients.length === 0;
@@ -407,8 +409,13 @@ export function StatsWidget() {
 						<h4 className="text-sm font-medium text-foreground/70">
 							Most Recognized — {resolvedVisibility.sourceMonthLabel}
 						</h4>
-						<span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground">
-							Final results
+						<span
+							className={cn(
+								"inline-flex items-center rounded-full px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide",
+								isLiveMonth ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground",
+							)}
+						>
+							{isLiveMonth ? "In progress" : "Final results"}
 						</span>
 					</div>
 					<ol className="space-y-2">
@@ -482,7 +489,9 @@ export function StatsWidget() {
 					</div>
 					<div className="flex min-h-48 items-center justify-center rounded-2xl border border-dashed border-gray-200 dark:border-white/10 bg-muted/30 px-6 py-8 text-center">
 						<p className="text-sm text-muted-foreground">
-							No recognitions were recorded last month.
+							{isLiveMonth
+								? "No recognitions yet this month."
+								: "No recognitions were recorded last month."}
 						</p>
 					</div>
 				</div>

--- a/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/_components/leaderboard-visibility.tsx
@@ -4,41 +4,56 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { updateLeaderboardVisibilitySettings } from "@/lib/actions/settings-actions";
-import { clampDay, REVEAL_DAY_MAX, REVEAL_DAY_MIN } from "@/lib/leaderboard/visibility";
+import {
+	type UpdateLeaderboardVisibilityInput,
+	updateLeaderboardVisibilitySettings,
+} from "@/lib/actions/settings-actions";
+import {
+	clampDay,
+	isMonthSource,
+	type LeaderboardMonthSource,
+	REVEAL_DAY_MAX,
+	REVEAL_DAY_MIN,
+} from "@/lib/leaderboard/visibility";
 import { cn } from "@/lib/utils";
+
+const MONTH_SOURCE_OPTIONS: { value: LeaderboardMonthSource; label: string }[] = [
+	{ value: "previous", label: "Last month" },
+	{ value: "current", label: "This month" },
+];
 
 export interface LeaderboardVisibilityPanelProps {
 	initialStartDay: number;
 	initialEndDay: number;
 	initialAlwaysVisible: boolean;
+	initialMonthSource: LeaderboardMonthSource;
 }
 
 export function LeaderboardVisibilityPanel({
 	initialStartDay,
 	initialEndDay,
 	initialAlwaysVisible,
+	initialMonthSource,
 }: LeaderboardVisibilityPanelProps) {
 	const [startDay, setStartDay] = useState<number>(initialStartDay);
 	const [endDay, setEndDay] = useState<number>(initialEndDay);
 	const [alwaysVisible, setAlwaysVisible] = useState(initialAlwaysVisible);
+	const [monthSource, setMonthSource] = useState<LeaderboardMonthSource>(initialMonthSource);
 	const [isPending, startTransition] = useTransition();
 	const queryClient = useQueryClient();
 
-	function save(
-		nextStart: number,
-		nextEnd: number,
-		nextAlwaysVisible: boolean,
-		onError?: () => void,
-	) {
+	function save(draft: UpdateLeaderboardVisibilityInput, onError?: () => void) {
 		startTransition(async () => {
 			try {
-				const result = await updateLeaderboardVisibilitySettings({
-					revealStartDay: nextStart,
-					revealEndDay: nextEnd,
-					alwaysVisible: nextAlwaysVisible,
-				});
+				const result = await updateLeaderboardVisibilitySettings(draft);
 
 				if (!result.success) {
 					onError?.();
@@ -55,16 +70,28 @@ export function LeaderboardVisibilityPanel({
 		});
 	}
 
-	function handleAlwaysVisibleChange(next: boolean) {
-		const previous = alwaysVisible;
-		setAlwaysVisible(next);
-		// Send the clamped days so a half-edited input can't fail the save, and
-		// mirror them into state so the inputs keep showing what was persisted.
+	// Clamped days keep a half-edited input from failing an unrelated save, and
+	// are mirrored into state so the inputs show what was actually persisted.
+	function normalizedDays() {
 		const nextStart = clampDay(startDay);
 		const nextEnd = Math.max(nextStart, clampDay(endDay));
 		if (nextStart !== startDay) setStartDay(nextStart);
 		if (nextEnd !== endDay) setEndDay(nextEnd);
-		save(nextStart, nextEnd, next, () => setAlwaysVisible(previous));
+		return { revealStartDay: nextStart, revealEndDay: nextEnd };
+	}
+
+	function handleAlwaysVisibleChange(next: boolean) {
+		const previous = alwaysVisible;
+		setAlwaysVisible(next);
+		save({ ...normalizedDays(), alwaysVisible: next, monthSource }, () =>
+			setAlwaysVisible(previous),
+		);
+	}
+
+	function handleMonthSourceChange(next: LeaderboardMonthSource) {
+		const previous = monthSource;
+		setMonthSource(next);
+		save({ ...normalizedDays(), alwaysVisible, monthSource: next }, () => setMonthSource(previous));
 	}
 
 	function handleStartBlur() {
@@ -74,7 +101,7 @@ export function LeaderboardVisibilityPanel({
 		const nextEnd = Math.max(clamped, clampDay(endDay));
 		if (clamped !== startDay) setStartDay(clamped);
 		if (nextEnd !== endDay) setEndDay(nextEnd);
-		save(clamped, nextEnd, alwaysVisible);
+		save({ revealStartDay: clamped, revealEndDay: nextEnd, alwaysVisible, monthSource });
 	}
 
 	function handleEndBlur() {
@@ -82,11 +109,16 @@ export function LeaderboardVisibilityPanel({
 		if (clamped < startDay) {
 			toast.error("Reveal end day must be on or after the start day");
 			setEndDay(startDay);
-			save(startDay, startDay, alwaysVisible);
+			save({
+				revealStartDay: startDay,
+				revealEndDay: startDay,
+				alwaysVisible,
+				monthSource,
+			});
 			return;
 		}
 		if (clamped !== endDay) setEndDay(clamped);
-		save(startDay, clamped, alwaysVisible);
+		save({ revealStartDay: startDay, revealEndDay: clamped, alwaysVisible, monthSource });
 	}
 
 	return (
@@ -103,6 +135,34 @@ export function LeaderboardVisibilityPanel({
 			</div>
 
 			<div className="space-y-4 px-5 py-6 sm:px-8">
+				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+					<div className="min-w-0">
+						<p className="text-sm font-medium text-foreground">Show winners from</p>
+						<p className="text-xs text-muted-foreground">
+							"Last month" shows the finalized winners of the completed month. "This month" shows a
+							live tally that changes as cards are sent, which is best paired with Always visible.
+						</p>
+					</div>
+					<Select
+						value={monthSource}
+						onValueChange={(val) => {
+							if (isMonthSource(val)) handleMonthSourceChange(val);
+						}}
+						disabled={isPending}
+					>
+						<SelectTrigger className="w-full rounded-full sm:w-40">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{MONTH_SOURCE_OPTIONS.map((opt) => (
+								<SelectItem key={opt.value} value={opt.value}>
+									{opt.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
 				<div className="flex flex-col gap-4 rounded-2xl border border-gray-200 p-4 dark:border-white/10 sm:flex-row sm:items-center sm:justify-between sm:p-5">
 					<div className="min-w-0">
 						<p className="text-sm font-medium text-foreground">Always visible</p>

--- a/app/(dashboard)/dashboard/admin-settings/page.tsx
+++ b/app/(dashboard)/dashboard/admin-settings/page.tsx
@@ -32,6 +32,7 @@ export default async function AdminSettingsPage() {
 				initialStartDay={visibility.revealStartDay}
 				initialEndDay={visibility.revealEndDay}
 				initialAlwaysVisible={visibility.alwaysVisible}
+				initialMonthSource={visibility.monthSource}
 			/>
 
 			<HelpMeVisibilityPanel initialEnabled={helpMeEnabled} />

--- a/app/api/recognition/stats/route.test.ts
+++ b/app/api/recognition/stats/route.test.ts
@@ -57,9 +57,14 @@ const REVEAL_END = new Date("2026-05-21T00:00:00Z");
 const NEXT_REVEAL_START = new Date("2026-06-01T00:00:00Z");
 const NEXT_MONTH_START = new Date("2026-05-31T16:00:00Z");
 const SOURCE_MONTH_KEY = "2026-04";
+const CURRENT_MONTH_KEY = "2026-05";
 const REQUEST = new Request("http://localhost/api/recognition/stats");
 
-function mockVisible(visible: boolean, alwaysVisible = false) {
+function mockVisible(
+	visible: boolean,
+	alwaysVisible = false,
+	monthSource: "previous" | "current" = "previous",
+) {
 	vi.mocked(computeLeaderboardVisibility).mockReturnValue({
 		visible,
 		alwaysVisible,
@@ -67,7 +72,8 @@ function mockVisible(visible: boolean, alwaysVisible = false) {
 		revealEnd: REVEAL_END,
 		nextRevealStart: NEXT_REVEAL_START,
 		nextMonthStart: NEXT_MONTH_START,
-		sourceMonthKey: SOURCE_MONTH_KEY,
+		sourceMonthKey: monthSource === "current" ? CURRENT_MONTH_KEY : SOURCE_MONTH_KEY,
+		monthSource,
 	});
 }
 
@@ -89,6 +95,7 @@ beforeEach(() => {
 		revealStartDay: 1,
 		revealEndDay: 20,
 		alwaysVisible: false,
+		monthSource: "previous",
 	});
 	vi.mocked(getTopRecognizedLimit).mockResolvedValue(5);
 	vi.mocked(prisma.recognitionCard.count).mockResolvedValue(0);
@@ -190,6 +197,35 @@ describe("GET /api/recognition/stats", () => {
 		// Clients rely on this to refresh at the month rollover, since no reveal
 		// boundary is ever reached in always-visible mode.
 		expect(body.data.leaderboardVisibility.nextMonthStart).toBe(NEXT_MONTH_START.toISOString());
+	});
+
+	test("tallies the running month live and never reads the archive", async () => {
+		mockVisible(true, true, "current");
+		vi.mocked(computeMonthRecipients).mockResolvedValue([
+			{ userId: "u1", firstName: "Ada", lastName: "Lovelace", avatar: null, count: 2, rank: 1 },
+		]);
+
+		const res = await GET(REQUEST);
+		const body = await res.json();
+
+		// The running month has no snapshot by design — reading one would serve a
+		// stale partial month.
+		expect(getArchivedRecipients).not.toHaveBeenCalled();
+		expect(computeMonthRecipients).toHaveBeenCalledWith(CURRENT_MONTH_KEY, 5);
+		expect(body.data.leaderboardVisibility.monthSource).toBe("current");
+		expect(body.data.leaderboardVisibility.sourceMonthKey).toBe(CURRENT_MONTH_KEY);
+		expect(body.data.topRecipients).toEqual([
+			{ firstName: "Ada", lastName: "Lovelace", avatar: null, count: 2 },
+		]);
+	});
+
+	test("still archives the previous month while showing the running one", async () => {
+		mockVisible(true, true, "current");
+
+		await GET(REQUEST);
+
+		// Snapshotting is independent of what the widget displays.
+		expect(maybeSnapshotPreviousMonth).toHaveBeenCalledTimes(1);
 	});
 
 	test("honors ?previewNow for a super admin but still snapshots with the real clock", async () => {

--- a/app/api/recognition/stats/route.ts
+++ b/app/api/recognition/stats/route.ts
@@ -83,10 +83,14 @@ export async function GET(request: Request) {
 			count: number;
 		}> = [];
 
-		// During the reveal window we show the previous (completed) month's
-		// finalized winners, read from its archived snapshot — never a live tally.
+		// The previous (completed) month is served from its archived snapshot —
+		// finalized and stable. The running month has no snapshot by design (one
+		// would freeze a partial month), so it is always tallied live.
 		if (visibility.visible) {
-			let recipients = await getArchivedRecipients(visibility.sourceMonthKey, topLimit);
+			const isLiveMonth = visibility.monthSource === "current";
+			let recipients = isLiveMonth
+				? null
+				: await getArchivedRecipients(visibility.sourceMonthKey, topLimit);
 			// Fall back to a live computation when the archive is missing or invalid
 			// (snapshot not yet written, swallowed failure, or corrupt JSON), so the
 			// reveal window never shows a false "no winners" state. Safe for everyone:
@@ -113,6 +117,7 @@ export async function GET(request: Request) {
 					visible: visibility.visible,
 					alwaysVisible: visibility.alwaysVisible,
 					sourceMonthKey: visibility.sourceMonthKey,
+					monthSource: visibility.monthSource,
 					sourceMonthLabel: formatMonthLabel(visibility.sourceMonthKey),
 					revealStart: visibility.revealStart.toISOString(),
 					revealEnd: visibility.revealEnd.toISOString(),

--- a/lib/actions/settings-actions.test.ts
+++ b/lib/actions/settings-actions.test.ts
@@ -119,6 +119,7 @@ describe("getLeaderboardVisibilitySettings", () => {
 			revealStartDay: 1,
 			revealEndDay: 20,
 			alwaysVisible: false,
+			monthSource: "previous",
 		});
 	});
 
@@ -131,6 +132,7 @@ describe("getLeaderboardVisibilitySettings", () => {
 			revealStartDay: 5,
 			revealEndDay: 15,
 			alwaysVisible: false,
+			monthSource: "previous",
 		});
 	});
 
@@ -143,6 +145,7 @@ describe("getLeaderboardVisibilitySettings", () => {
 			revealStartDay: 1,
 			revealEndDay: 20,
 			alwaysVisible: false,
+			monthSource: "previous",
 		});
 	});
 
@@ -155,6 +158,7 @@ describe("getLeaderboardVisibilitySettings", () => {
 			revealStartDay: 18,
 			revealEndDay: 18,
 			alwaysVisible: false,
+			monthSource: "previous",
 		});
 	});
 
@@ -171,6 +175,7 @@ describe("getLeaderboardVisibilitySettings", () => {
 			revealStartDay: 5,
 			revealEndDay: 15,
 			alwaysVisible: true,
+			monthSource: "previous",
 		});
 	});
 });
@@ -183,6 +188,7 @@ describe("updateLeaderboardVisibilitySettings", () => {
 			revealStartDay: 1,
 			revealEndDay: 20,
 			alwaysVisible: false,
+			monthSource: "previous",
 		});
 
 		expect(result).toEqual({ success: false, error: "Unauthorized" });
@@ -196,6 +202,7 @@ describe("updateLeaderboardVisibilitySettings", () => {
 			revealStartDay: 0,
 			revealEndDay: 20,
 			alwaysVisible: false,
+			monthSource: "previous",
 		});
 
 		expect(result.success).toBe(false);
@@ -209,6 +216,7 @@ describe("updateLeaderboardVisibilitySettings", () => {
 			revealStartDay: 15,
 			revealEndDay: 5,
 			alwaysVisible: false,
+			monthSource: "previous",
 		});
 
 		expect(result).toEqual({
@@ -226,6 +234,7 @@ describe("updateLeaderboardVisibilitySettings", () => {
 			revealStartDay: 3,
 			revealEndDay: 18,
 			alwaysVisible: false,
+			monthSource: "previous",
 		});
 
 		expect(result).toEqual({ success: true });
@@ -242,6 +251,7 @@ describe("updateLeaderboardVisibilitySettings", () => {
 			revealStartDay: 3,
 			revealEndDay: 18,
 			alwaysVisible: true,
+			monthSource: "previous",
 		});
 
 		expect(result).toEqual({ success: true });

--- a/lib/actions/settings-actions.ts
+++ b/lib/actions/settings-actions.ts
@@ -20,7 +20,10 @@ import {
 	TOP_RECOGNIZED_MIN,
 } from "@/lib/leaderboard/constants";
 import {
+	isMonthSource,
+	type LeaderboardMonthSource,
 	type LeaderboardVisibilitySettings,
+	MONTH_SOURCE_DEFAULT,
 	REVEAL_DAY_MAX,
 	REVEAL_DAY_MIN,
 	REVEAL_END_DAY_DEFAULT,
@@ -224,10 +227,12 @@ export async function updateHelpMeEnabled(
 const LEADERBOARD_START_DAY_KEY = "leaderboard_reveal_start_day";
 const LEADERBOARD_END_DAY_KEY = "leaderboard_reveal_end_day";
 const LEADERBOARD_ALWAYS_VISIBLE_KEY = "leaderboard_always_visible";
+const LEADERBOARD_MONTH_SOURCE_KEY = "leaderboard_month_source";
 const LEADERBOARD_KEYS = [
 	LEADERBOARD_START_DAY_KEY,
 	LEADERBOARD_END_DAY_KEY,
 	LEADERBOARD_ALWAYS_VISIBLE_KEY,
+	LEADERBOARD_MONTH_SOURCE_KEY,
 ];
 
 function invalidateLeaderboardCache() {
@@ -257,7 +262,10 @@ export async function getLeaderboardVisibilitySettings(): Promise<LeaderboardVis
 		// Absent row means off, so existing installs keep the windowed behaviour.
 		const alwaysVisible = map.get(LEADERBOARD_ALWAYS_VISIBLE_KEY) === "true";
 
-		return { revealStartDay, revealEndDay, alwaysVisible };
+		const rawMonthSource = map.get(LEADERBOARD_MONTH_SOURCE_KEY);
+		const monthSource = isMonthSource(rawMonthSource) ? rawMonthSource : MONTH_SOURCE_DEFAULT;
+
+		return { revealStartDay, revealEndDay, alwaysVisible, monthSource };
 	});
 }
 
@@ -265,6 +273,7 @@ export interface UpdateLeaderboardVisibilityInput {
 	revealStartDay: number;
 	revealEndDay: number;
 	alwaysVisible: boolean;
+	monthSource: LeaderboardMonthSource;
 }
 
 export async function updateLeaderboardVisibilitySettings(
@@ -293,6 +302,10 @@ export async function updateLeaderboardVisibilitySettings(
 		};
 	}
 
+	if (!isMonthSource(input.monthSource)) {
+		return { success: false, error: "Invalid month source" };
+	}
+
 	const alwaysVisible = String(input.alwaysVisible === true);
 
 	// The days are persisted even while "always visible" is on, so switching it
@@ -312,6 +325,11 @@ export async function updateLeaderboardVisibilitySettings(
 			where: { key: LEADERBOARD_ALWAYS_VISIBLE_KEY },
 			update: { value: alwaysVisible },
 			create: { key: LEADERBOARD_ALWAYS_VISIBLE_KEY, value: alwaysVisible },
+		}),
+		prisma.appSetting.upsert({
+			where: { key: LEADERBOARD_MONTH_SOURCE_KEY },
+			update: { value: input.monthSource },
+			create: { key: LEADERBOARD_MONTH_SOURCE_KEY, value: input.monthSource },
 		}),
 	]);
 

--- a/lib/leaderboard/visibility.test.ts
+++ b/lib/leaderboard/visibility.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "vitest";
 import { computeLeaderboardVisibility } from "./visibility";
 
 // Asia/Manila is UTC+8 with no DST, so Manila midnight on day D is UTC (D-1) 16:00.
-const WINDOW_1_TO_20 = { revealStartDay: 1, revealEndDay: 20, alwaysVisible: false };
+const WINDOW_1_TO_20 = {
+	revealStartDay: 1,
+	revealEndDay: 20,
+	alwaysVisible: false,
+	monthSource: "previous" as const,
+};
 
 describe("computeLeaderboardVisibility", () => {
 	test("is visible inside the window and points at the previous month", () => {
@@ -21,7 +26,12 @@ describe("computeLeaderboardVisibility", () => {
 		// 2026-06-03 12:00 Manila, window opens day 5
 		const now = new Date("2026-06-03T04:00:00Z");
 		const state = computeLeaderboardVisibility(
-			{ revealStartDay: 5, revealEndDay: 20, alwaysVisible: false },
+			{
+				revealStartDay: 5,
+				revealEndDay: 20,
+				alwaysVisible: false,
+				monthSource: "previous" as const,
+			},
 			now,
 		);
 
@@ -55,7 +65,12 @@ describe("computeLeaderboardVisibility", () => {
 	test("clamps out-of-range days into 1..28 and keeps start <= end", () => {
 		const now = new Date("2026-06-05T04:00:00Z");
 		const state = computeLeaderboardVisibility(
-			{ revealStartDay: 40, revealEndDay: 0, alwaysVisible: false },
+			{
+				revealStartDay: 40,
+				revealEndDay: 0,
+				alwaysVisible: false,
+				monthSource: "previous" as const,
+			},
 			now,
 		);
 
@@ -100,5 +115,41 @@ describe("computeLeaderboardVisibility", () => {
 
 		expect(state.visible).toBe(false);
 		expect(state.alwaysVisible).toBe(false);
+	});
+
+	test("uses the running month as the source when monthSource is current", () => {
+		// 2026-06-05 12:00 Manila
+		const now = new Date("2026-06-05T04:00:00Z");
+		const state = computeLeaderboardVisibility({ ...WINDOW_1_TO_20, monthSource: "current" }, now);
+
+		expect(state.sourceMonthKey).toBe("2026-06");
+		expect(state.monthSource).toBe("current");
+	});
+
+	test("keeps the previous month as the source by default", () => {
+		const now = new Date("2026-06-05T04:00:00Z");
+		const state = computeLeaderboardVisibility(WINDOW_1_TO_20, now);
+
+		expect(state.sourceMonthKey).toBe("2026-05");
+		expect(state.monthSource).toBe("previous");
+	});
+
+	test("rolls the running-month source over the year boundary", () => {
+		// 2027-01-05 12:00 Manila
+		const now = new Date("2027-01-05T04:00:00Z");
+		const state = computeLeaderboardVisibility({ ...WINDOW_1_TO_20, monthSource: "current" }, now);
+
+		expect(state.sourceMonthKey).toBe("2027-01");
+	});
+
+	test("falls back to previous for an unrecognized month source", () => {
+		const now = new Date("2026-06-05T04:00:00Z");
+		const state = computeLeaderboardVisibility(
+			{ ...WINDOW_1_TO_20, monthSource: "garbage" as unknown as "previous" },
+			now,
+		);
+
+		expect(state.monthSource).toBe("previous");
+		expect(state.sourceMonthKey).toBe("2026-05");
 	});
 });

--- a/lib/leaderboard/visibility.ts
+++ b/lib/leaderboard/visibility.ts
@@ -7,9 +7,21 @@ export const REVEAL_START_DAY_DEFAULT = 1;
 export const REVEAL_END_DAY_DEFAULT = 20;
 export const ALWAYS_VISIBLE_DEFAULT = false;
 
+// Which month the "Most Recognized" panel draws from: the previous completed
+// month (finalized, read from its archived snapshot) or the running month
+// (live tally that moves as cards are sent).
+export const MONTH_SOURCES = ["previous", "current"] as const;
+export type LeaderboardMonthSource = (typeof MONTH_SOURCES)[number];
+export const MONTH_SOURCE_DEFAULT: LeaderboardMonthSource = "previous";
+
+export function isMonthSource(value: unknown): value is LeaderboardMonthSource {
+	return MONTH_SOURCES.includes(value as LeaderboardMonthSource);
+}
+
 export interface LeaderboardVisibilitySettings {
 	revealStartDay: number;
 	revealEndDay: number;
+	monthSource: LeaderboardMonthSource;
 	// Master switch: when on, the reveal window is bypassed entirely and the
 	// panel stays unlocked. The days are still stored so turning it back off
 	// restores the configured window.
@@ -30,8 +42,11 @@ export interface LeaderboardVisibilityState {
 	// archived winners roll over. Clients watch this to refresh a long-open
 	// dashboard in always-visible mode, where no reveal boundary is ever hit.
 	nextMonthStart: Date;
-	// The completed month whose winners the window reveals (previous calendar month).
+	// The month whose winners are shown — previous or running, per monthSource.
 	sourceMonthKey: string;
+	// Mirrors the setting. When "current" the tally is still in progress, so
+	// clients should label it as live rather than as final winners.
+	monthSource: LeaderboardMonthSource;
 }
 
 const TZ_OFFSET_MS = 8 * 60 * 60 * 1000;
@@ -49,7 +64,7 @@ export function computeLeaderboardVisibility(
 	settings: LeaderboardVisibilitySettings,
 	now: Date = new Date(),
 ): LeaderboardVisibilityState {
-	const { year, month } = getCurrentMonthBoundaries(now);
+	const { year, month, monthKey } = getCurrentMonthBoundaries(now);
 
 	const startDay = clampDay(settings.revealStartDay);
 	const endDay = Math.max(startDay, clampDay(settings.revealEndDay));
@@ -60,6 +75,10 @@ export function computeLeaderboardVisibility(
 
 	const t = now.getTime();
 	const alwaysVisible = settings.alwaysVisible === true;
+	// Guard the boundary: settings may come from a raw DB row on older data.
+	const monthSource = isMonthSource(settings.monthSource)
+		? settings.monthSource
+		: MONTH_SOURCE_DEFAULT;
 	const visible = alwaysVisible || (t >= revealStart.getTime() && t < revealEnd.getTime());
 
 	// Before this month's window → it's still the next opening. At or after it
@@ -74,6 +93,7 @@ export function computeLeaderboardVisibility(
 		revealEnd,
 		nextRevealStart,
 		nextMonthStart: manilaMidnightToUtc(year, month + 1, 1),
-		sourceMonthKey: getPreviousMonthKey(now),
+		sourceMonthKey: monthSource === "current" ? monthKey : getPreviousMonthKey(now),
+		monthSource,
 	};
 }


### PR DESCRIPTION
## Summary

Adds a **Show winners from** setting to the Leaderboard Visibility panel:

- **Last month** (default) - the finalized winners of the completed month, read from its archived snapshot.
- **This month** - a live tally that moves as cards are sent.

Follow-up to #182. The panel was hardwired to the previous month, so always-visible mode showed a closed month that never changed for ~30 days. This makes that combination useful.

## Changes

| File | Change |
| --- | --- |
| `lib/leaderboard/visibility.ts` | `MONTH_SOURCES` / `LeaderboardMonthSource` / `isMonthSource` guard; `sourceMonthKey` now branches on `monthSource`, and the resolved value is returned so clients can label it. |
| `lib/actions/settings-actions.ts` | New `leaderboard_month_source` app setting, validated against the two literals and written in the existing `$transaction`. |
| `app/api/recognition/stats/route.ts` | The running month skips the archive lookup and goes straight to `computeMonthRecipients`; `monthSource` added to the payload. |
| `app/(dashboard)/dashboard/_components/stats-widget.tsx` | Badge reads **In progress** instead of **Final results**, and the empty state says "No recognitions yet this month." |
| `.../admin-settings/_components/leaderboard-visibility.tsx` | `Select` for the month source. `save()` refactored from four positional args to a draft object - it would not have scaled to a fifth. |

## Notes

- **No migration.** Absent or unrecognized value reads as `previous`, so existing environments are unchanged until an admin opts in.
- **Snapshots untouched.** `maybeSnapshotPreviousMonth` still archives the previous month regardless of what the panel shows, so switching back to "Last month" is lossless and `/dashboard/leaderboard` history is unaffected. The running month is never snapshotted - that would freeze a partial month.
- **Query cost.** The live path runs one extra `groupBy` per stats fetch, covered by the existing `@@index([createdAt])` and `@@index([recipientId, createdAt])` on `recognition_cards`.
- **Freshness.** Live counts ride the widget's existing 30s `staleTime` plus refetch-on-focus, and the `nextMonthStart` rollover refresh from #182 already handles the month flip.
- **Worth a thought before enabling:** the reveal window exists so people cannot watch themselves climb. A permanent live board changes that dynamic, which is why `previous` stays the default.

## Testing

- `bun run lint` - clean
- `bunx tsc --noEmit` - clean
- `bun run test` - 39 files, **411 tests passed** (up from 405)

New coverage: 4 tests in `visibility.test.ts` (running-month source, default, year-boundary rollover, fallback on a garbage value), 2 in `settings-actions.test.ts`, and 2 in `route.test.ts` (live month never reads the archive; the previous month is still archived while showing the running one).